### PR TITLE
Enable item file source download

### DIFF
--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -39,6 +39,7 @@ import { DirectoryService } from "../services/directory.service";
 import { CollectionRepository } from "../model/collection.model";
 import { getUploadedFile } from "./fileupload";
 import { PostalAddress } from "../model/postaladdress";
+import { downloadAndClean } from "../lib/http";
 
 const { logger } = Log;
 
@@ -501,11 +502,11 @@ export class LocRequestController extends ApiController {
         const file = request.getFile(hash);
         const tempFilePath = "/tmp/download-" + requestId + "-" + hash;
         await this.fileStorageService.exportFile(file, tempFilePath);
-        this.response.download(tempFilePath, file.name, { headers: { "content-type": file.contentType } }, (error: any) => {
-            rm(tempFilePath);
-            if(error) {
-                logger.error("Download failed: %s", error);
-            }
+        downloadAndClean({
+            response: this.response,
+            path: tempFilePath,
+            name: file.name,
+            contentType: file.contentType,
         });
     }
 

--- a/src/logion/controllers/lofile.controller.ts
+++ b/src/logion/controllers/lofile.controller.ts
@@ -17,6 +17,7 @@ import { OpenAPIV3 } from "express-oas-generator";
 import { LoFileRepository, LoFileFactory } from "../model/lofile.model";
 import { FileStorageService } from "../services/file.storage.service";
 import { getUploadedFile } from "./fileupload";
+import { downloadAndClean } from "../lib/http";
 
 const { logger } = Log;
 
@@ -107,11 +108,12 @@ export class LoFileController extends ApiController {
         )
         const tempFilePath = "/tmp/download-" + id;
         await this.fileStorageService.exportFile(file, tempFilePath);
-        this.response.download(tempFilePath, file.id, { headers: { "content-type": file.contentType } }, (error: any) => {
-            rm(tempFilePath);
-            if(error) {
-                logger.error("Download failed: %s", error);
-            }
+
+        downloadAndClean({
+            response: this.response,
+            path: tempFilePath,
+            name: requireDefined(file.id),
+            contentType: requireDefined(file.contentType),
         });
     }
 }

--- a/src/logion/lib/http.ts
+++ b/src/logion/lib/http.ts
@@ -1,0 +1,19 @@
+import { Log } from "@logion/rest-api-core";
+import { rmSync } from "fs";
+
+const { logger } = Log;
+
+export function downloadAndClean(args: {
+    response: any,
+    path: string,
+    name: string,
+    contentType: string
+}) {
+    const { response, path, name, contentType } = args;
+    response.download(path, name, {headers: { "content-type": contentType } }, (error: any) => {
+        rmSync(path);
+        if(error) {
+            logger.error("Download failed: %s", error);
+        }
+    });
+}

--- a/test/unit/controllers/lofile.controller.spec.ts
+++ b/test/unit/controllers/lofile.controller.spec.ts
@@ -132,6 +132,7 @@ function mockModel(container: Container): void {
     container.bind(LoFileFactory).toConstantValue(factory.object());
 
     const existingEntity = new Mock<LoFileAggregateRoot>()
+    existingEntity.setup(instance => instance.id).returns(existingFile.id);
     existingEntity.setup(instance => instance.contentType)
         .returns(existingFile.contentType)
     existingEntity.setup(instance => instance.oid)


### PR DESCRIPTION
* Currently, only item file deliveries could be downloaded
* An additional resource was added to enable the download of the original file by LOC requester and owner only

logion-network/logion-internal#615