### PR TITLE
Enable rework or cancel of rejected LOC request

### DIFF
--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -136,6 +136,13 @@ export class LocRequestAggregateRoot {
         this.decisionOn = rejectedOn.toISOString();
     }
 
+    rework(): void {
+        if (this.status != 'REJECTED') {
+            throw new Error("Cannot rework a non-rejected request");
+        }
+        this.status = 'DRAFT';
+    }
+
     accept(decisionOn: Moment): void {
         if (this.status != 'REQUESTED') {
             throw new Error("Cannot accept already decided request");
@@ -823,9 +830,9 @@ export class LocRequestRepository {
         return builder.getMany();
     }
 
-    async deleteDraft(request: LocRequestAggregateRoot): Promise<void> {
-        if(request.status !== "DRAFT") {
-            throw new Error("Cannot delete non-draft request");
+    async deleteDraftOrRejected(request: LocRequestAggregateRoot): Promise<void> {
+        if(request.status !== "DRAFT" && request.status !== "REJECTED") {
+            throw new Error("Cannot delete non-draft and non-rejected request");
         }
 
         return await appDataSource.manager.transaction(async entityManager => {

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -168,7 +168,19 @@ describe('LocRequestRepository.save()', () => {
         const locRequest = givenLoc(id, "Transaction", "DRAFT")
 
         await repository.save(locRequest)
-        await repository.deleteDraft(locRequest)
+        await repository.deleteDraftOrRejected(locRequest)
+
+        await checkAggregate(id, 0)
+    })
+
+    it("deletes a rejected LocRequest aggregate", async () => {
+        const id = uuid()
+        const locRequest = givenLoc(id, "Transaction", "DRAFT")
+        locRequest.submit();
+        locRequest.reject("Because", moment());
+
+        await repository.save(locRequest)
+        await repository.deleteDraftOrRejected(locRequest)
 
         await checkAggregate(id, 0)
     })
@@ -211,7 +223,7 @@ describe('LocRequestRepository - LOC correctly ordered', () => {
     });
 });
 
-function givenLoc(id: string, locType: LocType, status: LocRequestStatus): LocRequestAggregateRoot {
+function givenLoc(id: string, locType: LocType, status: "OPEN" | "DRAFT"): LocRequestAggregateRoot {
     const locRequest = new LocRequestAggregateRoot();
     locRequest.id = id;
     locRequest.requesterAddress = "5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ"

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -736,6 +736,15 @@ describe("LocRequestAggregateRoot (processes)", () => {
         request.submit();
         thenRequestStatusIs("REQUESTED");
 
+        // LLO rejects
+        request.reject("Because.", moment());
+        thenRequestStatusIs("REJECTED");
+
+        // User reworks and submits again
+        request.rework();
+        thenRequestStatusIs("DRAFT");
+        request.submit();
+
         // LLO accepts and publishes
         request.accept(moment());
         thenRequestStatusIs("OPEN");


### PR DESCRIPTION
* Rejected LOC requests can be deleted by the requester
* Rejected LOC requests can be reworked (i.e. turned back into draft mode) by the requester

logion-network/logion-internal#663