### PR TITLE
Add API for VTP flag

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -652,6 +652,10 @@
                     "company": {
                         "type": "string",
                         "description": "If the user requesting an Identity LOC is representing a company, its legal entity name"
+                    },
+                    "verifiedThirdParty": {
+                        "type": "boolean",
+                        "description": "Tells if the user behind this closed Identity LOC is a Verified Third Party"
                     }
                 },
                 "title": "LocRequestView",
@@ -1111,6 +1115,14 @@
                 "properties": {
                     "hash": {
                         "type": "string"
+                    }
+                }
+            },
+            "SetVerifiedThirdPartyRequest": {
+                "type": "object",
+                "properties": {
+                    "isVerifiedThirdParty": {
+                        "type": "boolean"
                     }
                 }
             }

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -415,6 +415,8 @@ export interface components {
       };
       /** @description If the user requesting an Identity LOC is representing a company, its legal entity name */
       company?: string;
+      /** @description Tells if the user behind this closed Identity LOC is a Verified Third Party */
+      verifiedThirdParty?: boolean;
     };
     /**
      * LocPublicView
@@ -698,6 +700,9 @@ export interface components {
     };
     FileUploadData: {
       hash?: string;
+    };
+    SetVerifiedThirdPartyRequest: {
+      isVerifiedThirdParty?: boolean;
     };
   };
 }

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -39,6 +39,7 @@ export interface LocRequestDescription {
     readonly locType: LocType;
     readonly seal?: PublicSeal;
     readonly company?: string;
+    readonly verifiedThirdParty: boolean;
 }
 
 export interface LocRequestDecision {
@@ -174,6 +175,7 @@ export class LocRequestAggregateRoot {
             locType: this.locType!,
             seal: toPublicSeal(this.seal),
             company: this.company!,
+            verifiedThirdParty: false,
         }
     }
 

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -222,6 +222,7 @@ describe("LocRequestFactory", () => {
             locType,
             seal,
             company: undefined,
+            verifiedThirdParty: false,
         };
     }
 });

--- a/test/unit/services/notification-test-data.ts
+++ b/test/unit/services/notification-test-data.ts
@@ -67,6 +67,7 @@ export function notifiedLOC(): LocRequestDescription & { decision: LocRequestDec
         },
         userIdentity: undefined,
         userPostalAddress: undefined,
+        verifiedThirdParty: false,
     }
 }
 


### PR DESCRIPTION
* A single resource was added enabling the setting of the flag
* `verifiedThirdParty` flag was added to the LOC request view

logion-network/logion-internal#678