### PR TITLE
chore: convert singular nft owner's addresses to Substrate (42).

### DIFF
--- a/src/logion/services/singular.service.ts
+++ b/src/logion/services/singular.service.ts
@@ -1,11 +1,17 @@
 import { injectable } from 'inversify';
+import { encodeAddress } from '@polkadot/util-crypto';
 import axios from "axios";
 
 @injectable()
 export class SingularService {
 
+    /**
+     * Retrieve owners of a nft on singular.
+     * @param nftId the id of the nft
+     * @return an array of addresses, converted to Substrate format (prefix 42)
+     */
     async getOwners(nftId: string): Promise<string[]> {
         const response = await axios.get(`https://singular.app/api/nft/${nftId}`);
-        return response.data.nfts.map((nft: any) => nft.owner);
+        return response.data.nfts.map((nft: any) => encodeAddress(nft.owner, 42));
     }
 }


### PR DESCRIPTION
Singular web service provides nft owner's addresses in Kusama format (prefix 2), while our frontend/backend only deal with Substrate format (42), so retrieved need to be converted.

logion-network/logion-internal#650