### PR TITLE
Change company flag into name

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -414,10 +414,6 @@
                     "phoneNumber": {
                         "type": "string",
                         "description": "Phone number"
-                    },
-                    "company": {
-                        "type": "boolean",
-                        "description": "True if the user is representing a company, false otherwise"
                     }
                 },
                 "title": "UserIdentityView",
@@ -477,6 +473,10 @@
                     "userPostalAddress": {
                         "description": "The postal address of the requester",
                         "$ref": "#/components/schemas/PostalAddressView"
+                    },
+                    "company": {
+                        "type": "boolean",
+                        "description": "True if the user requesting an Identity LOC is representing a company, false otherwise"
                     }
                 },
                 "title": "CreateLocRequestView",
@@ -643,6 +643,10 @@
                                 "description": "The date-time of voiding (chain time)"
                             }
                         }
+                    },
+                    "company": {
+                        "type": "boolean",
+                        "description": "True if the user requesting an Identity LOC is representing a company, false otherwise"
                     }
                 },
                 "title": "LocRequestView",

--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -475,8 +475,8 @@
                         "$ref": "#/components/schemas/PostalAddressView"
                     },
                     "company": {
-                        "type": "boolean",
-                        "description": "True if the user requesting an Identity LOC is representing a company, false otherwise"
+                        "type": "string",
+                        "description": "If the user requesting an Identity LOC is representing a company, its legal entity name"
                     }
                 },
                 "title": "CreateLocRequestView",
@@ -645,8 +645,8 @@
                         }
                     },
                     "company": {
-                        "type": "boolean",
-                        "description": "True if the user requesting an Identity LOC is representing a company, false otherwise"
+                        "type": "string",
+                        "description": "If the user requesting an Identity LOC is representing a company, its legal entity name"
                     }
                 },
                 "title": "LocRequestView",

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -301,8 +301,8 @@ export interface components {
       userIdentity?: components["schemas"]["UserIdentityView"];
       /** @description The postal address of the requester */
       userPostalAddress?: components["schemas"]["PostalAddressView"];
-      /** @description True if the user requesting an Identity LOC is representing a company, false otherwise */
-      company?: boolean;
+      /** @description If the user requesting an Identity LOC is representing a company, its legal entity name */
+      company?: string;
     };
     /**
      * LocRequestView
@@ -411,8 +411,8 @@ export interface components {
          */
         voidedOn?: string;
       };
-      /** @description True if the user requesting an Identity LOC is representing a company, false otherwise */
-      company?: boolean;
+      /** @description If the user requesting an Identity LOC is representing a company, its legal entity name */
+      company?: string;
     };
     /**
      * LocPublicView

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -265,8 +265,6 @@ export interface components {
       lastName?: string;
       /** @description Phone number */
       phoneNumber?: string;
-      /** @description True if the user is representing a company, false otherwise */
-      company?: boolean;
     };
     /**
      * @description The request's status
@@ -303,6 +301,8 @@ export interface components {
       userIdentity?: components["schemas"]["UserIdentityView"];
       /** @description The postal address of the requester */
       userPostalAddress?: components["schemas"]["PostalAddressView"];
+      /** @description True if the user requesting an Identity LOC is representing a company, false otherwise */
+      company?: boolean;
     };
     /**
      * LocRequestView
@@ -411,6 +411,8 @@ export interface components {
          */
         voidedOn?: string;
       };
