### PR TITLE
DB Migrations: Polish

### DIFF
--- a/ormconfig.json.sample
+++ b/ormconfig.json.sample
@@ -9,7 +9,7 @@
         "dist/model/*.model.js"
     ],
     "synchronize": false,
-    "migrations": ["src/logion/migration/*.ts"],
+    "migrations": ["dist/migration/*.js"],
     "cli": {
         "migrationsDir": "src/logion/migration"
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "teardown-test-db": "docker stop logion-test-db",
         "coverage-unit": "nyc yarn run unit-test",
         "coverage": "nyc yarn run test",
-        "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js"
+        "typeorm": "TYPEORM_MIGRATIONS=src/logion/migration/*.ts node --require ts-node/register ./node_modules/typeorm/cli.js"
     },
     "dependencies": {
         "@polkadot/api": "^5.4.1",

--- a/src/logion/migration/1636720219315-InitialSchema.ts
+++ b/src/logion/migration/1636720219315-InitialSchema.ts
@@ -24,7 +24,11 @@ export class InitialSchema1636720219315 implements MigrationInterface {
                                          "phone_number"      character varying(255),
                                          CONSTRAINT "PK_loc_request" PRIMARY KEY ("id")
                                      )`);
+        } else {
+            await queryRunner.query(`ALTER TABLE "loc_request"
+                RENAME CONSTRAINT "PK_6e5754f2cc6563e70656d4b577f" TO "PK_loc_request"`);
         }
+
         if (!await queryRunner.hasTable("loc_request_file")) {
             await queryRunner.query(`CREATE TABLE "loc_request_file"
                                      (
@@ -40,7 +44,13 @@ export class InitialSchema1636720219315 implements MigrationInterface {
                                      )`);
             await queryRunner.query(`ALTER TABLE "loc_request_file"
                 ADD CONSTRAINT "FK_loc_request_file_loc_request" FOREIGN KEY ("request_id") REFERENCES "loc_request" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        } else {
+            await queryRunner.query(`ALTER TABLE "loc_request_file"
+                RENAME CONSTRAINT "FK_4755be27f55e9ee359ed515f580" TO "FK_loc_request_file_loc_request"`);
+            await queryRunner.query(`ALTER TABLE "loc_request_file"
+                RENAME CONSTRAINT "PK_9ae38e3c6c5bdf319949162002a" TO "PK_loc_request_file"`);
         }
+
         if (!await queryRunner.hasTable("loc_metadata_item")) {
             await queryRunner.query(`CREATE TABLE "loc_metadata_item"
                                      (
@@ -53,7 +63,13 @@ export class InitialSchema1636720219315 implements MigrationInterface {
                                      )`);
             await queryRunner.query(`ALTER TABLE "loc_metadata_item"
                 ADD CONSTRAINT "FK_loc_metadata_item_loc_request" FOREIGN KEY ("request_id") REFERENCES "loc_request" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        } else {
+            await queryRunner.query(`ALTER TABLE "loc_metadata_item"
+                RENAME CONSTRAINT "FK_c7af840708bf7b05212d5f4464d" TO "FK_loc_metadata_item_loc_request"`);
+            await queryRunner.query(`ALTER TABLE "loc_metadata_item"
+                RENAME CONSTRAINT "PK_820b664cd40a707c6954fca49ae" TO "PK_loc_metadata_item"`);
         }
+
         if (!await queryRunner.hasTable("loc_link")) {
             await queryRunner.query(`CREATE TABLE "loc_link"
                                      (
@@ -65,7 +81,13 @@ export class InitialSchema1636720219315 implements MigrationInterface {
                                      )`);
             await queryRunner.query(`ALTER TABLE "loc_link"
                 ADD CONSTRAINT "FK_loc_link_loc_request" FOREIGN KEY ("request_id") REFERENCES "loc_request" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        } else {
+            await queryRunner.query(`ALTER TABLE "loc_link"
+                RENAME CONSTRAINT "FK_299ee6985a331d0743cee5ac487" TO "FK_loc_link_loc_request"`);
+            await queryRunner.query(`ALTER TABLE "loc_link"
+                RENAME CONSTRAINT "PK_c9816e1c3f9469b4302d1856630" TO "PK_loc_link"`);
         }
+
         if (!await queryRunner.hasTable("protection_request")) {
             await queryRunner.query(`CREATE TABLE "protection_request"
                                      (
@@ -91,7 +113,13 @@ export class InitialSchema1636720219315 implements MigrationInterface {
                                          CONSTRAINT "UQ_protection_request_requester_address" UNIQUE ("requester_address"),
                                          CONSTRAINT "PK_protection_request" PRIMARY KEY ("id")
                                      )`);
+        } else {
+            await queryRunner.query(`ALTER TABLE "protection_request"
+                RENAME CONSTRAINT "PK_ca3076de000a19df02246a57f45" TO "PK_protection_request"`);
+            await queryRunner.query(`ALTER TABLE "protection_request"
+                RENAME CONSTRAINT "UQ_6167060cd889517c5480c78bf4b" TO "UQ_protection_request_requester_address"`);
         }
+
         if (!await queryRunner.hasTable("session")) {
             await queryRunner.query(`CREATE TABLE "session"
                                      (
@@ -100,7 +128,11 @@ export class InitialSchema1636720219315 implements MigrationInterface {
                                          "created_on"   TIMESTAMP,
                                          CONSTRAINT "PK_session" PRIMARY KEY ("user_address")
                                      )`);
+        } else {
+            await queryRunner.query(`ALTER TABLE "session"
+                RENAME CONSTRAINT "PK_25f64a6b97d084e6fbcd14673bd" TO "PK_session"`);
         }
+
         if (!await queryRunner.hasTable("sync_point")) {
             await queryRunner.query(`CREATE TABLE "sync_point"
                                      (
@@ -109,7 +141,11 @@ export class InitialSchema1636720219315 implements MigrationInterface {
                                          "updated_on"               TIMESTAMP         NOT NULL,
                                          CONSTRAINT "PK_sync_point" PRIMARY KEY ("name")
                                      )`);
+        } else {
+            await queryRunner.query(`ALTER TABLE "sync_point"
+                RENAME CONSTRAINT "PK_3bef54353622a585decde4fedba" TO "PK_sync_point"`);
         }
+
         if (!await queryRunner.hasTable("transaction")) {
             await queryRunner.query(`CREATE TABLE "transaction"
                                      (
@@ -126,6 +162,9 @@ export class InitialSchema1636720219315 implements MigrationInterface {
                                          "created_on"      character varying      NOT NULL,
                                          CONSTRAINT "PK_transaction" PRIMARY KEY ("block_number", "extrinsic_index")
                                      )`);
+        } else {
+            await queryRunner.query(`ALTER TABLE "transaction"
+                RENAME CONSTRAINT "PK_899cf661aa1dcc1487b4e0843d9" TO "PK_transaction"`);
         }
     }
 


### PR DESCRIPTION
* Rename constraints in order to have same names across all DB instances.
* Fix config that prevent backend to start while referencing typescript migrations.