### PR TITLE
Enable transactions for all updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "@logion/node-exiftool": "^2.3.1-2",
-        "@logion/rest-api-core": "^0.2.0-4",
+        "@logion/rest-api-core": "^0.2.0-5",
         "@polkadot/wasm-crypto": "^6.3.1",
         "alchemy-sdk": "^2.1.0",
         "ansi-regex": "^6.0.1",

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -45,6 +45,7 @@ import { LoFileService, TransactionalLoFileService } from "../services/lofile.se
 import { ProtectionRequestService, TransactionalProtectionRequestService } from "../services/protectionrequest.service";
 import { SettingService, TransactionalSettingService } from "../services/settings.service";
 import { SyncPointService, TransactionalSyncPointService } from "../services/syncpoint.service";
+import { TransactionalTransactionService, TransactionService } from "../services/transaction.service";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -105,6 +106,8 @@ container.bind(SettingService).toService(TransactionalSettingService);
 container.bind(TransactionalSettingService).toSelf();
 container.bind(SyncPointService).toService(TransactionalSyncPointService);
 container.bind(TransactionalSyncPointService).toSelf();
+container.bind(TransactionService).toService(TransactionalTransactionService);
+container.bind(TransactionalTransactionService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -41,6 +41,7 @@ import { VerifiedThirdPartySelectionFactory, VerifiedThirdPartySelectionReposito
 import { VerifiedThirdPartyAdapter } from "../controllers/adapters/verifiedthirdpartyadapter";
 import { LocRequestAdapter } from "../controllers/adapters/locrequestadapter";
 import { LocRequestService, TransactionalLocRequestService } from "../services/locrequest.service";
+import { LoFileService, TransactionalLoFileService } from "../services/lofile.service";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -93,6 +94,8 @@ container.bind(LocRequestService).toService(TransactionalLocRequestService);
 container.bind(TransactionalLocRequestService).toSelf();
 container.bind(CollectionService).toService(TransactionalCollectionService);
 container.bind(TransactionalCollectionService).toSelf();
+container.bind(LoFileService).toService(TransactionalLoFileService);
+container.bind(TransactionalLoFileService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -47,6 +47,7 @@ import { SettingService, TransactionalSettingService } from "../services/setting
 import { SyncPointService, TransactionalSyncPointService } from "../services/syncpoint.service";
 import { TransactionalTransactionService, TransactionService } from "../services/transaction.service";
 import { TransactionalVaultTransferRequestService, VaultTransferRequestService } from "../services/vaulttransferrequest.service";
+import { TransactionalVerifiedThirdPartySelectionService, VerifiedThirdPartySelectionService } from "../services/verifiedthirdpartyselection.service";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -111,6 +112,8 @@ container.bind(TransactionService).toService(TransactionalTransactionService);
 container.bind(TransactionalTransactionService).toSelf();
 container.bind(VaultTransferRequestService).toService(TransactionalVaultTransferRequestService);
 container.bind(TransactionalVaultTransferRequestService).toSelf();
+container.bind(VerifiedThirdPartySelectionService).toService(TransactionalVerifiedThirdPartySelectionService);
+container.bind(TransactionalVerifiedThirdPartySelectionService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -43,6 +43,7 @@ import { LocRequestAdapter } from "../controllers/adapters/locrequestadapter";
 import { LocRequestService, TransactionalLocRequestService } from "../services/locrequest.service";
 import { LoFileService, TransactionalLoFileService } from "../services/lofile.service";
 import { ProtectionRequestService, TransactionalProtectionRequestService } from "../services/protectionrequest.service";
+import { SettingService, TransactionalSettingService } from "../services/settings.service";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -99,6 +100,8 @@ container.bind(LoFileService).toService(TransactionalLoFileService);
 container.bind(TransactionalLoFileService).toSelf();
 container.bind(ProtectionRequestService).toService(TransactionalProtectionRequestService);
 container.bind(TransactionalProtectionRequestService).toSelf();
+container.bind(SettingService).toService(TransactionalSettingService);
+container.bind(TransactionalSettingService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -42,6 +42,7 @@ import { VerifiedThirdPartyAdapter } from "../controllers/adapters/verifiedthird
 import { LocRequestAdapter } from "../controllers/adapters/locrequestadapter";
 import { LocRequestService, TransactionalLocRequestService } from "../services/locrequest.service";
 import { LoFileService, TransactionalLoFileService } from "../services/lofile.service";
+import { ProtectionRequestService, TransactionalProtectionRequestService } from "../services/protectionrequest.service";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -96,6 +97,8 @@ container.bind(CollectionService).toService(TransactionalCollectionService);
 container.bind(TransactionalCollectionService).toSelf();
 container.bind(LoFileService).toService(TransactionalLoFileService);
 container.bind(TransactionalLoFileService).toSelf();
+container.bind(ProtectionRequestService).toService(TransactionalProtectionRequestService);
+container.bind(TransactionalProtectionRequestService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -44,6 +44,7 @@ import { LocRequestService, TransactionalLocRequestService } from "../services/l
 import { LoFileService, TransactionalLoFileService } from "../services/lofile.service";
 import { ProtectionRequestService, TransactionalProtectionRequestService } from "../services/protectionrequest.service";
 import { SettingService, TransactionalSettingService } from "../services/settings.service";
+import { SyncPointService, TransactionalSyncPointService } from "../services/syncpoint.service";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -102,6 +103,8 @@ container.bind(ProtectionRequestService).toService(TransactionalProtectionReques
 container.bind(TransactionalProtectionRequestService).toSelf();
 container.bind(SettingService).toService(TransactionalSettingService);
 container.bind(TransactionalSettingService).toSelf();
+container.bind(SyncPointService).toService(TransactionalSyncPointService);
+container.bind(TransactionalSyncPointService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -46,6 +46,7 @@ import { ProtectionRequestService, TransactionalProtectionRequestService } from 
 import { SettingService, TransactionalSettingService } from "../services/settings.service";
 import { SyncPointService, TransactionalSyncPointService } from "../services/syncpoint.service";
 import { TransactionalTransactionService, TransactionService } from "../services/transaction.service";
+import { TransactionalVaultTransferRequestService, VaultTransferRequestService } from "../services/vaulttransferrequest.service";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -108,6 +109,8 @@ container.bind(SyncPointService).toService(TransactionalSyncPointService);
 container.bind(TransactionalSyncPointService).toSelf();
 container.bind(TransactionService).toService(TransactionalTransactionService);
 container.bind(TransactionalTransactionService).toSelf();
+container.bind(VaultTransferRequestService).toService(TransactionalVaultTransferRequestService);
+container.bind(TransactionalVaultTransferRequestService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();

--- a/src/logion/controllers/setting.controller.ts
+++ b/src/logion/controllers/setting.controller.ts
@@ -1,7 +1,8 @@
 import { injectable } from 'inversify';
 import { ApiController, Controller, HttpPut, Async, HttpGet } from 'dinoloop';
-import { SettingFactory, SettingRepository } from '../model/setting.model';
+import { SettingRepository } from '../model/setting.model';
 import { AuthenticationService } from '@logion/rest-api-core';
+import { SettingService } from '../services/settings.service';
 
 @injectable()
 @Controller('/setting')
@@ -9,8 +10,8 @@ export class SettingController extends ApiController {
 
     constructor(
         private settingRepository: SettingRepository,
-        private settingFactory: SettingFactory,
         private authenticationService: AuthenticationService,
+        private settingService: SettingService,
     ) {
         super();
     }
@@ -34,13 +35,6 @@ export class SettingController extends ApiController {
         (await this.authenticationService.authenticatedUser(this.request))
             .require(user => user.isNodeOwner());
         const value = body.value;
-        const existingSetting = await this.settingRepository.findById(id);
-        if(existingSetting) {
-            existingSetting.value = value;
-            await this.settingRepository.save(existingSetting);
-        } else {
-            const newSetting = this.settingFactory.newSetting({id, value});
-            await this.settingRepository.save(newSetting);
-        }
+        await this.settingService.createOrUpdate(id, value);
     }
 }

--- a/src/logion/controllers/verifiedthirdparty.controller.ts
+++ b/src/logion/controllers/verifiedthirdparty.controller.ts
@@ -10,6 +10,7 @@ import { NotificationService } from "../services/notification.service";
 import { DirectoryService } from "../services/directory.service";
 import { LocRequestAdapter } from "./adapters/locrequestadapter";
 import { LocRequestService } from "../services/locrequest.service";
+import { VerifiedThirdPartySelectionService } from "../services/verifiedthirdpartyselection.service";
 
 const { logger } = Log;
 
@@ -45,6 +46,7 @@ export class VerifiedThirdPartyController extends ApiController {
         private authenticationService: AuthenticationService,
         private verifiedThirdPartySelectionFactory: VerifiedThirdPartySelectionFactory,
         private verifiedThirdPartySelectionRepository: VerifiedThirdPartySelectionRepository,
+        private verifiedThirdPartySelectionService: VerifiedThirdPartySelectionService,
         private verifiedThirdPartyAdapter: VerifiedThirdPartyAdapter,
         private notificationService: NotificationService,
         private directoryService: DirectoryService,
@@ -80,7 +82,7 @@ export class VerifiedThirdPartyController extends ApiController {
         });
 
         if(!nominated) {
-            await this.verifiedThirdPartySelectionRepository.deleteByVerifiedThirdPartyId(requestId);
+            await this.verifiedThirdPartySelectionService.deleteByVerifiedThirdPartyId(requestId);
         }
 
         this.notifyVtpNominatedDismissed({
@@ -141,7 +143,7 @@ export class VerifiedThirdPartyController extends ApiController {
                 verifiedThirdPartyLocRequest,
                 locRequest,
             });
-            await this.verifiedThirdPartySelectionRepository.save(nomination);
+            await this.verifiedThirdPartySelectionService.add(nomination);
         } catch(e) {
             throw badRequest((e as Error).message);
         }
@@ -205,7 +207,7 @@ export class VerifiedThirdPartyController extends ApiController {
             locRequestId: requestId,
             verifiedThirdPartyLocId: partyId,
         };
-        await this.verifiedThirdPartySelectionRepository.deleteById(nominationId);
+        await this.verifiedThirdPartySelectionService.deleteById(nominationId);
 
         const verifiedThirdPartyLocRequest = requireDefined(await this.locRequestRepository.findById(partyId));
         this.notifyVtpSelectedUnselected({

--- a/src/logion/model/syncpoint.model.ts
+++ b/src/logion/model/syncpoint.model.ts
@@ -42,10 +42,6 @@ export class SyncPointRepository {
     async findByName(name: string): Promise<SyncPointAggregateRoot | null> {
         return await this.repository.findOneBy({ name });
     }
-
-    async delete(syncPoint: SyncPointAggregateRoot): Promise<void> {
-        await this.repository.delete(syncPoint.name!);
-    }
 }
 
 @injectable()

--- a/src/logion/model/verifiedthirdpartyselection.model.ts
+++ b/src/logion/model/verifiedthirdpartyselection.model.ts
@@ -34,8 +34,8 @@ export class VerifiedThirdPartySelectionRepository {
 
     readonly repository: Repository<VerifiedThirdPartySelectionAggregateRoot>;
 
-    async save(syncPoint: VerifiedThirdPartySelectionAggregateRoot): Promise<void> {
-        await this.repository.save(syncPoint);
+    async save(selection: VerifiedThirdPartySelectionAggregateRoot): Promise<void> {
+        await this.repository.save(selection);
     }
 
     async findById(id: VerifiedThirdPartySelectionId): Promise<VerifiedThirdPartySelectionAggregateRoot | null> {

--- a/src/logion/services/blockconsumption.service.ts
+++ b/src/logion/services/blockconsumption.service.ts
@@ -13,6 +13,7 @@ import { ExtrinsicDataExtractor } from "./extrinsic.data.extractor";
 import { toStringWithoutError } from "./types/responses/Extrinsic";
 import { ProgressRateLogger } from "./progressratelogger";
 import { PrometheusService } from "./prometheus.service";
+import { SyncPointService } from "./syncpoint.service";
 
 const { logger } = Log;
 
@@ -25,6 +26,7 @@ export class BlockConsumer {
         private blockService: BlockExtrinsicsService,
         private syncPointRepository: SyncPointRepository,
         private syncPointFactory: SyncPointFactory,
+        private syncPointService: SyncPointService,
         private transactionSynchronizer: TransactionSynchronizer,
         private locSynchronizer: LocSynchronizer,
         private protectionSynchronizer: ProtectionSynchronizer,
@@ -111,13 +113,13 @@ export class BlockConsumer {
                 latestHeadBlockNumber: head,
                 createdOn: now
             });
+            await this.syncPointService.add(current);
         } else {
-            current.update({
+            await this.syncPointService.update(TRANSACTIONS_SYNC_POINT_NAME, {
                 blockNumber: head,
                 updatedOn: now
             });
         }
-        await this.syncPointRepository.save(current);
         return current;
     }
 

--- a/src/logion/services/lofile.service.ts
+++ b/src/logion/services/lofile.service.ts
@@ -1,0 +1,51 @@
+import { injectable } from "inversify";
+import { DefaultTransactional, requireDefined } from "@logion/rest-api-core";
+import { LoFileAggregateRoot, LoFileRepository } from "../model/lofile.model";
+
+export abstract class LoFileService {
+
+    constructor(
+        private loFileRepository: LoFileRepository,
+    ) {}
+
+    async addLoFile(file: LoFileAggregateRoot) {
+        this.loFileRepository.save(file);
+    }
+
+    async updateLoFile(id: string, mutator: (file: LoFileAggregateRoot) => Promise<void>) {
+        const file = requireDefined(await this.loFileRepository.findById(id));
+        await mutator(file);
+        await this.loFileRepository.save(file);
+        return file;
+    }
+}
+
+@injectable()
+export class NonTransactionalLoFileService extends LoFileService {
+
+    constructor(
+        loFileRepository: LoFileRepository,
+    ) {
+        super(loFileRepository);
+    }
+}
+
+@injectable()
+export class TransactionalLoFileService extends LoFileService {
+
+    constructor(
+        loFileRepository: LoFileRepository,
+    ) {
+        super(loFileRepository);
+    }
+
+    @DefaultTransactional()
+    override async addLoFile(file: LoFileAggregateRoot) {
+        super.addLoFile(file);
+    }
+
+    @DefaultTransactional()
+    async updateLoFile(id: string, mutator: (file: LoFileAggregateRoot) => Promise<void>) {
+        return super.updateLoFile(id, mutator);
+    }
+}

--- a/src/logion/services/protectionrequest.service.ts
+++ b/src/logion/services/protectionrequest.service.ts
@@ -1,0 +1,51 @@
+import { DefaultTransactional, requireDefined } from "@logion/rest-api-core";
+import { injectable } from "inversify";
+import { ProtectionRequestAggregateRoot, ProtectionRequestRepository } from "../model/protectionrequest.model";
+
+export abstract class ProtectionRequestService {
+
+    constructor(
+        private protectionRequestRepository: ProtectionRequestRepository,
+    ) {}
+
+    async add(request: ProtectionRequestAggregateRoot) {
+        this.protectionRequestRepository.save(request);
+    }
+
+    async update(id: string, mutator: (request: ProtectionRequestAggregateRoot) => Promise<void>) {
+        const request = requireDefined(await this.protectionRequestRepository.findById(id));
+        await mutator(request);
+        await this.protectionRequestRepository.save(request);
+        return request;
+    }
+}
+
+@injectable()
+export class NonTransactionalProtectionRequestService extends ProtectionRequestService {
+
+    constructor(
+        protectionRequestRepository: ProtectionRequestRepository,
+    ) {
+        super(protectionRequestRepository);
+    }
+}
+
+@injectable()
+export class TransactionalProtectionRequestService extends ProtectionRequestService {
+
+    constructor(
+        protectionRequestRepository: ProtectionRequestRepository,
+    ) {
+        super(protectionRequestRepository);
+    }
+
+    @DefaultTransactional()
+    override async add(request: ProtectionRequestAggregateRoot) {
+        return super.add(request);
+    }
+
+    @DefaultTransactional()
+    override async update(id: string, mutator: (request: ProtectionRequestAggregateRoot) => Promise<void>) {
+        return super.update(id, mutator);
+    }
+}

--- a/src/logion/services/protectionsynchronization.service.ts
+++ b/src/logion/services/protectionsynchronization.service.ts
@@ -4,6 +4,7 @@ import { Log } from "@logion/rest-api-core";
 import { ProtectionRequestRepository, FetchProtectionRequestsSpecification } from '../model/protectionrequest.model';
 import { asArray, asString, JsonArgs } from './call';
 import { JsonExtrinsic, toString } from "./types/responses/Extrinsic";
+import { ProtectionRequestService } from './protectionrequest.service';
 
 const { logger } = Log;
 
@@ -12,6 +13,7 @@ export class ProtectionSynchronizer {
 
     constructor(
         private protectionRequestRepository: ProtectionRequestRepository,
+        private protectionRequestService: ProtectionRequestService,
     ) {
         if (process.env.OWNER === undefined) {
             throw Error("No node owner set, please set var OWNER");
@@ -36,9 +38,10 @@ export class ProtectionSynchronizer {
                 }));
                 for (let j = 0; j < requests.length; ++j) {
                     const request = requests[j];
-                    logger.info("Setting protection %s activated", request.id)
-                    request.setActivated();
-                    await this.protectionRequestRepository.save(request);
+                    logger.info("Setting protection %s activated", request.id);
+                    await this.protectionRequestService.update(request.id!, async request => {
+                        request.setActivated();
+                    });
                 }
             }
         }

--- a/src/logion/services/settings.service.ts
+++ b/src/logion/services/settings.service.ts
@@ -23,6 +23,13 @@ export abstract class SettingService {
 @injectable()
 export class TransactionalSettingService extends SettingService {
 
+    constructor(
+        settingRepository: SettingRepository,
+        settingFactory: SettingFactory,
+    ) {
+        super(settingRepository, settingFactory);
+    }
+
     @DefaultTransactional()
     override async createOrUpdate(id: string, value: string) {
         return super.createOrUpdate(id, value);
@@ -32,4 +39,10 @@ export class TransactionalSettingService extends SettingService {
 @injectable()
 export class NonTransactionalSettingService extends SettingService {
 
+    constructor(
+        settingRepository: SettingRepository,
+        settingFactory: SettingFactory,
+    ) {
+        super(settingRepository, settingFactory);
+    }
 }

--- a/src/logion/services/settings.service.ts
+++ b/src/logion/services/settings.service.ts
@@ -1,0 +1,35 @@
+import { DefaultTransactional } from "@logion/rest-api-core";
+import { injectable } from "inversify";
+import { SettingFactory, SettingRepository } from "../model/setting.model";
+
+export abstract class SettingService {
+
+    constructor(
+        private settingRepository: SettingRepository,
+        private settingFactory: SettingFactory,
+    ) {}
+
+    async createOrUpdate(id: string, value: string) {
+        let setting = await this.settingRepository.findById(id);
+        if(setting) {
+            setting.update(value);
+        } else {
+            setting = this.settingFactory.newSetting({id, value});
+        }
+        await this.settingRepository.save(setting);
+    }
+}
+
+@injectable()
+export class TransactionalSettingService extends SettingService {
+
+    @DefaultTransactional()
+    override async createOrUpdate(id: string, value: string) {
+        return super.createOrUpdate(id, value);
+    }
+}
+
+@injectable()
+export class NonTransactionalSettingService extends SettingService {
+
+}

--- a/src/logion/services/syncpoint.service.ts
+++ b/src/logion/services/syncpoint.service.ts
@@ -1,0 +1,46 @@
+import { DefaultTransactional, requireDefined } from "@logion/rest-api-core";
+import { injectable } from "inversify";
+import { Moment } from "moment";
+import { SyncPointAggregateRoot, SyncPointRepository } from "../model/syncpoint.model";
+
+export abstract class SyncPointService {
+
+    constructor(
+        private syncPointRepository: SyncPointRepository,
+    ) {}
+
+    async add(syncPoint: SyncPointAggregateRoot) {
+        await this.syncPointRepository.save(syncPoint);
+    }
+
+    async update(name: string, values: {
+        blockNumber: bigint,
+        updatedOn: Moment,
+    }) {
+        const syncPoint = requireDefined(await this.syncPointRepository.findByName(name));
+        syncPoint.update(values);
+        await this.syncPointRepository.save(syncPoint);
+    }
+}
+
+@injectable()
+export class NonTransactionnalSyncPointService extends SyncPointService {
+
+}
+
+@injectable()
+export class TransactionalSyncPointService extends SyncPointService {
+
+    @DefaultTransactional()
+    override async add(syncPoint: SyncPointAggregateRoot) {
+        return super.add(syncPoint);
+    }
+
+    @DefaultTransactional()
+    override async update(name: string, values: {
+        blockNumber: bigint,
+        updatedOn: Moment,
+    }) {
+        return super.update(name, values);
+    }
+}

--- a/src/logion/services/syncpoint.service.ts
+++ b/src/logion/services/syncpoint.service.ts
@@ -26,10 +26,21 @@ export abstract class SyncPointService {
 @injectable()
 export class NonTransactionnalSyncPointService extends SyncPointService {
 
+    constructor(
+        syncPointRepository: SyncPointRepository,
+    ) {
+        super(syncPointRepository);
+    }
 }
 
 @injectable()
 export class TransactionalSyncPointService extends SyncPointService {
+
+    constructor(
+        syncPointRepository: SyncPointRepository,
+    ) {
+        super(syncPointRepository);
+    }
 
     @DefaultTransactional()
     override async add(syncPoint: SyncPointAggregateRoot) {

--- a/src/logion/services/transaction.service.ts
+++ b/src/logion/services/transaction.service.ts
@@ -16,10 +16,21 @@ export abstract class TransactionService {
 @injectable()
 export class NonTransactionalTransactionService extends TransactionService {
 
+    constructor(
+        transactionRepository: TransactionRepository
+    ) {
+        super(transactionRepository);
+    }
 }
 
 @injectable()
 export class TransactionalTransactionService extends TransactionService {
+
+    constructor(
+        transactionRepository: TransactionRepository
+    ) {
+        super(transactionRepository);
+    }
 
     @DefaultTransactional()
     override async add(transaction: TransactionAggregateRoot) {

--- a/src/logion/services/transaction.service.ts
+++ b/src/logion/services/transaction.service.ts
@@ -1,0 +1,28 @@
+import { DefaultTransactional } from "@logion/rest-api-core";
+import { injectable } from "inversify";
+import { TransactionAggregateRoot, TransactionRepository } from "../model/transaction.model";
+
+export abstract class TransactionService {
+
+    constructor(
+        private transactionRepository: TransactionRepository
+    ) {}
+
+    async add(transaction: TransactionAggregateRoot) {
+        await this.transactionRepository.save(transaction);
+    }
+}
+
+@injectable()
+export class NonTransactionalTransactionService extends TransactionService {
+
+}
+
+@injectable()
+export class TransactionalTransactionService extends TransactionService {
+
+    @DefaultTransactional()
+    override async add(transaction: TransactionAggregateRoot) {
+        await super.add(transaction);
+    }
+}

--- a/src/logion/services/transactionsync.service.ts
+++ b/src/logion/services/transactionsync.service.ts
@@ -1,7 +1,8 @@
 import { injectable } from "inversify";
 import { v4 as uuid } from 'uuid';
-import { TransactionAggregateRoot, TransactionRepository, TransactionFactory, TransactionDescription } from "../model/transaction.model";
+import { TransactionAggregateRoot, TransactionFactory, TransactionDescription } from "../model/transaction.model";
 import { TransactionExtractor } from "./transaction.extractor";
+import { TransactionService } from "./transaction.service";
 import { BlockWithTransactions, Transaction } from './transaction.vo';
 import { BlockExtrinsics } from "./types/responses/Block";
 
@@ -9,9 +10,9 @@ import { BlockExtrinsics } from "./types/responses/Block";
 export class TransactionSynchronizer {
 
     constructor(
-        private transactionRepository: TransactionRepository,
         private transactionFactory: TransactionFactory,
         private transactionExtractor: TransactionExtractor,
+        private transactionService: TransactionService,
     ) {}
 
     async addTransactions(block: BlockExtrinsics): Promise<void> {
@@ -22,7 +23,7 @@ export class TransactionSynchronizer {
         for(let i = 0; i < blockWithTransactions.transactions.length; ++i) {
             const transaction = blockWithTransactions.transactions[i];
             const aggregate = this.toEntity(blockWithTransactions, transaction);
-            await this.transactionRepository.save(aggregate);
+            await this.transactionService.add(aggregate);
         }
     }
 
@@ -35,9 +36,5 @@ export class TransactionSynchronizer {
             createdOn,
         };
         return this.transactionFactory.newTransaction(description);
-    }
-
-    async reset() {
-        await this.transactionRepository.deleteAll();
     }
 }

--- a/src/logion/services/vaulttransferrequest.service.ts
+++ b/src/logion/services/vaulttransferrequest.service.ts
@@ -23,10 +23,21 @@ export abstract class VaultTransferRequestService {
 @injectable()
 export class NonTransactionalVaultTransferRequestService extends VaultTransferRequestService {
 
+    constructor(
+        vaultTransferRequestRepository: VaultTransferRequestRepository,
+    ) {
+        super(vaultTransferRequestRepository);
+    }
 }
 
 @injectable()
 export class TransactionalVaultTransferRequestService extends VaultTransferRequestService {
+
+    constructor(
+        vaultTransferRequestRepository: VaultTransferRequestRepository,
+    ) {
+        super(vaultTransferRequestRepository);
+    }
 
     @DefaultTransactional()
     override async add(vaultTransferRequest: VaultTransferRequestAggregateRoot) {

--- a/src/logion/services/vaulttransferrequest.service.ts
+++ b/src/logion/services/vaulttransferrequest.service.ts
@@ -1,0 +1,40 @@
+import { DefaultTransactional, requireDefined } from "@logion/rest-api-core";
+import { injectable } from "inversify";
+import { VaultTransferRequestAggregateRoot, VaultTransferRequestRepository } from "../model/vaulttransferrequest.model";
+
+export abstract class VaultTransferRequestService {
+
+    constructor(
+        private vaultTransferRequestRepository: VaultTransferRequestRepository,
+    ) {}
+
+    async add(vaultTransferRequest: VaultTransferRequestAggregateRoot) {
+        await this.vaultTransferRequestRepository.save(vaultTransferRequest);
+    }
+
+    async update(id: string, mutator: (vaultTransferRequest: VaultTransferRequestAggregateRoot) => Promise<void>) {
+        const vaultTransferRequest = requireDefined(await this.vaultTransferRequestRepository.findById(id));
+        await mutator(vaultTransferRequest);
+        await this.vaultTransferRequestRepository.save(vaultTransferRequest);
+        return vaultTransferRequest;
+    }
+}
+
+@injectable()
+export class NonTransactionalVaultTransferRequestService extends VaultTransferRequestService {
+
+}
+
+@injectable()
+export class TransactionalVaultTransferRequestService extends VaultTransferRequestService {
+
+    @DefaultTransactional()
+    override async add(vaultTransferRequest: VaultTransferRequestAggregateRoot) {
+        return super.add(vaultTransferRequest);
+    }
+
+    @DefaultTransactional()
+    override async update(id: string, mutator: (vaultTransferRequest: VaultTransferRequestAggregateRoot) => Promise<void>) {
+        return super.update(id, mutator);
+    }
+}

--- a/src/logion/services/verifiedthirdpartyselection.service.ts
+++ b/src/logion/services/verifiedthirdpartyselection.service.ts
@@ -1,0 +1,46 @@
+import { DefaultTransactional } from "@logion/rest-api-core";
+import { injectable } from "inversify";
+import { VerifiedThirdPartySelectionAggregateRoot, VerifiedThirdPartySelectionId, VerifiedThirdPartySelectionRepository } from "../model/verifiedthirdpartyselection.model";
+
+export abstract class VerifiedThirdPartySelectionService {
+
+    constructor(
+        private verifiedThirdPartySelectionRepository: VerifiedThirdPartySelectionRepository,
+    ) {}
+
+    async add(selection: VerifiedThirdPartySelectionAggregateRoot) {
+        await this.verifiedThirdPartySelectionRepository.save(selection);
+    }
+
+    async deleteById(id: VerifiedThirdPartySelectionId) {
+        await this.verifiedThirdPartySelectionRepository.deleteById(id);
+    }
+
+    async deleteByVerifiedThirdPartyId(verifiedThirdPartyLocId: string) {
+        await this.verifiedThirdPartySelectionRepository.deleteByVerifiedThirdPartyId(verifiedThirdPartyLocId);
+    }
+}
+
+@injectable()
+export class TransactionalVerifiedThirdPartySelectionService extends VerifiedThirdPartySelectionService {
+
+    @DefaultTransactional()
+    async add(selection: VerifiedThirdPartySelectionAggregateRoot) {
+        return super.add(selection);
+    }
+
+    @DefaultTransactional()
+    async deleteById(id: VerifiedThirdPartySelectionId) {
+        return super.deleteById(id);
+    }
+
+    @DefaultTransactional()
+    async deleteByVerifiedThirdPartyId(verifiedThirdPartyLocId: string) {
+        return super.deleteByVerifiedThirdPartyId(verifiedThirdPartyLocId);
+    }
+}
+
+@injectable()
+export class NonTransactionalVerifiedThirdPartySelectionService extends VerifiedThirdPartySelectionService {
+
+}

--- a/src/logion/services/verifiedthirdpartyselection.service.ts
+++ b/src/logion/services/verifiedthirdpartyselection.service.ts
@@ -24,6 +24,12 @@ export abstract class VerifiedThirdPartySelectionService {
 @injectable()
 export class TransactionalVerifiedThirdPartySelectionService extends VerifiedThirdPartySelectionService {
 
+    constructor(
+        verifiedThirdPartySelectionRepository: VerifiedThirdPartySelectionRepository,
+    ) {
+        super(verifiedThirdPartySelectionRepository);
+    }
+
     @DefaultTransactional()
     async add(selection: VerifiedThirdPartySelectionAggregateRoot) {
         return super.add(selection);
@@ -43,4 +49,9 @@ export class TransactionalVerifiedThirdPartySelectionService extends VerifiedThi
 @injectable()
 export class NonTransactionalVerifiedThirdPartySelectionService extends VerifiedThirdPartySelectionService {
 
+    constructor(
+        verifiedThirdPartySelectionRepository: VerifiedThirdPartySelectionRepository,
+    ) {
+        super(verifiedThirdPartySelectionRepository);
+    }
 }

--- a/test/unit/controllers/locrequest.controller.shared.ts
+++ b/test/unit/controllers/locrequest.controller.shared.ts
@@ -26,6 +26,7 @@ import { PersonalInfo } from "../../../src/logion/model/personalinfo.model";
 import { VerifiedThirdPartyAdapter } from "../../../src/logion/controllers/adapters/verifiedthirdpartyadapter";
 import { VerifiedThirdPartySelectionAggregateRoot, VerifiedThirdPartySelectionFactory, VerifiedThirdPartySelectionId, VerifiedThirdPartySelectionRepository } from "../../../src/logion/model/verifiedthirdpartyselection.model";
 import { LocRequestService, NonTransactionalLocRequestService } from "../../../src/logion/services/locrequest.service";
+import { NonTransactionalVerifiedThirdPartySelectionService, VerifiedThirdPartySelectionService } from "../../../src/logion/services/verifiedthirdpartyselection.service";
 
 export type IdentityLocation = IdentityLocType | 'EmbeddedInLoc';
 
@@ -151,6 +152,8 @@ export function buildMocks(container: Container, existingMocks?: Partial<Mocks>)
     container.bind(VerifiedThirdPartySelectionRepository).toConstantValue(verifiedThirdPartyNominationRepository.object());
 
     verifiedThirdPartyNominationRepository.setup(instance => instance.findBy(It.IsAny())).returnsAsync([]);
+
+    container.bind(VerifiedThirdPartySelectionService).toConstantValue(new NonTransactionalVerifiedThirdPartySelectionService(verifiedThirdPartyNominationRepository.object()));
 
     container.bind(LocRequestService).toConstantValue(new NonTransactionalLocRequestService(repository.object()));
 

--- a/test/unit/controllers/lofile.controller.spec.ts
+++ b/test/unit/controllers/lofile.controller.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../src/logion/model/lofile.model";
 import request from "supertest";
 import { writeFile } from "fs/promises";
+import { LoFileService, NonTransactionalLoFileService } from "../../../src/logion/services/lofile.service";
 
 const existingFile: LoFileDescription = {
     id: 'file1',
@@ -170,5 +171,7 @@ function mockModel(container: Container): void {
 
     const newEntity = new Mock<LoFileAggregateRoot>()
     factory.setup(instance => instance.newLoFile(newFile))
-        .returns(newEntity.object())
+        .returns(newEntity.object());
+
+    container.bind(LoFileService).toConstantValue(new NonTransactionalLoFileService(repository.object()));
 }

--- a/test/unit/controllers/protectionrequest.controller.spec.ts
+++ b/test/unit/controllers/protectionrequest.controller.spec.ts
@@ -21,6 +21,7 @@ import { DirectoryService } from "../../../src/logion/services/directory.service
 import { notifiedLegalOfficer } from "../services/notification-test-data";
 import { EmbeddableUserIdentity, UserIdentity } from '../../../src/logion/model/useridentity';
 import { EmbeddablePostalAddress, PostalAddress } from '../../../src/logion/model/postaladdress';
+import { NonTransactionalProtectionRequestService, ProtectionRequestService } from '../../../src/logion/services/protectionrequest.service';
 
 const DECISION_TIMESTAMP = "2021-06-10T16:25:23.668294";
 const { mockAuthenticationWithCondition, setupApp } = TestApp;
@@ -113,7 +114,9 @@ function mockProtectionRequestModel(container: Container, isRecovery: boolean, a
                 && params.description.requesterAddress === REQUESTER_ADDRESS)))
         .returns(root.object());
     container.bind(ProtectionRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container)
+    mockNotificationAndDirectoryService(container);
+
+    container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
 }
 
 function mockModelForRecovery(container: Container, addressToRecover: string): void {
@@ -199,6 +202,8 @@ function mockModelForFetch(container: Container): void {
     const factory = new Mock<ProtectionRequestFactory>();
     container.bind(ProtectionRequestFactory).toConstantValue(factory.object());
     mockNotificationAndDirectoryService(container)
+
+    container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
 }
 
 describe('acceptProtectionRequest', () => {
@@ -240,7 +245,9 @@ function mockModelForAccept(container: Container, verifies: boolean): void {
 
     const factory = new Mock<ProtectionRequestFactory>();
     container.bind(ProtectionRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container)
+    mockNotificationAndDirectoryService(container);
+
+    container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
 }
 
 const REQUEST_ID = "requestId";
@@ -391,7 +398,9 @@ function mockModelForReject(container: Container, verifies: boolean): void {
 
     const factory = new Mock<ProtectionRequestFactory>();
     container.bind(ProtectionRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container)
+    mockNotificationAndDirectoryService(container);
+
+    container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
 }
 
 function mockNotificationAndDirectoryService(container: Container) {
@@ -458,5 +467,7 @@ function mockModelForUser(container: Container, protectionRequest: Mock<Protecti
 
     const factory = new Mock<ProtectionRequestFactory>();
     container.bind(ProtectionRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container)
+    mockNotificationAndDirectoryService(container);
+
+    container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
 }

--- a/test/unit/controllers/setting.controller.spec.ts
+++ b/test/unit/controllers/setting.controller.spec.ts
@@ -1,0 +1,89 @@
+import { Container } from 'inversify';
+import { It, Mock } from 'moq.ts';
+import request from 'supertest';
+import { TestApp } from '@logion/rest-api-core';
+import { SettingController } from '../../../src/logion/controllers/setting.controller';
+import { SettingAggregateRoot, SettingFactory, SettingRepository } from '../../../src/logion/model/setting.model';
+import { NonTransactionalSettingService, SettingService } from '../../../src/logion/services/settings.service';
+
+const { setupApp } = TestApp;
+
+describe("SettingController", () => {
+
+    it("lists settings", async () => {
+        const app = setupApp(SettingController, container => mockForList(container));
+        await request(app)
+            .get(`/api/setting`)
+            .expect(200)
+            .expect('Content-Type', /application\/json/)
+            .expect(response => {
+                expect(response.body.settings).toBeDefined();
+                expect(response.body.settings[settingId]).toBe(settingValue);
+            });
+    });
+
+    it("creates setting", async () => {
+        const app = setupApp(SettingController, container => mockForCreate(container));
+        await request(app)
+            .put(`/api/setting/${ settingId }`)
+            .send({ value: settingValue })
+            .expect(200);
+        settingRepository.verify(instance => instance.save(setting.object()));
+    });
+
+    it("updates setting", async () => {
+        const app = setupApp(SettingController, container => mockForUpdate(container));
+        await request(app)
+            .put(`/api/setting/${ settingId }`)
+            .send({ value: settingValue })
+            .expect(200);
+        setting.verify(instance => instance.update(settingValue));
+        settingRepository.verify(instance => instance.save(setting.object()));
+    });
+});
+
+let settingRepository: Mock<SettingRepository>;
+let settingFactory: Mock<SettingFactory>;
+let setting: Mock<SettingAggregateRoot>;
+
+function mockForList(container: Container) {
+    createAndBindMocks(container);
+
+    setting.setup(instance => instance.id).returns(settingId);
+    setting.setup(instance => instance.value).returns(settingValue);
+
+    settingRepository.setup(instance => instance.findAll()).returnsAsync([ setting.object() ]);
+}
+
+function createAndBindMocks(container: Container) {
+    setting = new Mock<SettingAggregateRoot>();
+
+    settingFactory = new Mock<SettingFactory>();
+    container.bind(SettingFactory).toConstantValue(settingFactory.object());
+
+    settingRepository = new Mock<SettingRepository>();
+    container.bind(SettingRepository).toConstantValue(settingRepository.object());
+
+    container.bind(SettingService).toConstantValue(new NonTransactionalSettingService(settingRepository.object(), settingFactory.object()));
+}
+
+function mockForCreate(container: Container) {
+    createAndBindMocks(container);
+
+    settingFactory.setup(instance => instance.newSetting(It.Is<{id: string, value: string}>(args => args.id === settingId && args.value === settingValue))).returns(setting.object());
+    
+    settingRepository.setup(instance => instance.findById(settingId)).returnsAsync(null);
+    settingRepository.setup(instance => instance.save(setting.object())).returnsAsync();    
+}
+
+const settingId = "some-id";
+const settingValue = "value";
+
+function mockForUpdate(container: Container) {
+    createAndBindMocks(container);
+
+    setting.setup(instance => instance.update(settingValue)).returns();
+
+    settingRepository.setup(instance => instance.findById(settingId)).returnsAsync(setting.object());
+    settingRepository.setup(instance => instance.save(setting.object())).returnsAsync();
+}

--- a/test/unit/controllers/vaulttransferrequest.controller.spec.ts
+++ b/test/unit/controllers/vaulttransferrequest.controller.spec.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../src/logion/model/protectionrequest.model';
 import { UserIdentity } from '../../../src/logion/model/useridentity';
 import { PostalAddress } from '../../../src/logion/model/postaladdress';
+import { NonTransactionalVaultTransferRequestService, VaultTransferRequestService } from '../../../src/logion/services/vaulttransferrequest.service';
 
 const { mockAuthenticatedUser, mockAuthenticationWithAuthenticatedUser, mockAuthenticationWithCondition, setupApp } = TestApp;
 
@@ -201,12 +202,12 @@ function mockModelForReject(container: Container, verifies: boolean): void {
 
     const factory = new Mock<VaultTransferRequestFactory>();
     container.bind(VaultTransferRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container)
+    mockNotificationAndDirectoryService(container, repository);
 }
 
 const ALICE_LEGAL_OFFICER = notifiedLegalOfficer(ALICE);
 
-function mockNotificationAndDirectoryService(container: Container) {
+function mockNotificationAndDirectoryService(container: Container, repository: Mock<VaultTransferRequestRepository>) {
     notificationService = new Mock<NotificationService>();
     notificationService
         .setup(instance => instance.notify(It.IsAny<string>(), It.IsAny<Template>(), It.IsAny<any>()))
@@ -227,6 +228,8 @@ function mockNotificationAndDirectoryService(container: Container) {
         .setup(instance => instance.findBy(It.IsAny<FetchProtectionRequestsSpecification>()))
         .returns(Promise.resolve([ protectionRequest.object() ]));
     container.bind(ProtectionRequestRepository).toConstantValue(protectionRequestRepository.object());
+
+    container.bind(VaultTransferRequestService).toConstantValue(new NonTransactionalVaultTransferRequestService(repository.object()));
 }
 
 function mockVaultTransferRequest(): Mock<VaultTransferRequestAggregateRoot> {
@@ -297,7 +300,7 @@ function mockModelForFetch(container: Container): void {
 
     const factory = new Mock<VaultTransferRequestFactory>();
     container.bind(VaultTransferRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container);
+    mockNotificationAndDirectoryService(container, repository);
 }
 
 function mockModelForRequest(container: Container): void {
@@ -319,7 +322,7 @@ function mockVaultTransferRequestModel(container: Container): void {
                 description.requesterAddress === REQUESTER_ADDRESS)))
         .returns(root.object());
     container.bind(VaultTransferRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container);
+    mockNotificationAndDirectoryService(container, repository);
 }
 
 let notificationService: Mock<NotificationService>;
@@ -345,5 +348,5 @@ function mockModelForAcceptOrCancel(container: Container, verifies: boolean): vo
 
     const factory = new Mock<VaultTransferRequestFactory>();
     container.bind(VaultTransferRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container);
+    mockNotificationAndDirectoryService(container, repository);
 }

--- a/test/unit/services/blockconsumption.service.spec.ts
+++ b/test/unit/services/blockconsumption.service.spec.ts
@@ -57,7 +57,6 @@ describe("BlockConsumer", () => {
         blockService.verify(instance => instance.getHeadBlockHash());
         transactionSynchronizer.verify(instance => instance.addTransactions, Times.Never());
         locSynchronizer.verify(instance => instance.updateLocRequests, Times.Never());
-        transactionSynchronizer.verify(instance => instance.reset, Times.Never());
         syncPointRepository.verify(instance => instance.findByName(TRANSACTIONS_SYNC_POINT_NAME));
         prometheusService.verify(instance => instance.setLastSynchronizedBlock, Times.Never());
     });

--- a/test/unit/services/blockconsumption.service.spec.ts
+++ b/test/unit/services/blockconsumption.service.spec.ts
@@ -15,7 +15,8 @@ import { TransactionSynchronizer } from "../../../src/logion/services/transactio
 import { ProtectionSynchronizer } from "../../../src/logion/services/protectionsynchronization.service";
 import { ExtrinsicDataExtractor } from "../../../src/logion/services/extrinsic.data.extractor";
 import { JsonExtrinsic } from "../../../src/logion/services/types/responses/Extrinsic";
-import { PrometheusService } from 'src/logion/services/prometheus.service';
+import { PrometheusService } from '../../../src/logion/services/prometheus.service';
+import { NonTransactionnalSyncPointService } from '../../../src/logion/services/syncpoint.service';
 
 describe("BlockConsumer", () => {
 
@@ -85,6 +86,7 @@ describe("BlockConsumer", () => {
             blockService.object(),
             syncPointRepository.object(),
             syncPointFactory.object(),
+            new NonTransactionnalSyncPointService(syncPointRepository.object()),
             transactionSynchronizer.object(),
             locSynchronizer.object(),
             protectionSynchronizer.object(),
@@ -127,7 +129,7 @@ describe("BlockConsumer", () => {
         await consumeNewBlocks();
 
         // Then
-        syncPointRepository.verify(instance => instance.findByName(TRANSACTIONS_SYNC_POINT_NAME));
+        syncPointRepository.verify(instance => instance.findByName(TRANSACTIONS_SYNC_POINT_NAME), Times.Exactly(2));
         blockService.verify(instance => instance.getBlockExtrinsics(It.Is(_ => true)), Times.Exactly(5));
         syncPoint.verify(instance => instance.update(
             It.Is<{blockNumber: bigint}>(value => value.blockNumber === head)));
@@ -180,7 +182,7 @@ describe("BlockConsumer", () => {
         await consumeNewBlocks();
 
         // Then
-        syncPointRepository.verify(instance => instance.findByName(TRANSACTIONS_SYNC_POINT_NAME));
+        syncPointRepository.verify(instance => instance.findByName(TRANSACTIONS_SYNC_POINT_NAME), Times.Exactly(2));
         blockService.verify(instance => instance.getBlockExtrinsics(It.Is(_ => true)), Times.Exactly(1));
         syncPoint.verify(instance => instance.update(
             It.Is<{blockNumber: bigint}>(value => value.blockNumber === head)));

--- a/test/unit/services/transactionsync.service.spec.ts
+++ b/test/unit/services/transactionsync.service.spec.ts
@@ -6,6 +6,7 @@ import { BlockExtrinsics } from '../../../src/logion/services/types/responses/Bl
 import { TransactionExtractor } from '../../../src/logion/services/transaction.extractor';
 import { TransactionSynchronizer } from "../../../src/logion/services/transactionsync.service";
 import { Transaction, BlockWithTransactionsBuilder } from "../../../src/logion/services/transaction.vo";
+import { NonTransactionalTransactionService } from '../../../src/logion/services/transaction.service';
 
 describe("TransactionSync", () => {
 
@@ -21,9 +22,9 @@ describe("TransactionSync", () => {
 
     function transactionSync(): TransactionSynchronizer {
         return new TransactionSynchronizer(
-            transactionRepository.object(),
             transactionFactory.object(),
             transactionExtractor.object(),
+            new NonTransactionalTransactionService(transactionRepository.object()),
         );
     }
 
@@ -53,13 +54,5 @@ describe("TransactionSync", () => {
         transactionExtractor.verify(instance => instance.extractBlockWithTransactions(block.object()));
         transactionFactory.verify(instance => instance.newTransaction(It.IsAny()));
         transactionRepository.verify(instance => instance.save(transactionAggregate.object()));
-    });
-
-    it("deletes all transactions on reset", async () => {
-        transactionRepository.setup(instance => instance.deleteAll()).returns(Promise.resolve());
-
-        await transactionSync().reset();
-
-        transactionRepository.verify(instance => instance.deleteAll());
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,9 +1004,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/rest-api-core@npm:^0.2.0-4":
-  version: 0.2.0-4
-  resolution: "@logion/rest-api-core@npm:0.2.0-4"
+"@logion/rest-api-core@npm:^0.2.0-5":
+  version: 0.2.0-5
+  resolution: "@logion/rest-api-core@npm:0.2.0-5"
   dependencies:
     "@logion/authenticator": ^0.3.2-1
     dinoloop: ^2.4.0
@@ -1020,7 +1020,7 @@ __metadata:
     swagger-ui-express: ^4.5.0
     typeorm: ^0.3.9
     typeorm-transactional: ^0.4.0
-  checksum: 41cf923ed501ed9d7bce613aa1ec26c76d86e8415a8c5e863d816a8e6f310afa0618272f717a922ca0b170ea27d07c3afa413d30c783488e6338d202852b1c55
+  checksum: 4ab7b27511f5679dd1bb4318b80637d7ed971faa18cb42d633d2412c4b3db9aa035229a0375fc34e8095359902c1a224f6e6f50740223184cc36b44a49299e3f
   languageName: node
   linkType: hard
 
@@ -4732,7 +4732,7 @@ __metadata:
   dependencies:
     "@istanbuljs/nyc-config-typescript": ^1.0.2
     "@logion/node-exiftool": ^2.3.1-2
-    "@logion/rest-api-core": ^0.2.0-4
+    "@logion/rest-api-core": ^0.2.0-5
     "@polkadot/wasm-crypto": ^6.3.1
     "@tsconfig/node16": ^1.0.3
     "@types/cors": ^2.8.12


### PR DESCRIPTION
* Adds missing services and use them in controllers and/or sync services
* Logged queries (not enabled by default, set `TYPEORM_LOGGING` to true in `Dockerfile` to test) show that transactions are indeed started and committed for all updates

logion-network/logion-internal#644