### PR TITLE
Keep unselected parties in LOC

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -1159,6 +1159,10 @@
                     "address": {
                         "type": "string",
                         "description": "The SS58 address of the Verified Third Party"
+                    },
+                    "selected": {
+                        "type": "boolean",
+                        "description": "Tells if the VTP was selected in the scope of current LOC"
                     }
                 }
             },

--- a/src/logion/controllers/adapters/verifiedthirdpartyadapter.ts
+++ b/src/logion/controllers/adapters/verifiedthirdpartyadapter.ts
@@ -35,22 +35,23 @@ export class VerifiedThirdPartyAdapter {
     private async toVerifiedThirdPartyView(verifiedThirdPartySelection: VerifiedThirdPartySelectionAggregateRoot): Promise<VerifiedThirdPartyView> {
         const identityLocId = requireDefined(verifiedThirdPartySelection.id.verifiedThirdPartyLocId);
         const identityLocRequest = requireDefined(await this.locRequestRepository.findById(identityLocId));
-        return this.toView(identityLocRequest);
+        return this.toView(identityLocRequest, verifiedThirdPartySelection.selected);
     }
 
-    toView(identityLocRequest: LocRequestAggregateRoot): VerifiedThirdPartyView {
+    toView(identityLocRequest: LocRequestAggregateRoot, selected?: boolean): VerifiedThirdPartyView {
         const description = identityLocRequest.getDescription();
         return {
             identityLocId: identityLocRequest.id,
             address: identityLocRequest.requesterAddress,
             firstName: description.userIdentity?.firstName,
             lastName: description.userIdentity?.lastName,
+            selected,
         };
     }
 
     toViews(identityLocRequests: LocRequestAggregateRoot[]): VerifiedThirdPartiesView {
         return {
-            verifiedThirdParties: identityLocRequests.map(this.toView).sort(this.compareParties)
+            verifiedThirdParties: identityLocRequests.map(request => this.toView(request)).sort(this.compareParties)
         };
     }
 

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -718,6 +718,8 @@ export interface components {
       identityLocId?: string;
       /** @description The SS58 address of the Verified Third Party */
       address?: string;
+      /** @description Tells if the VTP was selected in the scope of current LOC */
+      selected?: boolean;
     };
     VerifiedThirdPartiesView: {
       verifiedThirdParties?: components["schemas"]["VerifiedThirdPartyView"][];

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -41,7 +41,7 @@ import { getUploadedFile } from "./fileupload";
 import { PostalAddress } from "../model/postaladdress";
 import { downloadAndClean } from "../lib/http";
 import { LocRequestAdapter } from "./adapters/locrequestadapter";
-import { VerifiedThirdPartySelectionRepository } from "../model/verifiedthirdpartyselection.model";
+import { VerifiedThirdPartySelectionAggregateRoot, VerifiedThirdPartySelectionRepository } from "../model/verifiedthirdpartyselection.model";
 import { LocRequestService } from "../services/locrequest.service";
 
 const { logger } = Log;
@@ -290,8 +290,13 @@ export class LocRequestController extends ApiController {
             return false;
         } else {
             const participants = await this.verifiedThirdPartySelectionRepository.findBy({ locRequestId: request.id })
-            return participants.find(participant => participant.id.verifiedThirdPartyLocId === verifiedThirdPartyLoc.id) !== undefined;
+            const selectedParticipant = participants.find(participant => this.isSelectedParticipant(verifiedThirdPartyLoc.id, participant));
+            return selectedParticipant !== undefined;
         }
+    }
+
+    private isSelectedParticipant(verifiedThirdPartyLocId: string | undefined, participant: VerifiedThirdPartySelectionAggregateRoot) {
+        return participant.id.verifiedThirdPartyLocId === verifiedThirdPartyLocId && participant.selected;
     }
 
     static getPublicLoc(spec: OpenAPIV3.Document) {

--- a/src/logion/migration/1669287321053-AddSelectedFlag.ts
+++ b/src/logion/migration/1669287321053-AddSelectedFlag.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSelectedFlag1669287321053 implements MigrationInterface {
+    name = 'AddSelectedFlag1669287321053'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "vtp_selection" ADD "selected" boolean NOT NULL DEFAULT true`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "vtp_selection" DROP COLUMN "selected"`);
+    }
+
+}

--- a/src/logion/model/verifiedthirdpartyselection.model.ts
+++ b/src/logion/model/verifiedthirdpartyselection.model.ts
@@ -61,7 +61,7 @@ export class VerifiedThirdPartySelectionRepository {
 @injectable()
 export class VerifiedThirdPartySelectionFactory {
 
-    newNomination(args: {
+    newSelection(args: {
         locRequest: LocRequestAggregateRoot,
         verifiedThirdPartyLocRequest: LocRequestAggregateRoot,
     }): VerifiedThirdPartySelectionAggregateRoot {

--- a/src/logion/services/verifiedthirdpartyselection.service.ts
+++ b/src/logion/services/verifiedthirdpartyselection.service.ts
@@ -26,7 +26,7 @@ export abstract class VerifiedThirdPartySelectionService {
             selection.setSelected(select);
             await this.verifiedThirdPartySelectionRepository.save(selection);
         } else if(select) {
-            selection = this.verifiedThirdPartySelectionFactory.newNomination({
+            selection = this.verifiedThirdPartySelectionFactory.newSelection({
                 locRequest,
                 verifiedThirdPartyLocRequest
             });

--- a/test/integration/model/verifiedthirdpartyselection.model.spec.ts
+++ b/test/integration/model/verifiedthirdpartyselection.model.spec.ts
@@ -50,16 +50,8 @@ describe("VerifiedThirdPartySelectionRepository - write", () => {
         await disconnect();
     });
 
-    it("deletes by ID", async () => {
-        await repository.deleteById({
-            locRequestId: "a7b80f86-1c51-4aff-ba32-d8361bb462b1",
-            verifiedThirdPartyLocId: "a4eb8352-a032-44a6-8087-c95a40da0744",
-        });
-        checkNumOfRows(`SELECT * FROM vtp_selection`, 2);
-    });
-
     it("deletes by VTP LOC ID", async () => {
-        await repository.deleteByVerifiedThirdPartyId("a4eb8352-a032-44a6-8087-c95a40da0744");
-        checkNumOfRows(`SELECT * FROM vtp_selection`, 2);
+        await repository.unselectAll("a4eb8352-a032-44a6-8087-c95a40da0744");
+        checkNumOfRows(`SELECT * FROM vtp_selection WHERE selected IS TRUE`, 2);
     });
 });

--- a/test/unit/controllers/locrequest.controller.items.spec.ts
+++ b/test/unit/controllers/locrequest.controller.items.spec.ts
@@ -12,7 +12,7 @@ import {
     MetadataItemDescription,
 } from "../../../src/logion/model/locrequest.model";
 import { fileExists } from "../../helpers/filehelper";
-import { buildMocksForUpdate, mockPolkadotIdentityLoc, mockRequest, REQUEST_ID, setupRequest, setupSelectedVtp, testData, VTP_ADDRESS } from "./locrequest.controller.shared";
+import { buildMocksForUpdate, mockPolkadotIdentityLoc, mockRequest, REQUEST_ID, setupRequest, setupSelectedVtp, SetupVtpMode, testData, VTP_ADDRESS } from "./locrequest.controller.shared";
 import { mockAuthenticationForUserOrLegalOfficer } from "@logion/rest-api-core/dist/TestApp";
 
 const { mockAuthenticationWithCondition, setupApp } = TestApp;
@@ -23,14 +23,14 @@ describe('LocRequestController - Items -', () => {
         const locRequest = new Mock<LocRequestAggregateRoot>();
         locRequest.setup(instance => instance.ownerAddress).returns(ALICE);
         locRequest.setup(instance => instance.requesterAddress).returns(REQUESTER);
-        const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, false));
+        const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, 'NOT_VTP'));
         await testAddFileSuccess(app, locRequest);
     })
 
     it('adds file to loc - VTP', async () => {
         const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, VTP_ADDRESS);
         const locRequest = new Mock<LocRequestAggregateRoot>();
-        const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, true), authenticatedUserMock);
+        const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, 'SELECTED'), authenticatedUserMock);
         await testAddFileSuccess(app, locRequest);
     })
 
