### PR TITLE
Check file hash on upload

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -843,22 +843,15 @@
             "AddFileView": {
                 "type": "object",
                 "properties": {
+                    "hash": {
+                        "type": "string",
+                        "description": "Hash of uploaded file"
+                    },
                     "nature": {
                         "type": "string",
                         "description": "The file's nature"
                     }
                 }
-            },
-            "AddFileResultView": {
-                "type": "object",
-                "properties": {
-                    "hash": {
-                        "type": "string",
-                        "description": "Hex-encoded SHA256 hash of added file"
-                    }
-                },
-                "title": "AddFileResultView",
-                "description": "The result of adding a file to a LOC"
             },
             "AddLinkView": {
                 "type": "object",
@@ -1112,6 +1105,14 @@
                 },
                 "title": "CreateSofRequestView",
                 "description": "A Statement of Facts Request to create"
+            },
+            "FileUploadData": {
+                "type": "object",
+                "properties": {
+                    "hash": {
+                        "type": "string"
+                    }
+                }
             }
         }
     }

--- a/src/logion/app.ts
+++ b/src/logion/app.ts
@@ -1,36 +1,18 @@
 import { appDataSource, Log } from "@logion/rest-api-core";
-import express from 'express';
-import expressOasGenerator, { SPEC_OUTPUT_FILE_BEHAVIOR } from 'express-oas-generator';
 
 import { AppContainer } from './container/app.container';
 import { Scheduler } from "./scheduler/scheduler.service";
-import { setupApp, predefinedSpec } from "./app.support";
+import { setupApp } from "./app.support";
 import { PrometheusService } from "./services/prometheus.service";
 
 const { logger } = Log;
 
 require('source-map-support').install();
 
