### PR TITLE
Add singular_kusama ownership check

### DIFF
--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -34,6 +34,7 @@ import { RestrictedDeliveryService } from '../services/restricteddelivery.servic
 import { ExifService } from '../services/exif.service';
 import { PersonalInfoSealService } from "../services/seal.service";
 import { BackendHealthService } from "../services/health.service";
+import { SingularService } from "../services/singular.service";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -76,6 +77,7 @@ container.bind(RestrictedDeliveryService).toSelf();
 container.bind(PersonalInfoSealService).toSelf();
 container.bind(BackendHealthService).toSelf();
 container.bind(HealthService).toService(BackendHealthService);
+container.bind(SingularService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();

--- a/src/logion/services/ownershipcheck.service.ts
+++ b/src/logion/services/ownershipcheck.service.ts
@@ -3,12 +3,14 @@ import { ItemToken } from '@logion/node-api';
 import { CollectionItem } from '@logion/node-api/dist/Types';
 
 import { Network, AlchemyService } from './alchemy.service';
+import { SingularService } from './singular.service';
 
 @injectable()
 export class OwnershipCheckService {
 
     constructor(
         private alchemyService: AlchemyService,
+        private singularService: SingularService,
     ) {}
 
     async isOwner(address: string, item: CollectionItem): Promise<boolean> {
@@ -26,6 +28,8 @@ export class OwnershipCheckService {
                     return this.isOwnerOfErc721OrErc1155(Network.ETH_GOERLI, normalizedAddress, item.token);
                 } else if(tokenType === 'owner') {
                     return normalizedAddress === item.token.id.toLowerCase();
+                } else if(tokenType === 'singular_kusama') {
+                    return this.isOwnerOfSingularKusama(address, item.token.id);
                 } else {
                     throw new Error(`Unsupported token type ${tokenType}`);
                 }
@@ -53,5 +57,10 @@ export class OwnershipCheckService {
         } else {
             return { contractHash, contractTokenId };
         }
+    }
+
+    private async isOwnerOfSingularKusama(address: string, tokenId: string): Promise<boolean> {
+        const owners = await this.singularService.getOwners(tokenId);
+        return owners.find(owner => owner === address) !== undefined;
     }
 }

--- a/src/logion/services/singular.service.ts
+++ b/src/logion/services/singular.service.ts
@@ -1,0 +1,11 @@
+import { injectable } from 'inversify';
+import axios from "axios";
+
+@injectable()
+export class SingularService {
+
+    async getOwners(nftId: string): Promise<string[]> {
+        const response = await axios.get(`https://singular.app/api/nft/${nftId}`);
+        return response.data.nfts.map((nft: any) => nft.owner);
+    }
+}

--- a/test/unit/services/ownershipcheck.service.spec.ts
+++ b/test/unit/services/ownershipcheck.service.spec.ts
@@ -3,25 +3,30 @@ import { Mock } from "moq.ts";
 
 import { AlchemyService, Network } from "../../../src/logion/services/alchemy.service";
 import { OwnershipCheckService } from "../../../src/logion/services/ownershipcheck.service";
+import { SingularService } from "../../../src/logion/services/singular.service";
 
 describe("OwnershipCheckService", () => {
-    it("detects ethereum_erc721 ownership", () => testDetectsOwnership(ethereumErc721Item, Network.ETH_MAINNET));
+    it("detects ethereum_erc721 ownership", () => testDetectsOwnership(ethereumErc721Item, owner, Network.ETH_MAINNET));
     it("detects no ethereum_erc721 ownership", () => testDetectsNoOwnership(ethereumErc721Item, Network.ETH_MAINNET));
-    it("detects ethereum_erc1155 ownership", () => testDetectsOwnership(ethereumErc1155Item, Network.ETH_MAINNET));
+    it("detects ethereum_erc1155 ownership", () => testDetectsOwnership(ethereumErc1155Item, owner, Network.ETH_MAINNET));
     it("detects no ethereum_erc1155 ownership", () => testDetectsNoOwnership(ethereumErc1155Item, Network.ETH_MAINNET));
 
-    it("detects goerli_erc721 ownership", () => testDetectsOwnership(goerliErc721Item, Network.ETH_GOERLI));
+    it("detects goerli_erc721 ownership", () => testDetectsOwnership(goerliErc721Item, owner, Network.ETH_GOERLI));
     it("detects no goerli_erc721 ownership", () => testDetectsNoOwnership(goerliErc721Item, Network.ETH_GOERLI));
-    it("detects goerli_erc1155 ownership", () => testDetectsOwnership(goerliErc1155Item, Network.ETH_GOERLI));
+    it("detects goerli_erc1155 ownership", () => testDetectsOwnership(goerliErc1155Item, owner, Network.ETH_GOERLI));
     it("detects no goerli_erc1155 ownership", () => testDetectsNoOwnership(goerliErc1155Item, Network.ETH_GOERLI));
 
-    it("detects owner ownership", () => testDetectsOwnership(ownerItem));
+    it("detects owner ownership", () => testDetectsOwnership(ownerItem, owner));
     it("detects no owner ownership", () => testDetectsNoOwnership(ownerItem));
+
+    it("detects singular_kusama ownership", () => testDetectsOwnership(singularKusamaItem, polkadotOwner));
+    it("detects no singular_kusama ownership", () => testDetectsNoOwnership(singularKusamaItem));
 });
 
-async function testDetectsOwnership(item: CollectionItem, network?: Network) {
+async function testDetectsOwnership(item: CollectionItem, owner: string, network?: Network) {
     const alchemyService = mockAlchemyService(network);
-    const ownershipCheckService = new OwnershipCheckService(alchemyService);
+    const singularService = mockSingularService();
+    const ownershipCheckService = new OwnershipCheckService(alchemyService, singularService);
     const result = await ownershipCheckService.isOwner(owner, item);
     expect(result).toBe(true);
 }
@@ -38,15 +43,32 @@ function mockAlchemyService(network?: Network): AlchemyService {
     return service.object();
 }
 
+function mockSingularService(): SingularService {
+    const service = new Mock<SingularService>();
+    service.setup(instance => instance.getOwners).returns((_tokenId: string) => {
+        if(singularTokenId === _tokenId) {
+            return Promise.resolve([ polkadotOwner ]);
+        } else {
+            return Promise.resolve([]);
+        }
+    });
+    return service.object();
+}
+
 const owner = "0xa6db31d1aee06a3ad7e4e56de3775e80d2f5ea84";
 
 const contractHash = "0x765df6da33c1ec1f83be42db171d7ee334a46df5";
 
 const tokenId = "4391";
 
+const polkadotOwner = "GUo1ZJ9bBCmCt8GZMHRqys1ZdUBCpJKi7CgjH1RkRgVeJNF";
+
+const singularTokenId = "15057162-acba02847598b67746-DSTEST1-LUXEMBOURG_HOUSE-00000001";
+
 async function testDetectsNoOwnership(item: CollectionItem, network?: Network) {
     const alchemyService = mockAlchemyService(network);
-    const ownershipCheckService = new OwnershipCheckService(alchemyService);
+    const singularService = mockSingularService();
+    const ownershipCheckService = new OwnershipCheckService(alchemyService, singularService);
     const result = await ownershipCheckService.isOwner(anotherOwner, item);
     expect(result).toBe(false);
 }
@@ -127,12 +149,29 @@ const ownerItem: CollectionItem = {
     files: [{
         name: "image.png",
         contentType: "image/png",
-        hash: "0x7D6fd7774f0d87624da6dCF16d0d3d104c3191e771fbe2f39c86aed4b2bf1a0F",
+        hash: "0x7d6fd7774f0d87624da6dcf16d0d3d104c3191e771fbe2f39c86aed4b2bf1a0f",
         size: 1234n
     }],
     token: {
         type: "owner",
         id: `${owner}`
+    },
+    restrictedDelivery: true,
+    termsAndConditions: [],
+};
+
+const singularKusamaItem: CollectionItem = {
+    id: "0xf2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
+    description: "Some artwork",
+    files: [{
+        name: "image.png",
+        contentType: "image/png",
+        hash: "0x7d6fd7774f0d87624da6dcf16d0d3d104c3191e771fbe2f39c86aed4b2bf1a0f",
+        size: 1234n
+    }],
+    token: {
+        type: "singular_kusama",
+        id: `${singularTokenId}`
     },
     restrictedDelivery: true,
     termsAndConditions: [],


### PR DESCRIPTION
* Ownership check is now possible with Singular Kusama NFTs (but not yet Statemine)
* The check uses Singular's REST API

logion-network/logion-internal#650