@@ -38,7 +38,7 @@ describe('LocRequestController - Items -', () => {
         const locRequest = new Mock<LocRequestAggregateRoot>();
         locRequest.setup(instance => instance.ownerAddress).returns(ALICE);
         locRequest.setup(instance => instance.requesterAddress).returns(REQUESTER);
-        const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, false));
+        const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, 'NOT_VTP'));
         const buffer = Buffer.from(SOME_DATA);
         await request(app)
             .post(`/api/loc-request/${ REQUEST_ID }/files`)
@@ -60,41 +60,51 @@ describe('LocRequestController - Items -', () => {
     it('fails to add file to loc if not contributor', async () => {
         const locRequest = new Mock<LocRequestAggregateRoot>();
         const mock = mockAuthenticationWithCondition(false);
-        const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, false), mock);
-        const buffer = Buffer.from(SOME_DATA);
-        await request(app)
-            .post(`/api/loc-request/${ REQUEST_ID }/files`)
-            .field({ nature: "some nature" })
-            .attach('file', buffer, {
-                filename: FILE_NAME,
-                contentType: 'text/plain',
-            })
-            .expect(403);
-    })
+        const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, 'NOT_VTP'), mock);
+        await testAddFileForbidden(app);
+    });
+
+    it('fails to add file to loc if unselected VTP', async () => {
+        const locRequest = new Mock<LocRequestAggregateRoot>();
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, VTP_ADDRESS);
+        const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, 'UNSELECTED'), authenticatedUserMock);
+        await testAddFileForbidden(app);
+    });
 
     it('downloads existing file given its hash', async () => {
-        const app = setupApp(LocRequestController, container => mockModelForDownloadFile(container, false));
+        const app = setupApp(LocRequestController, container => mockModelForDownloadFile(container, 'NOT_VTP'));
         await testDownloadSuccess(app);
     });
 