-const app = express();
-
-expressOasGenerator.handleResponses(app, {
-    predefinedSpec,
-    specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE,
-    swaggerDocumentOptions: {
-
-    },
-    alwaysServeDocs: true,
-});
-
 appDataSource.initialize()
 .then(() => {
-
-    setupApp(app)
-
+    const app = setupApp();
     AppContainer.get(Scheduler).start();
-
-    expressOasGenerator.handleRequests();
-
     const port = process.env.PORT || 8080;
     app.listen(port, () => logger.info(`API server started on port ${ port }`));
 

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -528,16 +528,10 @@ export interface components {
       rejectReason?: string;
     };
     AddFileView: {
+      /** @description Hash of uploaded file */
+      hash?: string;
       /** @description The file's nature */
       nature?: string;
-    };
-    /**
-     * AddFileResultView
-     * @description The result of adding a file to a LOC
-     */
-    AddFileResultView: {
-      /** @description Hex-encoded SHA256 hash of added file */
-      hash?: string;
     };
     AddLinkView: {
       /** @description The link's target */
@@ -701,6 +695,9 @@ export interface components {
        * @example 0xecdc3920d5cb4d6721f65c6c36f35996faf34eccf8f7948d69004483fddf19e6
        */
       itemId?: string;
+    };
+    FileUploadData: {
+      hash?: string;
     };
   };
 }

--- a/src/logion/controllers/fileupload.ts
+++ b/src/logion/controllers/fileupload.ts
@@ -1,7 +1,8 @@
 import { UploadedFile, FileArray } from "express-fileupload";
 import { badRequest } from "@logion/rest-api-core";
+import { sha256File } from "../lib/crypto/hashing";
 
-export function getUploadedFile(request: Express.Request): UploadedFile {
+export async function getUploadedFile(request: Express.Request, receivedHash: string): Promise<UploadedFile> {
     const files: FileArray | undefined = request.files;
     if(files === undefined || files === null) {
         throw badRequest("No file detected");
@@ -15,6 +16,10 @@ export function getUploadedFile(request: Express.Request): UploadedFile {
     }
     if (file.truncated) {
         throw badRequest("File upload failed (truncated)")
+    }
+    const localHash = await sha256File(file.tempFilePath);
+    if(localHash !== receivedHash) {
+        throw badRequest(`Received hash ${receivedHash} does not match ${localHash}`)
     }
     return file;
 }

--- a/test/unit/app.spec.ts
+++ b/test/unit/app.spec.ts
@@ -1,18 +1,8 @@
-import expressOasGenerator, { SPEC_OUTPUT_FILE_BEHAVIOR } from "express-oas-generator";
-import { predefinedSpec, setupApp } from "../../src/logion/app.support";
-import express from "express";
+import { setupApp } from "../../src/logion/app.support";
 
 describe('app', () => {
 
     it("succeeds to do init sequence", () => {
-        const app = express()
-        expressOasGenerator.handleResponses(app, {
-            predefinedSpec,
-            specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE,
-            swaggerDocumentOptions: {},
-            alwaysServeDocs: true,
-        });
-        setupApp(app);
-        expressOasGenerator.handleRequests()
+        setupApp();
     })
 })

--- a/test/unit/controllers/collection.controller.spec.ts
+++ b/test/unit/controllers/collection.controller.spec.ts
@@ -112,11 +112,28 @@ describe("CollectionController", () => {
         const buffer = Buffer.from(SOME_DATA);
         await request(app)
             .post(`/api/collection/${ collectionLocId }/${ itemId }/files`)
+            .field({ hash: SOME_DATA_HASH })
             .attach('file', buffer, { filename: FILE_NAME })
-            .expect(200)
+            .expect(200);
+    })
+
+    it('fails to add file to collection item if wrong hash', async () => {
+        const app = setupApp(CollectionController, container => mockModel(container, {
+            collectionItemAlreadyInDB: true,
+            fileAlreadyInDB: true,
+            collectionItemPublished: true,
+            filePublished: true,
+            restrictedDelivery: false,
+        }));
+        const buffer = Buffer.from(SOME_DATA);
+        await request(app)
+            .post(`/api/collection/${ collectionLocId }/${ itemId }/files`)
+            .field({ hash: "wrong-hash" })
+            .attach('file', buffer, { filename: FILE_NAME })
+            .expect(400)
             .expect('Content-Type', /application\/json/)
             .then(response => {
-                expect(response.body.hash).toBe(SOME_DATA_HASH);
+                expect(response.body.errorMessage).toBe("Received hash wrong-hash does not match 0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee");
             });
     })
 
@@ -131,6 +148,7 @@ describe("CollectionController", () => {
         const buffer = Buffer.from(SOME_DATA);
         await request(app)
             .post(`/api/collection/${ collectionLocId }/${ itemId }/files`)
+            .field({ hash: SOME_DATA_HASH })
             .attach('file', buffer, { filename: FILE_NAME })
             .expect(400)
             .expect('Content-Type', /application\/json/)
@@ -150,6 +168,7 @@ describe("CollectionController", () => {
         const buffer = Buffer.from(SOME_DATA);
         await request(app)
             .post(`/api/collection/${ collectionLocId }/${ itemId }/files`)
+            .field({ hash: SOME_DATA_HASH })
             .attach('file', buffer, { filename: FILE_NAME })
             .expect(400)
             .expect('Content-Type', /application\/json/)
@@ -169,6 +188,7 @@ describe("CollectionController", () => {
         const buffer = Buffer.from(SOME_DATA);
         await request(app)
             .post(`/api/collection/${ collectionLocId }/${ itemId }/files`)
+            .field({ hash: SOME_DATA_HASH })
             .attach('file', buffer, { filename: FILE_NAME })
             .expect(400)
             .expect('Content-Type', /application\/json/)
@@ -188,6 +208,7 @@ describe("CollectionController", () => {
         const buffer = Buffer.from(SOME_DATA);
         await request(app)
             .post(`/api/collection/${ collectionLocId }/${ itemId }/files`)
+            .field({ hash: SOME_DATA_HASH })
             .attach('file', buffer, { filename: "WrongName.pdf" })
             .expect(400)
             .expect('Content-Type', /application\/json/)


### PR DESCRIPTION
* Backend now expects a client-side generated hash and compares it with its own
* File hash is not returned anymore by the backend (if the request passes, client has the guarantee that provided hash is shared with the server)

logion-network/logion-internal#665