### PR TITLE
Add ownership check for Goerli/ERC1155

### DIFF
--- a/src/logion/services/Etherscan.service.ts
+++ b/src/logion/services/Etherscan.service.ts
@@ -1,15 +1,24 @@
 import { injectable } from 'inversify';
 import axios from 'axios';
 
+export type NetworkType = 'mainnet' | 'goerli';
+
 @injectable()
 export class EtherscanService {
 
     async getTokenHolderInventoryPage(parameters: {
+        network: NetworkType,
         contractHash: string,
         tokenId: string,
+        page: number,
     }): Promise<string> {
-        const { contractHash, tokenId } = parameters;
-        const response = await axios.get(`https://etherscan.io/token/generic-tokenholder-inventory?m=normal&contractAddress=${contractHash}&a=${tokenId}&pUrl=token`);
+        const { network, contractHash, tokenId, page } = parameters;
+        const response = await axios.get(`https://${EtherscanService.HOSTNAMES[network]}/token/generic-tokenholder-inventory?m=normal&contractAddress=${contractHash}&a=${tokenId}&pUrl=token&p=${page}`);
         return response.data;
     }
+
+    private static HOSTNAMES: Record<NetworkType, string> = {
+        "mainnet": "etherscan.io",
+        "goerli": "goerli.etherscan.io",
+    };
 }

--- a/src/logion/services/etherscanscrapper.ts
+++ b/src/logion/services/etherscanscrapper.ts
@@ -11,4 +11,9 @@ export class EtherscanScrapper {
         const regex = new RegExp(`${address}`);
         return regex.test(this.pageContent);
     }
+
+    isEmptyPage(): boolean {
+        const regex = new RegExp("no matching entries");
+        return regex.test(this.pageContent);
+    }
 }

--- a/src/logion/services/ownershipcheck.service.ts
+++ b/src/logion/services/ownershipcheck.service.ts
@@ -3,7 +3,7 @@ import { ItemToken } from '@logion/node-api';
 import { CollectionItem } from '@logion/node-api/dist/Types';
 
 import { EtherscanScrapper } from './etherscanscrapper';