-
     it('downloads existing file given its hash and is VTP', async () => {
         const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, VTP_ADDRESS);
-        const app = setupApp(LocRequestController, container => mockModelForDownloadFile(container, true), authenticatedUserMock);
+        const app = setupApp(LocRequestController, container => mockModelForDownloadFile(container, 'SELECTED'), authenticatedUserMock);
         await testDownloadSuccess(app);
+    });
+
+    it('fails to download existing file given its hash if not contributor', async () => {
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, "some-address");
+        const app = setupApp(LocRequestController, container => mockModelForDownloadFile(container, 'NOT_VTP'), authenticatedUserMock);
+        await testDownloadForbidden(app);
+    });
+
+    it('fails to download existing file given its hash if unselected VTP', async () => {
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, VTP_ADDRESS);
+        const app = setupApp(LocRequestController, container => mockModelForDownloadFile(container, 'UNSELECTED'), authenticatedUserMock);
+        await testDownloadForbidden(app);
     });
 
     it('deletes a file', async () => {
         const locRequest = new Mock<LocRequestAggregateRoot>();
-        const app = setupApp(LocRequestController, container => mockModelForDeleteFile(container, locRequest, false))
-        await testDeleteFileSuccess(app, locRequest, false);
+        const app = setupApp(LocRequestController, container => mockModelForDeleteFile(container, locRequest, 'NOT_VTP'))
+        await testDeleteFileSuccess(app, locRequest, 'NOT_VTP');
     });
 
     it('deletes a file - VTP', async () => {
         const locRequest = new Mock<LocRequestAggregateRoot>();
         const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, VTP_ADDRESS);
-        const app = setupApp(LocRequestController, container => mockModelForDeleteFile(container, locRequest, true), authenticatedUserMock);
-        await testDeleteFileSuccess(app, locRequest, true);
+        const app = setupApp(LocRequestController, container => mockModelForDeleteFile(container, locRequest, 'SELECTED'), authenticatedUserMock);
+        await testDeleteFileSuccess(app, locRequest, 'SELECTED');
     });
 
     it('confirms a file', async () => {
@@ -106,7 +116,7 @@ describe('LocRequestController - Items -', () => {
 
     it('adds a metadata item', async () => {
         const locRequest = mockRequestForMetadata();
-        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, false))
+        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'NOT_VTP'))
         await testAddMetadataSuccess(app, locRequest);
     });
 
