### PR TITLE
Upgrade node-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@ethersproject/transactions": "^5.6.2",
-        "@logion/node-api": "^0.4.0-3",
+        "@logion/node-api": "^0.5.0-1",
         "@logion/node-exiftool": "^2.3.1-2",
         "@polkadot/wasm-crypto": "^6.3.1",
         "ansi-regex": "^6.0.1",

--- a/src/logion/services/authority.service.ts
+++ b/src/logion/services/authority.service.ts
@@ -1,6 +1,5 @@
 import { injectable } from "inversify";
 import { PolkadotService } from "./polkadot.service";
-import { Option, bool } from "@polkadot/types-codec";
 
 @injectable()
 export class AuthorityService {
@@ -11,7 +10,7 @@ export class AuthorityService {
 
     async isLegalOfficer(address: string): Promise<boolean> {
         const api = await this.polkadotService.readyApi();
-        const entry:Option<bool> = await api.query.loAuthorityList.legalOfficerSet(address)
-        return entry.isSome && entry.unwrap().isTrue
+        const entry = await api.query.loAuthorityList.legalOfficerSet(address);
+        return entry.isSome;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,18 +552,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.4.0-3":
-  version: 0.4.0-3
-  resolution: "@logion/node-api@npm:0.4.0-3"
+"@logion/node-api@npm:^0.5.0-1":
+  version: 0.5.0-1
+  resolution: "@logion/node-api@npm:0.5.0-1"
   dependencies:
     "@polkadot/api": ^8.14.1
     "@polkadot/util": ^10.1.1
     "@polkadot/util-crypto": ^10.1.1
     "@types/uuid": ^8.3.4
     fast-sha256: ^1.3.0
-    moment: ^2.29.4
     uuid: ^8.3.2
-  checksum: 87548727f8018afb241e6946bac80b0718ce89c563e7600b27f27395d8d169c43d32ad50935a2540144f8dd34a02867ea426ebb6406a2f2045dabd186ab64f8e
+  checksum: 6c394383a1a8adae6450329c0a2c7ba21f706ee5030789f81cc6506a8f11ca642c98f512cefaaeb79ad91df8f0b8f5fd0f3a4e23ec248d623e96394ae03e0881
   languageName: node
   linkType: hard
 
@@ -4125,7 +4124,7 @@ __metadata:
   dependencies:
     "@ethersproject/transactions": ^5.6.2
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/node-api": ^0.4.0-3
+    "@logion/node-api": ^0.5.0-1
     "@logion/node-exiftool": ^2.3.1-2
     "@polkadot/wasm-crypto": ^6.3.1
     "@tsconfig/node16": ^1.0.3


### PR DESCRIPTION
This change is necessary for the `AuthorityService` to work despite the pallet upgrade.

logion-network/logion-internal#575