-import { EtherscanService } from './Etherscan.service';
+import { EtherscanService, NetworkType } from './Etherscan.service';
 
 @injectable()
 export class OwnershipCheckService {
@@ -20,8 +20,10 @@ export class OwnershipCheckService {
                 throw new Error("Item with restricted delivery but no token defined");
             } else {
                 const tokenType = item.token.type;
-                if(tokenType === 'ethereum_erc721') {
-                    return this.isOwnerOfEthereumErc721(address, item.token);
+                if(tokenType === 'ethereum_erc721' || tokenType === 'ethereum_erc1155') {
+                    return this.isOwnerOfErc721OrErc1155('mainnet', address, item.token);
+                } else if(tokenType === 'goerli_erc721' || tokenType === 'goerli_erc1155') {
+                    return this.isOwnerOfErc721OrErc1155('goerli', address, item.token);
                 } else if(tokenType === 'owner') {
                     return address.toLowerCase() === item.token.id.toLowerCase();
                 } else {
@@ -31,17 +33,33 @@ export class OwnershipCheckService {
         }
     }
 
-    private async isOwnerOfEthereumErc721(address: string, token: ItemToken): Promise<boolean> {
-        const { contractHash, contractTokenId } = this.parseEthereumErc721TokenId(token.id);
-        const inventoryPage = await this.etherscanService.getTokenHolderInventoryPage({
-            contractHash,
-            tokenId: contractTokenId,
-        });
-        const scrapper = new EtherscanScrapper(inventoryPage);
-        return scrapper.tokenHolderInventoryPageContainsHolder(address);
+    private async isOwnerOfErc721OrErc1155(network: NetworkType, address: string, token: ItemToken): Promise<boolean> {
+        const { contractHash, contractTokenId: tokenId } = this.parseErc721Or1155TokenId(token.id);
+        let page = 1;
+        while(page < OwnershipCheckService.MAX_PAGES) {
+            const inventoryPage = await this.etherscanService.getTokenHolderInventoryPage({
+                network,
+                contractHash,
+                tokenId,
+                page,
+            });
+
+            const scrapper = new EtherscanScrapper(inventoryPage);
+            if(scrapper.tokenHolderInventoryPageContainsHolder(address)) {
+                return true;
+            } else if(scrapper.isEmptyPage()) {
+                return false;
+            }
+
+            ++page;
+        }
+
+        return false;
     }
 
-    private parseEthereumErc721TokenId(tokenId: string): { contractHash: string, contractTokenId: string } {
+    private static MAX_PAGES = 100;
+
+    private parseErc721Or1155TokenId(tokenId: string): { contractHash: string, contractTokenId: string } {
         let tokenIdObject;
         try {
             tokenIdObject = JSON.parse(tokenId);

--- a/test/unit/services/etherscanscrapper.spec.ts
+++ b/test/unit/services/etherscanscrapper.spec.ts
@@ -9,12 +9,25 @@ describe("EtherscanScrapper", () => {
     it("does not detect token if not in holder inventory page", () => {
         testPageContainsToken(tokenInventoryWithAnotherHolder, false);
     });
+
+    it("detects empty holder inventory page", () => {
+        testPageIsEmpty(emptyHolderInventory, true);
+    });
+
+    it("does not detect holder inventory page as empty", () => {
+        testPageIsEmpty(tokenInventoryWithHolder, false);
+    });
 });
 
 function testPageContainsToken(pageContent: string, expected: boolean) {
     const scrapper = new EtherscanScrapper(pageContent);
     const contains = scrapper.tokenHolderInventoryPageContainsHolder(holderAddress);
     expect(contains).toBe(expected);
+}
+
+function testPageIsEmpty(content: string, expected: boolean) {
+    const scrapper = new EtherscanScrapper(content);
+    expect(scrapper.isEmptyPage()).toBe(expected);
 }
 
 export const emptyHolderInventory = `

--- a/test/unit/services/ownershipcheck.service.spec.ts
+++ b/test/unit/services/ownershipcheck.service.spec.ts
@@ -3,7 +3,7 @@ import { It, Mock } from "moq.ts";
 
 import { EtherscanService } from "../../../src/logion/services/Etherscan.service";
 import { OwnershipCheckService } from "../../../src/logion/services/ownershipcheck.service";
-import { emptyHolderInventory, tokenInventoryWithHolder } from "./etherscanscrapper.spec";
+import { emptyHolderInventory, tokenInventoryWithAnotherHolder, tokenInventoryWithHolder } from "./etherscanscrapper.spec";
 
 const owner = "0xa6db31d1aee06a3ad7e4e56de3775e80d2f5ea84";
 
@@ -24,6 +24,57 @@ const ethereumErc721Item: CollectionItem = {
     }],
     token: {
         type: "ethereum_erc721",
+        id: `{"contract":"${contractHash}","id":"${tokenId}"}`
+    },
+    restrictedDelivery: true,
+    termsAndConditions: [],
+};
+
+const ethereumErc1155Item: CollectionItem = {
+    id: "0xf2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
+    description: "Some artwork",
+    files: [{
+        name: "image.png",
+        contentType: "image/png",
+        hash: "0x7d6fd7774f0d87624da6dcf16d0d3d104c3191e771fbe2f39c86aed4b2bf1a0f",
+        size: 1234n
+    }],
+    token: {
+        type: "ethereum_erc1155",
+        id: `{"contract":"${contractHash}","id":"${tokenId}"}`
+    },
+    restrictedDelivery: true,
+    termsAndConditions: [],
+};
+
+const goerliErc721Item: CollectionItem = {
+    id: "0xf2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
+    description: "Some artwork",
+    files: [{
+        name: "image.png",
+        contentType: "image/png",
+        hash: "0x7d6fd7774f0d87624da6dcf16d0d3d104c3191e771fbe2f39c86aed4b2bf1a0f",
+        size: 1234n
+    }],
+    token: {
+        type: "ethereum_erc721",
+        id: `{"contract":"${contractHash}","id":"${tokenId}"}`
+    },
+    restrictedDelivery: true,
+    termsAndConditions: [],
+};
+
+const goerliErc1155Item: CollectionItem = {
+    id: "0xf2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
+    description: "Some artwork",
+    files: [{
+        name: "image.png",
+        contentType: "image/png",
+        hash: "0x7d6fd7774f0d87624da6dcf16d0d3d104c3191e771fbe2f39c86aed4b2bf1a0f",
+        size: 1234n
+    }],
+    token: {
+        type: "ethereum_erc1155",
         id: `{"contract":"${contractHash}","id":"${tokenId}"}`
     },
     restrictedDelivery: true,
@@ -57,6 +108,30 @@ describe("OwnershipCheckService", () => {
         await testDetectsNoOwnership(ethereumErc721Item);
     });
 
+    it("detects ethereum_erc1155 ownership", async () => {
+        await testDetectsOwnership(ethereumErc1155Item);
+    });
+
+    it("detects no ethereum_erc1155 ownership", async () => {
+        await testDetectsNoOwnership(ethereumErc1155Item);
+    });
+
+    it("detects goerli_erc721 ownership", async () => {
+        await testDetectsOwnership(goerliErc721Item);
+    });
+
+    it("detects no goerli_erc721 ownership", async () => {
+        await testDetectsNoOwnership(goerliErc721Item);
+    });
+
+    it("detects goerli_erc1155 ownership", async () => {
+        await testDetectsOwnership(goerliErc1155Item);
+    });
+
+    it("detects no goerli_erc1155 ownership", async () => {
+        await testDetectsNoOwnership(goerliErc1155Item);
+    });
+
     it("detects owner ownership", async () => {
         await testDetectsOwnership(ownerItem);
     });
@@ -68,14 +143,35 @@ describe("OwnershipCheckService", () => {
 
 function mockEtherscanService(): EtherscanService {
     const service = new Mock<EtherscanService>();
+
+    // First page does not contain holder
     service.setup(instance => instance.getTokenHolderInventoryPage(It.Is<{
         contractHash: string,
         tokenId: string,
-    }>(param => param.contractHash === contractHash && param.tokenId === tokenId))).returnsAsync(tokenInventoryWithHolder);
+        page: number,
+    }>(param => param.contractHash === contractHash && param.tokenId === tokenId && param.page === 1))).returnsAsync(tokenInventoryWithAnotherHolder);
+
+    // Second page contains expected holder
     service.setup(instance => instance.getTokenHolderInventoryPage(It.Is<{
         contractHash: string,
         tokenId: string,
+        page: number,
+    }>(param => param.contractHash === contractHash && param.tokenId === tokenId && param.page === 2))).returnsAsync(tokenInventoryWithHolder);
+
+    // Next pages are empty
+    service.setup(instance => instance.getTokenHolderInventoryPage(It.Is<{
+        contractHash: string,
+        tokenId: string,
+        page: number,
+    }>(param => param.contractHash === contractHash && param.tokenId === tokenId && param.page > 2))).returnsAsync(emptyHolderInventory);
+
+    // Any other page is empty
+    service.setup(instance => instance.getTokenHolderInventoryPage(It.Is<{
+        contractHash: string,
+        tokenId: string,
+        page: number,
     }>(param => param.contractHash === contractHash && param.tokenId !== tokenId))).returnsAsync(emptyHolderInventory);
+
     return service.object();
 }
 


### PR DESCRIPTION
* Support is added for both goerli network and ERC1155 tokens
* A single ERC1155 token may be hold by several owners in different quantities, hence the paging

logion-network/logion-internal#610