@@ -115,36 +125,40 @@ describe('LocRequestController - Items -', () => {
         const locRequest = mockRequestForMetadata();
         locRequest.setup(instance => instance.ownerAddress).returns(ALICE);
         locRequest.setup(instance => instance.requesterAddress).returns(REQUESTER);
-        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, true), authenticatedUserMock)
+        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'SELECTED'), authenticatedUserMock)
         await testAddMetadataSuccess(app, locRequest);
     });
 
     it('fails to add a metadata item when not contributor', async () => {
         const locRequest = mockRequestForMetadata();
         const mock = mockAuthenticationForUserOrLegalOfficer(false, "any other address");
-        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, false), mock);
-        await request(app)
-            .post(`/api/loc-request/${ REQUEST_ID }/metadata`)
-            .send({ name: SOME_DATA_NAME, value: SOME_DATA_VALUE })
-            .expect(403)
+        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'NOT_VTP'), mock);
+        await testAddMetadataForbidden(app);
+    });
+
+    it('fails to add a metadata item when unselected VTP', async () => {
+        const locRequest = mockRequestForMetadata();
+        const mock = mockAuthenticationForUserOrLegalOfficer(false, "any other address");
+        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'UNSELECTED'), mock);
+        await testAddMetadataForbidden(app);
     });
 
     it('deletes a metadata item', async () => {
         const locRequest = mockRequestForMetadata();
-        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, false));
+        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'NOT_VTP'));
         await testDeleteMetadataSuccess(app, locRequest, false);
     });
 
     it('deletes a metadata item - VTP', async () => {
         const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, VTP_ADDRESS);
         const locRequest = mockRequestForMetadata();
-        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, true), authenticatedUserMock);
+        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'SELECTED'), authenticatedUserMock);
         await testDeleteMetadataSuccess(app, locRequest, true);
     });
 
     it('confirms a metadata item', async () => {
         const locRequest = mockRequestForMetadata();
-        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, false))
+        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'NOT_VTP'))
         const dataName = encodeURIComponent(SOME_DATA_NAME)
         await request(app)
             .put(`/api/loc-request/${ REQUEST_ID }/metadata/${ dataName }/confirm`)
@@ -165,7 +179,7 @@ describe('LocRequestController - Items -', () => {
 
     it('deletes a link', async () => {
         const locRequest = mockRequestForLink();
-        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, false))
+        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'NOT_VTP'))
         await request(app)
             .delete(`/api/loc-request/${ REQUEST_ID }/links/${ SOME_LINK_TARGET }`)
             .expect(200)
@@ -174,7 +188,7 @@ describe('LocRequestController - Items -', () => {
 
     it('confirms a link', async () => {
         const locRequest = mockRequestForLink();
-        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, false))
+        const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'NOT_VTP'))
         await request(app)
             .put(`/api/loc-request/${ REQUEST_ID }/links/${ SOME_LINK_TARGET }/confirm`)
             .expect(204)
@@ -186,14 +200,14 @@ const SOME_DATA = 'some data';
 const SOME_DATA_HASH = '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee';
 const FILE_NAME = "'a-file.pdf'";
 
-function mockModelForAddFile(container: Container, request: Mock<LocRequestAggregateRoot>, isVtp: boolean): void {
+function mockModelForAddFile(container: Container, request: Mock<LocRequestAggregateRoot>, vtpMode: SetupVtpMode): void {
     const { fileStorageService, repository, verifiedThirdPartySelectionRepository } = buildMocksForUpdate(container, { request });
 
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.hasFile(SOME_DATA_HASH)).returns(false);
     request.setup(instance => instance.addFile(It.IsAny())).returns();
 
-    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, isVtp);
+    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, vtpMode);
 
     fileStorageService.setup(instance => instance.importFile(It.IsAny<string>()))
         .returns(Promise.resolve("cid-42"));
@@ -217,7 +231,19 @@ async function testAddFileSuccess(app: Express, locRequest: Mock<LocRequestAggre
     locRequest.verify(instance => instance.addFile(It.IsAny()));
 }
 
-function mockModelForDownloadFile(container: Container, isVtp: boolean): void {
+async function testAddFileForbidden(app: Express) {
+    const buffer = Buffer.from(SOME_DATA);
+    await request(app)
+        .post(`/api/loc-request/${ REQUEST_ID }/files`)
+        .field({ nature: "some nature" })
+        .attach('file', buffer, {
+            filename: FILE_NAME,
+            contentType: 'text/plain',
+        })
+        .expect(403);
+}
+
+function mockModelForDownloadFile(container: Container, vtpMode: SetupVtpMode): void {
     const { request, fileStorageService, repository, verifiedThirdPartySelectionRepository } = buildMocksForUpdate(container);
 
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
@@ -227,14 +253,14 @@ function mockModelForDownloadFile(container: Container, isVtp: boolean): void {
     const hash = SOME_DATA_HASH;
     request.setup(instance => instance.getFile(hash)).returns({
         ...SOME_FILE,
-        submitter: isVtp ? VTP_ADDRESS : REQUESTER,
+        submitter: vtpMode !== "NOT_VTP" ? VTP_ADDRESS : REQUESTER,
     });
 
     const filePath = "/tmp/download-" + REQUEST_ID + "-" + hash;
     fileStorageService.setup(instance => instance.exportFile({ oid: SOME_OID }, filePath))
         .returns(Promise.resolve());
 
-    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, isVtp);
+    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, vtpMode);
 }
 
 const SOME_OID = 123456;