+      /** @description True if the user requesting an Identity LOC is representing a company, false otherwise */
+      company?: boolean;
     };
     /**
      * LocPublicView

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -134,6 +134,7 @@ export class LocRequestController extends ApiController {
             createdOn: moment().toISOString(),
             userIdentity: locType === "Identity" ? this.fromUserIdentityView(createLocRequestView.userIdentity) : undefined,
             userPostalAddress: locType === "Identity" ? this.fromUserPostalAddressView(createLocRequestView.userPostalAddress) : undefined,
+            company: createLocRequestView.company || false,
         }
         if (locType === "Identity") {
             if ((await this.existsValidPolkadotIdentityLoc(description.requesterAddress))) {
@@ -222,7 +223,8 @@ export class LocRequestController extends ApiController {
                 nature: link.nature,
                 addedOn: link.addedOn?.toISOString() || undefined,
             })),
-            seal: locDescription.seal?.hash
+            seal: locDescription.seal?.hash,
+            company: locDescription.company,
         };
         const voidInfo = request.getVoidInfo();
         if(voidInfo !== null) {
@@ -243,7 +245,6 @@ export class LocRequestController extends ApiController {
             lastName: userIdentity.lastName,
             email: userIdentity.email,
             phoneNumber: userIdentity.phoneNumber,
-            company: userIdentity.company,
         }
     }
 
@@ -256,7 +257,6 @@ export class LocRequestController extends ApiController {
             lastName: userIdentityView.lastName || "",
             email: userIdentityView.email || "",
             phoneNumber: userIdentityView.phoneNumber || "",
-            company: userIdentityView.company || false,
         }
     }
 
@@ -818,6 +818,7 @@ export class LocRequestController extends ApiController {
             createdOn: moment().toISOString(),
             userIdentity,
             userPostalAddress,
+            company: false,
         }
         let request: LocRequestAggregateRoot = await this.locRequestFactory.newSofRequest({
             id: uuid(),

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -134,7 +134,7 @@ export class LocRequestController extends ApiController {
             createdOn: moment().toISOString(),
             userIdentity: locType === "Identity" ? this.fromUserIdentityView(createLocRequestView.userIdentity) : undefined,
             userPostalAddress: locType === "Identity" ? this.fromUserPostalAddressView(createLocRequestView.userPostalAddress) : undefined,
-            company: createLocRequestView.company || false,
+            company: createLocRequestView.company,
         }
         if (locType === "Identity") {
             if ((await this.existsValidPolkadotIdentityLoc(description.requesterAddress))) {
@@ -818,7 +818,6 @@ export class LocRequestController extends ApiController {
             createdOn: moment().toISOString(),
             userIdentity,
             userPostalAddress,
-            company: false,
         }
         let request: LocRequestAggregateRoot = await this.locRequestFactory.newSofRequest({
             id: uuid(),

--- a/src/logion/controllers/protectionrequest.controller.ts
+++ b/src/logion/controllers/protectionrequest.controller.ts
@@ -97,7 +97,6 @@ export class ProtectionRequestController extends ApiController {
                     lastName: body.userIdentity!.lastName!,
                     email: body.userIdentity!.email!,
                     phoneNumber: body.userIdentity!.phoneNumber!,
-                    company: body.userIdentity!.company!,
                 },
                 userPostalAddress: {
                     line1: body.userPostalAddress!.line1!,
@@ -157,7 +156,6 @@ export class ProtectionRequestController extends ApiController {
                 lastName: request.userIdentity?.lastName || "",
                 email: request.userIdentity?.email || "",
                 phoneNumber: request.userIdentity?.phoneNumber || "",
-                company: request.userIdentity?.company || false,
             },
             userPostalAddress: {
                 line1: request.userPostalAddress?.line1 || "",

--- a/src/logion/migration/1666083444245-AddCompany.ts
+++ b/src/logion/migration/1666083444245-AddCompany.ts
@@ -6,7 +6,6 @@ export class AddCompany1666083444245 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "loc_request" ADD "company" boolean NOT NULL DEFAULT false`);
         await queryRunner.query(`ALTER TABLE "loc_request" ADD "seal_version" integer NOT NULL DEFAULT '0'`);
-        await queryRunner.query(`ALTER TABLE "protection_request" ADD "company" boolean NOT NULL DEFAULT false`);
         await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "first_name" DROP NOT NULL`);
         await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "last_name" DROP NOT NULL`);
         await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "email" DROP NOT NULL`);
@@ -26,7 +25,6 @@ export class AddCompany1666083444245 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "email" SET NOT NULL`);
         await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "last_name" SET NOT NULL`);
         await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "first_name" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "protection_request" DROP COLUMN "company"`);
         await queryRunner.query(`ALTER TABLE "loc_request" DROP COLUMN "seal_version"`);
         await queryRunner.query(`ALTER TABLE "loc_request" DROP COLUMN "company"`);
     }

--- a/src/logion/migration/1666182071461-AddCompany.ts
+++ b/src/logion/migration/1666182071461-AddCompany.ts
@@ -1,10 +1,10 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class AddCompany1666083444245 implements MigrationInterface {
-    name = 'AddCompany1666083444245'
+export class AddCompany1666182071461 implements MigrationInterface {
+    name = 'AddCompany1666182071461'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "loc_request" ADD "company" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "loc_request" ADD "company" character varying(255)`);
         await queryRunner.query(`ALTER TABLE "loc_request" ADD "seal_version" integer NOT NULL DEFAULT '0'`);
         await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "first_name" DROP NOT NULL`);
         await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "last_name" DROP NOT NULL`);

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -38,7 +38,7 @@ export interface LocRequestDescription {
     readonly userPostalAddress: PostalAddress | undefined;
     readonly locType: LocType;
     readonly seal?: PublicSeal;
-    readonly company: boolean;
+    readonly company?: string;
 }
 
 export interface LocRequestDecision {
@@ -555,8 +555,8 @@ export class LocRequestAggregateRoot {
     @Column(() => EmbeddablePostalAddress, { prefix: "" })
     userPostalAddress?: EmbeddablePostalAddress;
 
-    @Column("boolean", { default: false })
-    company?: boolean;
+    @Column("varchar", { length: 255, name: "company", nullable: true })
+    company?: string | null;
 
     @OneToMany(() => LocFile, file => file.request, {
         eager: true,

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -38,6 +38,7 @@ export interface LocRequestDescription {
     readonly userPostalAddress: PostalAddress | undefined;
     readonly locType: LocType;
     readonly seal?: PublicSeal;
+    readonly company: boolean;
 }
 
 export interface LocRequestDecision {
@@ -158,6 +159,7 @@ export class LocRequestAggregateRoot {
             userPostalAddress,
             locType: this.locType!,
             seal: toPublicSeal(this.seal),
+            company: this.company!,
         }
     }
 
@@ -500,9 +502,10 @@ export class LocRequestAggregateRoot {
     }
 
     updateSealedPersonalInfo(personalInfo: PersonalInfo, seal: Seal) {
-        const { userIdentity, userPostalAddress } = personalInfo;
+        const { userIdentity, userPostalAddress, company } = personalInfo;
         this.updateUserIdentity(userIdentity);
         this.updateUserPostalAddress(userPostalAddress)
+        this.company = company;
         this.seal = EmbeddableSeal.from(seal);
     }
 
@@ -551,6 +554,9 @@ export class LocRequestAggregateRoot {
 
     @Column(() => EmbeddablePostalAddress, { prefix: "" })
     userPostalAddress?: EmbeddablePostalAddress;
+
+    @Column("boolean", { default: false })
+    company?: boolean;
 
     @OneToMany(() => LocFile, file => file.request, {
         eager: true,
@@ -863,13 +869,15 @@ export class LocRequestFactory {
             city: "",
             country: ""
         }
+        const company = description.company;
         if (request.locType === 'Identity') {
-            const personalInfo: PersonalInfo = { userIdentity, userPostalAddress }
+            const personalInfo: PersonalInfo = { userIdentity, userPostalAddress, company }
             const seal = this.sealService.seal(personalInfo, LATEST_SEAL_VERSION);
             request.updateSealedPersonalInfo(personalInfo, seal);
         } else {
             request.updateUserIdentity(userIdentity);
             request.updateUserPostalAddress(userPostalAddress);
+            request.company = company;
         }
         request.files = [];
         request.metadata = [];

--- a/src/logion/model/personalinfo.model.ts
+++ b/src/logion/model/personalinfo.model.ts
@@ -2,6 +2,7 @@ import { UserIdentity } from "./useridentity";
 import { PostalAddress } from "./postaladdress";
 
 export interface PersonalInfo {
-    userIdentity: UserIdentity
-    userPostalAddress: PostalAddress
+    userIdentity: UserIdentity;
+    userPostalAddress: PostalAddress;
+    company: boolean;
 }

--- a/src/logion/model/personalinfo.model.ts
+++ b/src/logion/model/personalinfo.model.ts
@@ -4,5 +4,5 @@ import { PostalAddress } from "./postaladdress";
 export interface PersonalInfo {
     userIdentity: UserIdentity;
     userPostalAddress: PostalAddress;
-    company: boolean;
+    company?: string;
 }

--- a/src/logion/model/useridentity.ts
+++ b/src/logion/model/useridentity.ts
@@ -5,7 +5,6 @@ export interface UserIdentity {
     lastName: string,
     email: string,
     phoneNumber: string,
-    company: boolean,
 }
 
 export class EmbeddableUserIdentity {
@@ -22,9 +21,6 @@ export class EmbeddableUserIdentity {
     @Column("varchar", { length: 255, name: "phone_number", nullable: true })
     phoneNumber?: string | null;
 
-    @Column("boolean", { default: false })
-    company?: boolean;
-
     static from(identity: UserIdentity | undefined): EmbeddableUserIdentity {
         const embeddable = new EmbeddableUserIdentity();
         if(identity) {
@@ -32,27 +28,24 @@ export class EmbeddableUserIdentity {
             embeddable.lastName = identity.lastName;
             embeddable.email = identity.email;
             embeddable.phoneNumber = identity.phoneNumber;
-            embeddable.company = identity.company;
         } else {
             embeddable.firstName = "";
             embeddable.lastName = "";
             embeddable.email = "";
             embeddable.phoneNumber = "";
-            embeddable.company = false;
         }
         return embeddable;
     }
 }
 
 export function toUserIdentity(embedded: EmbeddableUserIdentity | undefined): UserIdentity | undefined {
-    return embedded && (embedded.firstName || embedded.lastName || embedded.email || embedded.phoneNumber || embedded.company)
+    return embedded && (embedded.firstName || embedded.lastName || embedded.email || embedded.phoneNumber)
         ?
         {
             firstName: embedded.firstName || "",
             lastName: embedded.lastName || "",
             email: embedded.email || "",
             phoneNumber: embedded.phoneNumber || "",
-            company: embedded.company || false,
         }
         : undefined;
 }

--- a/src/logion/services/seal.service.ts
+++ b/src/logion/services/seal.service.ts
@@ -65,8 +65,8 @@ export class PersonalInfoSealService extends SealService<PersonalInfo> {
     override values(personalInfo: PersonalInfo, version: number): string[] {
         let values = [];
         values = this.userIdentityValues(personalInfo.userIdentity, version);
-        if(version === LATEST_SEAL_VERSION) {
-            values = values.concat(personalInfo.company.toString())
+        if(version === LATEST_SEAL_VERSION && personalInfo.company) {
+            values.push(personalInfo.company)
         }
         values = values.concat(this.postalAddressValue(personalInfo.userPostalAddress, version));
         return values;

--- a/src/logion/services/seal.service.ts
+++ b/src/logion/services/seal.service.ts
@@ -63,14 +63,17 @@ export class PersonalInfoSealService extends SealService<PersonalInfo> {
     }
 
     override values(personalInfo: PersonalInfo, version: number): string[] {
-        return this.userIdentityValues(personalInfo.userIdentity, version)
-            .concat(this.postalAddressValue(personalInfo.userPostalAddress, version));
+        let values = [];
+        values = this.userIdentityValues(personalInfo.userIdentity, version);
+        if(version === LATEST_SEAL_VERSION) {
+            values = values.concat(personalInfo.company.toString())
+        }
+        values = values.concat(this.postalAddressValue(personalInfo.userPostalAddress, version));
+        return values;
     }
 
     private userIdentityValues(userIdentity: UserIdentity, version: number): string[] {
-        if(version === LATEST_SEAL_VERSION) {
-            return [ userIdentity.firstName, userIdentity.lastName, userIdentity.email, userIdentity.phoneNumber, userIdentity.company.toString() ];
-        } else if(version === 0) {
+        if(version === 0 || version === LATEST_SEAL_VERSION) {
             return [ userIdentity.firstName, userIdentity.lastName, userIdentity.email, userIdentity.phoneNumber ];
         } else {
             throw new Error(`Unsupported seal version ${version}`);

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -73,7 +73,6 @@ describe('LocRequestRepository - read accesses', () => {
             lastName: 'Doe',
             email: 'john.doe@logion.network',
             phoneNumber: '+123456',
-            company: false,
         });
         expect(requests[0].status).toBe("REJECTED");
     })

--- a/test/unit/controllers/locrequest.controller.spec.ts
+++ b/test/unit/controllers/locrequest.controller.spec.ts
@@ -41,7 +41,6 @@ const userIdentities: Record<IdentityLocation, UserPrivateData> = {
             lastName: "the Cat",
             email: "felix@logion.network",
             phoneNumber: "+0101",
-            company: false,
         },
         userPostalAddress: {
             line1: "Rue de la Paix, 1",
@@ -58,7 +57,6 @@ const userIdentities: Record<IdentityLocation, UserPrivateData> = {
             lastName: "Tiger",
             email: "scott.tiger@logion.network",
             phoneNumber: "+6789",
-            company: false,
         },
         userPostalAddress: {
             line1: "Rue de la Paix, 2",
@@ -75,7 +73,6 @@ const userIdentities: Record<IdentityLocation, UserPrivateData> = {
             lastName: "Doe",
             email: "john.doe@logion.network",
             phoneNumber: "+1234",
-            company: false,
         },
         userPostalAddress: {
             line1: "Rue de la Paix, 3",

--- a/test/unit/controllers/protectionrequest.controller.spec.ts
+++ b/test/unit/controllers/protectionrequest.controller.spec.ts
@@ -82,7 +82,6 @@ const IDENTITY: UserIdentity = {
     firstName: "John",
     lastName: "Doe",
     phoneNumber: "+1234",
-    company: false,
 };
 
 const POSTAL_ADDRESS: PostalAddress = {

--- a/test/unit/controllers/vaulttransferrequest.controller.spec.ts
+++ b/test/unit/controllers/vaulttransferrequest.controller.spec.ts
@@ -259,7 +259,6 @@ const IDENTITY: UserIdentity = {
     firstName: "John",
     lastName: "Doe",
     phoneNumber: "+1234",
-    company: false,
 };
 
 const POSTAL_ADDRESS: PostalAddress = {

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -37,7 +37,6 @@ describe("LocRequestFactory", () => {
         lastName: "Tiger",
         email: "scott@logion.network",
         phoneNumber: "+789",
-        company: false,
     };
 
     it("creates Transaction LOC request", async () => {
@@ -210,6 +209,7 @@ describe("LocRequestFactory", () => {
             userPostalAddress,
             locType,
             seal,
+            company: false,
         };
     }
 });

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -209,7 +209,7 @@ describe("LocRequestFactory", () => {
             userPostalAddress,
             locType,
             seal,
-            company: false,
+            company: undefined,
         };
     }
 });

--- a/test/unit/model/protectionrequest.model.spec.ts
+++ b/test/unit/model/protectionrequest.model.spec.ts
@@ -102,7 +102,6 @@ const description: ProtectionRequestDescription = {
         firstName: "John",
         lastName: "Doe",
         phoneNumber: "+1234",
-        company: false,
     },
     userPostalAddress: {
         line1: "Place de le République Française, 10",

--- a/test/unit/services/notification-test-data.ts
+++ b/test/unit/services/notification-test-data.ts
@@ -67,7 +67,6 @@ export function notifiedLOC(): LocRequestDescription & { decision: LocRequestDec
         },
         userIdentity: undefined,
         userPostalAddress: undefined,
-        company: false,
     }
 }
 

--- a/test/unit/services/notification-test-data.ts
+++ b/test/unit/services/notification-test-data.ts
@@ -18,7 +18,6 @@ export const notifiedProtection: ProtectionRequestDescription & { decision: Lega
         lastName: "Doe",
         email: "john.doe@logion.network",
         phoneNumber: "123456",
-        company: false,
     },
     userPostalAddress: {
         line1: "Rue de la Paix",
@@ -44,7 +43,6 @@ export function notifiedLegalOfficer(address:string): LegalOfficer {
             lastName: "Network",
             email: address === BOB ? "bob@logion.network" : "alice@logion.network",
             phoneNumber: "123465",
-            company: false,
         },
         postalAddress: {
             company: "Alice & Co",
@@ -69,6 +67,7 @@ export function notifiedLOC(): LocRequestDescription & { decision: LocRequestDec
         },
         userIdentity: undefined,
         userPostalAddress: undefined,
+        company: false,
     }
 }
 

--- a/test/unit/services/seal.service.spec.ts
+++ b/test/unit/services/seal.service.spec.ts
@@ -12,7 +12,6 @@ describe("PersonalInfoSealService", () => {
         lastName: "Tiger",
         phoneNumber: "123",
         email: "scott.tiger@example.org",
-        company: false,
     }
 
     const userPostalAddress: PostalAddress = {
@@ -25,7 +24,8 @@ describe("PersonalInfoSealService", () => {
 
     const personalInfo: PersonalInfo = {
         userIdentity,
-        userPostalAddress
+        userPostalAddress,
+        company: false,
     }
 
     const salt = "aa456085-5344-4937-b3be-559489366be6";

--- a/test/unit/services/seal.service.spec.ts
+++ b/test/unit/services/seal.service.spec.ts
@@ -25,7 +25,7 @@ describe("PersonalInfoSealService", () => {
     const personalInfo: PersonalInfo = {
         userIdentity,
         userPostalAddress,
-        company: false,
+        company: "The Company I Represent",
     }
 
     const salt = "aa456085-5344-4937-b3be-559489366be6";
@@ -34,7 +34,7 @@ describe("PersonalInfoSealService", () => {
 
     const expectedHashesPerVersion = [
         "0x90e6d447523780d1a048194b939fa95587e52c01b82bf5683b3801729e300c36",
-        "0xb71dc9082fa5008fad01eb4fdcebda271c9a5323bef8898c1d7a712e42af7367",
+        "0xa22772e11382ecc1cdcc6d776b0e6a8ed210aa0e19e6d2b83dce67c3868468e9",
     ];
 
     it("seals with salt", () => {


### PR DESCRIPTION
* Company flag (true = I represent a company) was turned into a name (defined = I represent a company with given legal entity name)
* That information was moved from user identity to LOC request (only taken into account with Identity LOCs)
* As the initial migration has not been applied yet in DEV, it was modified to fit with the new model