### PR TITLE
Load LOC request relations on find by spec

### DIFF
--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -784,7 +784,10 @@ export class LocRequestRepository {
     }
 
     public async findBy(specification: FetchLocRequestsSpecification): Promise<LocRequestAggregateRoot[]> {
-        let builder = this.repository.createQueryBuilder("request");
+        let builder = this.repository.createQueryBuilder("request")
+            .leftJoinAndSelect("request.files", "file")
+            .leftJoinAndSelect("request.metadata", "metadata_item")
+            .leftJoinAndSelect("request.links", "link");
 
         if (specification.expectedRequesterAddress) {
             builder.where("request.requester_address = :expectedRequesterAddress",

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -48,6 +48,11 @@ describe('LocRequestRepository - read accesses', () => {
         checkDescription(requests, undefined, "loc-1", "loc-2", "loc-3", "loc-4", "loc-5",
             "loc-6", "loc-7", "loc-8", "loc-9", "loc-10", "loc-11", "loc-12", "loc-13", "loc-21", "loc-22", "loc-23",
             "loc-24", "loc-25", "loc-26");
+
+        const requestWithItems = requests.find(request => request.description === "loc-10");
+        expect(requestWithItems?.files?.length).toBe(1);
+        expect(requestWithItems?.metadata?.length).toBe(1);
+        expect(requestWithItems?.links?.length).toBe(1);
     })
 
     it("find LOCS with Logion requester", async () => {


### PR DESCRIPTION
* Eager loading is disabled when using a query builder
* In that case, relations to load have to be explicitly configured with a join
* Not doing so implies empty files, metadata and links fields in returned views on fetch with specification