@@ -270,29 +296,35 @@ async function expectFileExists(filePath: string) {
     }
 }
 
-function mockModelForDeleteFile(container: Container, request: Mock<LocRequestAggregateRoot>, isVtp: boolean) {
+async function testDownloadForbidden(app: Express) {
+    await request(app)
+        .get(`/api/loc-request/${ REQUEST_ID }/files/${ SOME_DATA_HASH }`)
+        .expect(403);
+}
+
+function mockModelForDeleteFile(container: Container, request: Mock<LocRequestAggregateRoot>, vtpMode: SetupVtpMode) {
     const { fileStorageService, repository, verifiedThirdPartySelectionRepository } = buildMocksForUpdate(container, { request });
 
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.ownerAddress).returns(ALICE);
     request.setup(instance => instance.requesterAddress).returns(REQUESTER);
 
-    if(isVtp) {
+    if(vtpMode !== 'NOT_VTP') {
         request.setup(instance => instance.removeFile(VTP_ADDRESS, SOME_DATA_HASH)).returns(SOME_FILE);
     } else {
         request.setup(instance => instance.removeFile(ALICE, SOME_DATA_HASH)).returns(SOME_FILE);
     }
 
-    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, isVtp);
+    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, vtpMode);
 
     fileStorageService.setup(instance => instance.deleteFile({ oid: SOME_OID })).returns(Promise.resolve());
 }
 
