### PR TITLE
Fine-tune order by clause to fetch loc requests.

### DIFF
--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -813,12 +813,13 @@ export class LocRequestRepository {
             builder.andWhere("request.requester_address IS NULL")
         }
 
-        if (specification.expectedStatuses &&
-            (specification.expectedStatuses.includes("OPEN") || specification.expectedStatuses.includes("CLOSED"))) {
-            builder.orderBy("request.loc_created_on", "DESC")
-        } else {
-            builder.orderBy("request.created_on", "DESC")
-        }
+        builder
+            .orderBy("request.voided_on", "DESC", "NULLS FIRST")
+            .addOrderBy("request.closed_on", "DESC", "NULLS FIRST")
+            .addOrderBy("request.loc_created_on", "DESC", "NULLS FIRST")
+            .addOrderBy("request.decision_on", "DESC", "NULLS FIRST")
+            .addOrderBy("request.created_on", "DESC", "NULLS FIRST");
+
         return builder.getMany();
     }
 

--- a/test/integration/model/loc_requests_order.sql
+++ b/test/integration/model/loc_requests_order.sql
@@ -1,0 +1,30 @@
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-1', 'Transaction', 'REQUESTED', '2022-10-01', null, null, null, null);
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-2', 'Transaction', 'REQUESTED', '2022-10-02', null, null, null, null);
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-9', 'Transaction', 'REJECTED', '2022-10-01', '2022-10-02', null, null, null);
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-10', 'Transaction', 'REJECTED', '2022-10-02', '2022-10-03', null, null, null);
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-3', 'Transaction', 'OPEN', '2022-10-01', '2022-10-02', '2022-10-03', null, null);
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-4', 'Transaction', 'OPEN', '2022-10-02', '2022-10-03', '2022-10-04', null, null);
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-5', 'Transaction', 'CLOSED', '2022-10-01', '2022-10-02', '2022-10-03', '2022-10-04', null);
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-6', 'Transaction', 'CLOSED', '2022-10-02', '2022-10-03', '2022-10-04', '2022-10-05', null);
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-7', 'Transaction', 'CLOSED', '2022-10-01', '2022-10-02', '2022-10-03', '2022-10-04', '2022-10-05'); -- VOID
+INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+        'ordered-loc-8', 'Transaction', 'CLOSED', '2022-10-02', '2022-10-03', '2022-10-04', '2022-10-05', '2022-10-06'); -- VOID

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -174,6 +174,43 @@ describe('LocRequestRepository.save()', () => {
     })
 })
 
+describe('LocRequestRepository - LOC correctly ordered', () => {
+
+    beforeAll(async () => {
+        await connect([ LocRequestAggregateRoot, LocFile, LocMetadataItem, LocLink ]);
+        await executeScript("test/integration/model/loc_requests_order.sql");
+        repository = new LocRequestRepository();
+    });
+
+    let repository: LocRequestRepository;
+
+    afterAll(async () => {
+        await disconnect();
+    });
+
+    it("deletes a draft LocRequest aggregate", async () => {
+        const locs = await repository.findBy({
+            expectedLocTypes: ["Collection", "Identity", "Transaction"],
+            expectedOwnerAddress: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            expectedStatuses: ["CLOSED", "OPEN", "REJECTED", "REQUESTED"]
+        });
+
+        const descriptions = locs.map(loc => loc.description);
+        expect(descriptions).toEqual([
+            "ordered-loc-2",
+            "ordered-loc-1",
+            "ordered-loc-10",
+            "ordered-loc-9",
+            "ordered-loc-4",
+            "ordered-loc-3",
+            "ordered-loc-6",
+            "ordered-loc-5",
+            "ordered-loc-8",
+            "ordered-loc-7",
+        ])
+    });
+});
+
 function givenLoc(id: string, locType: LocType, status: LocRequestStatus): LocRequestAggregateRoot {
     const locRequest = new LocRequestAggregateRoot();
     locRequest.id = id;


### PR DESCRIPTION
A global order by clause is setup, so that LOC requests will appear following this order:
1. REQUESTED LOCs, ordered by descending created_on,
1. REJECTED LOC requests, ordered by descending created_on,
1. OPEN LOCs, ordered by descending loc_created_on,
1. CLOSED LOCs, ordered by descending closed_on,
1. VOIDED LOCs, ordered by descending voided_on.

logion-network/logion-internal#639