-async function testDeleteFileSuccess(app: Express, locRequest: Mock<LocRequestAggregateRoot>, isVtp: boolean) {
+async function testDeleteFileSuccess(app: Express, locRequest: Mock<LocRequestAggregateRoot>, vtpMode: SetupVtpMode) {
     await request(app)
         .delete(`/api/loc-request/${REQUEST_ID}/files/${SOME_DATA_HASH}`)
         .expect(200);
-    if(isVtp) {
+    if(vtpMode !== 'NOT_VTP') {
         locRequest.verify(instance => instance.removeFile(VTP_ADDRESS, SOME_DATA_HASH));
     } else {
         locRequest.verify(instance => instance.removeFile(ALICE, SOME_DATA_HASH));
@@ -335,6 +367,13 @@ async function testAddMetadataSuccess(app: Express, locRequest: Mock<LocRequestA
         It.Is<MetadataItemDescription>(item => item.name == SOME_DATA_NAME && item.value == SOME_DATA_VALUE)));
 }
 
+async function testAddMetadataForbidden(app: Express) {
+    await request(app)
+        .post(`/api/loc-request/${ REQUEST_ID }/metadata`)
+        .send({ name: SOME_DATA_NAME, value: SOME_DATA_VALUE })
+        .expect(403);
+}
+
 async function testDeleteMetadataSuccess(app: Express, locRequest: Mock<LocRequestAggregateRoot>, isVtp: boolean) {
     const dataName = encodeURIComponent(SOME_DATA_NAME)
     await request(app)
@@ -361,10 +400,10 @@ function mockRequestForLink(): Mock<LocRequestAggregateRoot> {
     return request;
 }
 
-function mockModelForAnyItem(container: Container, request: Mock<LocRequestAggregateRoot>, isVtp: boolean) {
+function mockModelForAnyItem(container: Container, request: Mock<LocRequestAggregateRoot>, vtpMode: SetupVtpMode) {
     const { repository, verifiedThirdPartySelectionRepository } = buildMocksForUpdate(container, { request });
     mockPolkadotIdentityLoc(repository, false);
-    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, isVtp);
+    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, vtpMode);
 }
 
 function mockModelForAddLink(container: Container, request: Mock<LocRequestAggregateRoot>) {

--- a/test/unit/controllers/locrequest.controller.sof.spec.ts
+++ b/test/unit/controllers/locrequest.controller.sof.spec.ts
@@ -95,6 +95,6 @@ function mockModelForCreateSofRequest(container: Container, factory: Mock<LocReq
             .returns(Promise.resolve(collectionItem.object()));
     }
 
-    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, false);
+    setupSelectedVtp({ repository, verifiedThirdPartySelectionRepository }, 'NOT_VTP');
 
 }

--- a/test/unit/controllers/verifiedthirdparty.controller.spec.ts
+++ b/test/unit/controllers/verifiedthirdparty.controller.spec.ts
@@ -142,7 +142,7 @@ function mockModelForSelect(
     request.setup(instance => instance.id).returns(REQUEST_ID);
     request.setup(instance => instance.getDescription()).returns(description.object());
 
-    verifiedThirdPartyNominationFactory.setup(instance => instance.newNomination(
+    verifiedThirdPartyNominationFactory.setup(instance => instance.newSelection(
         It.Is<{
             locRequest: LocRequestAggregateRoot,
             verifiedThirdPartyLocRequest: LocRequestAggregateRoot,

--- a/test/unit/model/verifiedthirdpartyselection.model.spec.ts
+++ b/test/unit/model/verifiedthirdpartyselection.model.spec.ts
@@ -41,7 +41,7 @@ function buildNomination(identityLoc: Mock<LocRequestAggregateRoot>): VerifiedTh
     const locRequest = new Mock<LocRequestAggregateRoot>();
     locRequest.setup(instance => instance.id).returns(SELECTION_ID.locRequestId);
 
-    return factory.newNomination({
+    return factory.newSelection({
         verifiedThirdPartyLocRequest: identityLoc.object(),
         locRequest: locRequest.object(),
     })

--- a/test/unit/model/verifiedthirdpartyselection.model.spec.ts
+++ b/test/unit/model/verifiedthirdpartyselection.model.spec.ts
@@ -4,25 +4,25 @@ import { VerifiedThirdPartySelectionAggregateRoot, VerifiedThirdPartySelectionFa
 
 describe("VerifiedThirdPartySelectionFactory", () => {
 
-    it("creates new nomination for VTP", async () => {
+    it("creates new nomination for VTP", () => {
         const identityLoc = buildIdentityLoc("Identity", "CLOSED", true);
-        const nomination = await buildNomination(identityLoc);
+        const nomination = buildNomination(identityLoc);
         expect(nomination.id).toEqual(SELECTION_ID);
     });
 
-    it("fails creating nomination with non-Identity LOC", async () => {
+    it("fails creating nomination with non-Identity LOC", () => {
         const identityLoc = buildIdentityLoc("Collection", "CLOSED", false);
-        await expectAsync(buildNomination(identityLoc)).toBeRejectedWithError("VTP LOC is not an identity LOC");
+        expect(() => buildNomination(identityLoc)).toThrowError("VTP LOC is not an identity LOC");
     });
 
-    it("fails creating nomination with non-closed Identity LOC", async () => {
+    it("fails creating nomination with non-closed Identity LOC", () => {
         const identityLoc = buildIdentityLoc("Identity", "OPEN", false);
-        await expectAsync(buildNomination(identityLoc)).toBeRejectedWithError("VTP LOC is not closed");
+        expect(() => buildNomination(identityLoc)).toThrowError("VTP LOC is not closed");
     });
 
-    it("fails creating nomination with non-verified Identity LOC", async () => {
+    it("fails creating nomination with non-verified Identity LOC", () => {
         const identityLoc = buildIdentityLoc("Identity", "CLOSED", false);
-        await expectAsync(buildNomination(identityLoc)).toBeRejectedWithError("Party is not verified");
+        expect(() => buildNomination(identityLoc)).toThrowError("Party is not verified");
     });
 });
 
@@ -35,7 +35,7 @@ function buildIdentityLoc(locType: LocType, status: LocRequestStatus, verifiedTh
     return identityLoc;
 }
 
-function buildNomination(identityLoc: Mock<LocRequestAggregateRoot>): Promise<VerifiedThirdPartySelectionAggregateRoot> {
+function buildNomination(identityLoc: Mock<LocRequestAggregateRoot>): VerifiedThirdPartySelectionAggregateRoot {
     const factory = new VerifiedThirdPartySelectionFactory();
 
     const locRequest = new Mock<LocRequestAggregateRoot>();


### PR DESCRIPTION
* VerifiedThirdPartySelections are not deleted anymore on unselection
* A flag now tells if the VerifiedThirdPartySelection is "active" or not
* Access rules have been updated accordingly

logion-network/logion-internal#676