### PR TITLE
Add iDenfy integration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,7 @@ JWT_TTL_SEC=3600 # TTL of issued JWT tokens
 OWNER=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
 HEALTH_TOKEN="change-me-please"
 DIRECTORY_URL=http://localhost:8090
+BASE_URL=http://localhost:8080
 
 # E-mail
 SMTP_ENABLED=true # False prevents any e-mail to be sent
@@ -30,3 +31,8 @@ ENC_PASSWORD=secret
 # Alchemy SDK keys
 GOERLI_ALCHEMY_KEY=""
 ETHEREUM_ALCHEMY_KEY=""
+
+# iDenfy - enable integration by setting below variables
+# IDENFY_SECRET=
+# IDENFY_API_KEY=
+# IDENFY_API_SECRET=

--- a/doc/DbMigration.md
+++ b/doc/DbMigration.md
@@ -9,8 +9,9 @@ Pre-requisite:
 This is the step-by-step sequence to upgrade the database schema:
 
 * Adapt the model with the proper annotations.
-* Choose a name for the migration, for instance `MyMigration` 
+* Build the project.
+* Choose a name for the migration, for instance `MyMigration`.
 * Run `yarn typeorm migration:generate ./src/logion/migration/MyMigration` - this will generate a new migration `TIMESTAMP-MyMigration.ts` under [migration](/src/logion/migration).
 * (Optional) Modify the generated file.
-* Apply the migration(s): `yarn typeorm migration:run`
-* (Optional) Revert the last migration: `yarn typeorm migration:revert`
+* Apply the migration(s): `yarn typeorm migration:run`.
+* (Optional) Revert the last migration: `yarn typeorm migration:revert`.

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
         "inspect": "yarn run build && NODE_ENV=development node --inspect dist/app.js",
         "serve": "tsc-watch --p ./tsconfig.app.json --onSuccess \"env NODE_ENV=development node ./dist/app.js\"",
         "test": "NODE_OPTIONS=--loader=ts-node/esm jasmine --config=spec/support/jasmine.json",
-        "integration-test": "yarn run setup-test-db && jasmine --config=spec/support/jasmine-integration.json ; yarn run teardown-test-db",
+        "integration-test": "yarn run setup-test-db && NODE_OPTIONS=--loader=ts-node/esm jasmine --config=spec/support/jasmine-integration.json ; yarn run teardown-test-db",
         "setup-test-db": "docker run -d --rm --name logion-test-db -e POSTGRES_PASSWORD=secret -p 5432:5432 logionnetwork/logion-postgres:latest",
         "teardown-test-db": "docker stop logion-test-db",
         "coverage": "nyc yarn run test",
-        "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js -d ./src/logion/db-tools/ormconfig.ts"
+        "typeorm": "node ./node_modules/typeorm/cli.js -d ./dist/db-tools/ormconfig.js"
     },
     "dependencies": {
         "@logion/node-exiftool": "^2.3.1-2",

--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -48,6 +48,21 @@
                     }
                 }
             },
+            "Config": {
+                "description": "Backend configuration which impacts clients",
+                "type": "object",
+                "properties": {
+                    "integrations": {
+                        "description": "Available integrations and their status (enabled/disabled)",
+                        "type": "object",
+                        "properties": {
+                            "iDenfy": {
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                }
+            },
             "CreateProtectionRequestView": {
                 "type": "object",
                 "properties": {
@@ -1194,6 +1209,16 @@
                         "items": {
                             "$ref": "#/components/schemas/VerifiedThirdPartyView"
                         }
+                    }
+                }
+            },
+            "IdenfyVerificationRedirectView": {
+                "description": "Provides the URL to redirect to in order to start an identity verification process at iDenfy",
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "description": "The URL to redirect to",
+                        "type": "string"
                     }
                 }
             }

--- a/src/logion/app.support.ts
+++ b/src/logion/app.support.ts
@@ -19,6 +19,8 @@ import { fillInSpec as fillInSpecForVaultTransferRequest, VaultTransferRequestCo
 import { fillInSpec as fillInSpecForLoFile, LoFileController } from "./controllers/lofile.controller.js";
 import { fillInSpec as fillInSpecForSettings, SettingController } from "./controllers/setting.controller.js";
 import { fillInSpec as fillInSpecVerifiedThirdParty, VerifiedThirdPartyController } from "./controllers/verifiedthirdparty.controller.js";
+import { fillInSpec as fillInSpecConfig, ConfigController } from "./controllers/config.controller.js";
+import { fillInSpec as fillInSpecIdenfy, IdenfyController } from "./controllers/idenfy.controller.js";
 
 export function predefinedSpec(spec: OpenAPIV3.Document): OpenAPIV3.Document {
     setOpenApi3(spec);
@@ -50,6 +52,8 @@ export function predefinedSpec(spec: OpenAPIV3.Document): OpenAPIV3.Document {
     fillInSpecForSettings(spec);
     fillInSpecForVaultTransferRequest(spec);
     fillInSpecVerifiedThirdParty(spec);
+    fillInSpecConfig(spec);
+    fillInSpecIdenfy(spec);
 
     return spec;
 }
@@ -68,7 +72,11 @@ export function buildExpress(withDoc?: boolean): Express {
         });
     }
 
-    app.use(bodyParser.json());
+    app.use(bodyParser.json({
+        verify: (req, _res, buf) => {
+            (req as any).rawBody = buf;
+        }
+    }));
     app.use(bodyParser.urlencoded({ extended: false }));
     app.use(fileUpload({
         limits: { fileSize: 300 * 1024 * 1024 },
@@ -94,6 +102,8 @@ export function setupApp(withDoc?: boolean): Express {
     dino.registerController(LoFileController);
     dino.registerController(SettingController);
     dino.registerController(VerifiedThirdPartyController);
+    dino.registerController(ConfigController);
+    dino.registerController(IdenfyController);
 
     dino.dependencyResolver<Container>(AppContainer,
         (injector, type) => {

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -48,6 +48,9 @@ import { SyncPointService, TransactionalSyncPointService } from "../services/syn
 import { TransactionalTransactionService, TransactionService } from "../services/transaction.service.js";
 import { TransactionalVaultTransferRequestService, VaultTransferRequestService } from "../services/vaulttransferrequest.service.js";
 import { TransactionalVerifiedThirdPartySelectionService, VerifiedThirdPartySelectionService } from "../services/verifiedthirdpartyselection.service.js";
+import { DisabledIdenfyService, EnabledIdenfyService, IdenfyService } from "../services/idenfy/idenfy.service.js";
+import { ConfigController } from "../controllers/config.controller.js";
+import { IdenfyController } from "../controllers/idenfy.controller.js";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -114,6 +117,13 @@ container.bind(VaultTransferRequestService).toService(TransactionalVaultTransfer
 container.bind(TransactionalVaultTransferRequestService).toSelf();
 container.bind(VerifiedThirdPartySelectionService).toService(TransactionalVerifiedThirdPartySelectionService);
 container.bind(TransactionalVerifiedThirdPartySelectionService).toSelf();
+if(process.env.IDENFY_SECRET) {
+    container.bind(EnabledIdenfyService).toSelf();
+    container.bind(IdenfyService).toService(EnabledIdenfyService);
+} else {
+    container.bind(DisabledIdenfyService).toSelf();
+    container.bind(IdenfyService).toService(DisabledIdenfyService);
+}
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();
@@ -122,5 +132,7 @@ container.bind(TransactionController).toSelf().inTransientScope();
 container.bind(VaultTransferRequestController).toSelf().inTransientScope();
 container.bind(SettingController).toSelf().inTransientScope();
 container.bind(VerifiedThirdPartyController).toSelf().inTransientScope();
+container.bind(ConfigController).toSelf().inTransientScope();
+container.bind(IdenfyController).toSelf().inTransientScope();
 
 export { container as AppContainer };

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -33,6 +33,13 @@ export interface components {
       owner?: string;
       belongsToCurrentOwner?: boolean;
     };
+    /** @description Backend configuration which impacts clients */
+    Config: {
+      /** @description Available integrations and their status (enabled/disabled) */
+      integrations?: {
+        iDenfy?: boolean;
+      };
+    };
     /**
      * CreateProtectionRequestView 
      * @description A Protection Request to create
@@ -716,6 +723,11 @@ export interface components {
     };
     VerifiedThirdPartiesView: {
       verifiedThirdParties?: (components["schemas"]["VerifiedThirdPartyView"])[];
+    };
+    /** @description Provides the URL to redirect to in order to start an identity verification process at iDenfy */
+    IdenfyVerificationRedirectView: {
+      /** @description The URL to redirect to */
+      url?: string;
     };
   };
   responses: never;

--- a/src/logion/controllers/config.controller.ts
+++ b/src/logion/controllers/config.controller.ts
@@ -1,0 +1,52 @@
+import { injectable } from "inversify";
+import { Controller, ApiController, Async, HttpGet } from "dinoloop";
+import { components } from "./components.js";
+import { OpenAPIV3 } from "express-oas-generator";
+import {
+    addTag,
+    setControllerTag,
+    AuthenticationService,
+    getDefaultResponses,
+} from "@logion/rest-api-core";
+
+export function fillInSpec(spec: OpenAPIV3.Document): void {
+    const tagName = 'Config';
+    addTag(spec, {
+        name: tagName,
+        description: "Backend configuration"
+    });
+    setControllerTag(spec, /^\/api\/config.*/, tagName);
+
+    ConfigController.getConfig(spec);
+}
+
+type Config = components["schemas"]["Config"];
+
+@injectable()
+@Controller('/config')
+export class ConfigController extends ApiController {
+
+    constructor(
+        private authenticationService: AuthenticationService,
+    ) {
+        super();
+    }
+
+    static getConfig(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/config"].get!;
+        operationObject.summary = "Provides the backend configuration elements relevant to clients";
+        operationObject.description = "Requires authentication.";
+        operationObject.responses = getDefaultResponses("Config");
+    }
+
+    @HttpGet('')
+    @Async()
+    async getConfig(): Promise<Config> {
+        await this.authenticationService.authenticatedUser(this.request);
+        return {
+            integrations: {
+                iDenfy: process.env.IDENFY_SECRET !== undefined,
+            }
+        }
+    }
+}

--- a/src/logion/controllers/idenfy.controller.ts
+++ b/src/logion/controllers/idenfy.controller.ts
@@ -1,0 +1,84 @@
+import { injectable } from "inversify";
+import { Controller, ApiController, Async, HttpPost } from "dinoloop";
+import { components } from "./components.js";
+import { OpenAPIV3 } from "express-oas-generator";
+import {
+    addTag,
+    setControllerTag,
+    AuthenticationService,
+    getDefaultResponses,
+    requireDefined,
+    setPathParameters,
+    forbidden,
+    getDefaultResponsesWithAnyBody,
+    badRequest,
+} from "@logion/rest-api-core";
+import { IdenfyService } from "../services/idenfy/idenfy.service.js";
+import { LocRequestRepository } from "../model/locrequest.model.js";
+import { IdenfyCallbackPayload } from "../services/idenfy/idenfy.types.js";
+
+export function fillInSpec(spec: OpenAPIV3.Document): void {
+    const tagName = 'iDenfy integration';
+    addTag(spec, {
+        name: tagName,
+        description: "Provides iDenfy-related resources"
+    });
+    setControllerTag(spec, /^\/api\/idenfy.*/, tagName);
+
+    IdenfyController.createVerificationSession(spec);
+    IdenfyController.callback(spec);
+}
+
+type IdenfyVerificationRedirectView = components["schemas"]["IdenfyVerificationRedirectView"];
+
+@injectable()
+@Controller('/idenfy')
+export class IdenfyController extends ApiController {
+
+    constructor(
+        private authenticationService: AuthenticationService,
+        private idenfyService: IdenfyService,
+        private locRequestRepository: LocRequestRepository,
+    ) {
+        super();
+    }
+
+    static createVerificationSession(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/idenfy/verification-session/{locId}"].post!;
+        operationObject.summary = "Initiates an iDenfy verification session";
+        operationObject.description = "Requires authentication and the user to be the requester of target Identity LOC.";
+        operationObject.responses = getDefaultResponses("IdenfyVerificationRedirectView");
+        setPathParameters(operationObject, {
+            locId: "The target Identity LOC ID",
+        });
+    }
+
+    @HttpPost('/verification-session/:locId')
+    @Async()
+    async createVerificationSession(_body: never, locId: string): Promise<IdenfyVerificationRedirectView> {
+        const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
+        const request = requireDefined(await this.locRequestRepository.findById(locId), () => badRequest("LOC not found"));
+        authenticatedUser.require(user => request.requesterAddress === user.address,
+            "Only LOC requester can start an identity verification session");
+        return await this.idenfyService.createVerificationSession(request);
+    }
+
+    static callback(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/idenfy/callback/{secret}"].post!;
+        operationObject.summary = "Webhook called by iDenfy at the end of a verification process";
+        operationObject.description = "The security of the endpoint is managed by expecting a secret which is shared only between the backend and iDenfy at session creation time.";
+        operationObject.responses = getDefaultResponsesWithAnyBody();
+        setPathParameters(operationObject, {
+            secret: "The shared secret",
+        });
+    }
+
+    @HttpPost('/callback/:secret')
+    @Async()
+    async callback(body: any, secret: string): Promise<void> {
+        if(secret !== process.env.IDENFY_SECRET) {
+            throw forbidden("Bad secret");
+        }
+        await this.idenfyService.callback(body as IdenfyCallbackPayload, this.request.rawBody);
+    }
+}

--- a/src/logion/db-tools/ormconfig.ts
+++ b/src/logion/db-tools/ormconfig.ts
@@ -1,15 +1,16 @@
 import { DataSource, DataSourceOptions } from 'typeorm';
 import { LogionNamingStrategy } from "@logion/rest-api-core";
+import { readFileSync } from 'fs';
 
-const config: DataSourceOptions = require("../../../ormconfig.json")
+const config: DataSourceOptions = JSON.parse(readFileSync("ormconfig.json").toString());
 
 const migrationConfig: DataSourceOptions = {
     ...config,
     entities: [
-        "src/logion/model/*.model.ts"
+        "dist/model/*.model.js"
     ],
     migrations: [
-        "src/logion/migration/*.ts"
+        "dist/migration/*.js"
     ],
     namingStrategy: new LogionNamingStrategy(),
 }

--- a/src/logion/migration/1671178160805-Idenfy.ts
+++ b/src/logion/migration/1671178160805-Idenfy.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Idenfy1671178160805 implements MigrationInterface {
+    name = 'Idenfy1671178160805'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request" ADD "idenfy_auth_token" character varying(40)`);
+        await queryRunner.query(`ALTER TABLE "loc_request" ADD "idenfy_scan_ref" character varying(40)`);
+        await queryRunner.query(`ALTER TABLE "loc_request" ADD "idenfy_status" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "loc_request" ADD "idenfy_callback_payload" text`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request" DROP COLUMN "idenfy_callback_payload"`);
+        await queryRunner.query(`ALTER TABLE "loc_request" DROP COLUMN "idenfy_status"`);
+        await queryRunner.query(`ALTER TABLE "loc_request" DROP COLUMN "idenfy_scan_ref"`);
+        await queryRunner.query(`ALTER TABLE "loc_request" DROP COLUMN "idenfy_auth_token"`);
+    }
+
+}

--- a/src/logion/services/axiosfactory.service.ts
+++ b/src/logion/services/axiosfactory.service.ts
@@ -1,0 +1,10 @@
+import axios, { AxiosInstance, CreateAxiosDefaults } from "axios";
+import { injectable } from "inversify";
+
+@injectable()
+export class AxiosFactory {
+
+    create(config?: CreateAxiosDefaults): AxiosInstance {
+        return axios.create(config);
+    }
+}

--- a/src/logion/services/idenfy/idenfy.types.ts
+++ b/src/logion/services/idenfy/idenfy.types.ts
@@ -1,0 +1,19 @@
+export interface IdenfyVerificationSession {
+    authToken: string;
+    scanRef: string;
+}
+
+export type IdenfyVerificationStatus = "APPROVED" | "DENIED" | "SUSPECTED" | "EXPIRED";
+
+export const IdenfyCallbackPayloadFileTypes = ['FRONT', 'BACK', 'FACE', 'FRONT_VIDEO', 'BACK_VIDEO', 'FACE_VIDEO'] as const;
+
+export interface IdenfyCallbackPayload {
+    clientId: string;
+    status: {
+        overall: IdenfyVerificationStatus;
+    };
+    final: boolean;
+    fileUrls: {
+        [K in typeof IdenfyCallbackPayloadFileTypes[number]]: string | null;
+    };
+}

--- a/test/integration/lib/db/large_objects.spec.ts
+++ b/test/integration/lib/db/large_objects.spec.ts
@@ -1,4 +1,4 @@
-import { importFile, exportFile, deleteFile } from "../../../../src/logion/lib/db/large_objects";
+import { importFile, exportFile, deleteFile } from "../../../../src/logion/lib/db/large_objects.js";
 import { readFile, rm } from 'fs/promises';
 
 describe("Large Objects module", () => {

--- a/test/integration/model/collection.model.spec.ts
+++ b/test/integration/model/collection.model.spec.ts
@@ -5,9 +5,9 @@ import {
     CollectionItemFile,
     CollectionItemFileDelivered,
     CollectionItemFileDescription
-} from "../../../src/logion/model/collection.model";
+} from "../../../src/logion/model/collection.model.js";
 import moment from "moment";
-import { CollectionService, TransactionalCollectionService } from "../../../src/logion/services/collection.service";
+import { CollectionService, TransactionalCollectionService } from "../../../src/logion/services/collection.service.js";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -7,10 +7,10 @@ import {
     LocFile,
     LocMetadataItem,
     LocLink, LocType,
-} from "../../../src/logion/model/locrequest.model";
-import { ALICE, BOB } from "../../helpers/addresses";
+} from "../../../src/logion/model/locrequest.model.js";
+import { ALICE, BOB } from "../../helpers/addresses.js";
 import { v4 as uuid } from "uuid";
-import { LocRequestService, TransactionalLocRequestService } from "../../../src/logion/services/locrequest.service";
+import { LocRequestService, TransactionalLocRequestService } from "../../../src/logion/services/locrequest.service.js";
 
 const SUBMITTER = "5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw";
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
@@ -39,6 +39,11 @@ describe('LocRequestRepository - read accesses', () => {
         checkDescription(requests, "Transaction", "loc-1", "loc-2", "loc-4", "loc-5", "loc-10", "loc-17", "loc-18");
 
         expect(requests[0].getDescription().userIdentity).toBeUndefined();
+
+        expect(requests[0].iDenfyVerification?.authToken).toBeNull();
+        expect(requests[0].iDenfyVerification?.scanRef).toBeNull();
+        expect(requests[0].iDenfyVerification?.status).toBeNull();
+        expect(requests[0].iDenfyVerification?.callbackPayload).toBeNull();
     })
 
     it("find LOCS with Polkadot requester", async () => {

--- a/test/integration/model/lofile.model.spec.ts
+++ b/test/integration/model/lofile.model.spec.ts
@@ -1,7 +1,7 @@
-import { LoFileRepository, LoFileAggregateRoot, LoFileDescription } from "../../../src/logion/model/lofile.model";
+import { LoFileRepository, LoFileAggregateRoot, LoFileDescription } from "../../../src/logion/model/lofile.model.js";
 import { TestDb } from "@logion/rest-api-core";
-import { ALICE } from "../../helpers/addresses";
-import { LegalOfficerSettingId } from "../../../src/logion/model/legalofficer.model";
+import { ALICE } from "../../helpers/addresses.js";
+import { LegalOfficerSettingId } from "../../../src/logion/model/legalofficer.model.js";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 

--- a/test/integration/model/protectionrequest.model.spec.ts
+++ b/test/integration/model/protectionrequest.model.spec.ts
@@ -1,14 +1,14 @@
 import { TestDb } from "@logion/rest-api-core";
-import { EmbeddablePostalAddress } from "../../../src/logion/model/postaladdress";
-import { EmbeddableUserIdentity } from "../../../src/logion/model/useridentity";
+import { EmbeddablePostalAddress } from "../../../src/logion/model/postaladdress.js";
+import { EmbeddableUserIdentity } from "../../../src/logion/model/useridentity.js";
 import {
     FetchProtectionRequestsSpecification,
     ProtectionRequestAggregateRoot,
     ProtectionRequestRepository,
     ProtectionRequestKind,
     ProtectionRequestStatus,
-} from "../../../src/logion/model/protectionrequest.model";
-import { ALICE, BOB } from "../../helpers/addresses";
+} from "../../../src/logion/model/protectionrequest.model.js";
+import { ALICE, BOB } from "../../helpers/addresses.js";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 

--- a/test/integration/model/setting.model.spec.ts
+++ b/test/integration/model/setting.model.spec.ts
@@ -1,6 +1,6 @@
 import { TestDb } from "@logion/rest-api-core";
-import { SettingRepository, SettingAggregateRoot } from "../../../src/logion/model/setting.model";
-import { ALICE, BOB, CHARLY } from "../../helpers/addresses";
+import { SettingRepository, SettingAggregateRoot } from "../../../src/logion/model/setting.model.js";
+import { ALICE, BOB, CHARLY } from "../../helpers/addresses.js";
 
 const { connect, disconnect, executeScript } = TestDb;
 

--- a/test/integration/model/syncpoint.model.spec.ts
+++ b/test/integration/model/syncpoint.model.spec.ts
@@ -4,7 +4,7 @@ import {
     SyncPointAggregateRoot,
     SyncPointRepository,
     TRANSACTIONS_SYNC_POINT_NAME,
-} from "../../../src/logion/model/syncpoint.model";
+} from "../../../src/logion/model/syncpoint.model.js";
 
 const { connect, disconnect, query, executeScript } = TestDb;
 

--- a/test/integration/model/transaction.model.spec.ts
+++ b/test/integration/model/transaction.model.spec.ts
@@ -2,7 +2,7 @@ import { TestDb } from "@logion/rest-api-core";
 import {
     TransactionAggregateRoot,
     TransactionRepository,
-} from "../../../src/logion/model/transaction.model";
+} from "../../../src/logion/model/transaction.model.js";
 import moment from "moment";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;

--- a/test/integration/model/vaulttransferrequest.model.spec.ts
+++ b/test/integration/model/vaulttransferrequest.model.spec.ts
@@ -4,8 +4,8 @@ import {
     VaultTransferRequestAggregateRoot,
     VaultTransferRequestRepository,
     VaultTransferRequestStatus,
-} from "../../../src/logion/model/vaulttransferrequest.model";
-import { ALICE } from "../../helpers/addresses";
+} from "../../../src/logion/model/vaulttransferrequest.model.js";
+import { ALICE } from "../../helpers/addresses.js";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 

--- a/test/integration/model/verifiedthirdpartyselection.model.spec.ts
+++ b/test/integration/model/verifiedthirdpartyselection.model.spec.ts
@@ -1,5 +1,5 @@
 import { TestDb } from "@logion/rest-api-core";
-import { VerifiedThirdPartySelectionAggregateRoot, VerifiedThirdPartySelectionRepository } from "../../../src/logion/model/verifiedthirdpartyselection.model";
+import { VerifiedThirdPartySelectionAggregateRoot, VerifiedThirdPartySelectionRepository } from "../../../src/logion/model/verifiedthirdpartyselection.model.js";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 

--- a/test/integration/services/mail.service.spec.ts
+++ b/test/integration/services/mail.service.spec.ts
@@ -1,6 +1,6 @@
-import { MailService } from "../../../src/logion/services/mail.service";
+import { MailService } from "../../../src/logion/services/mail.service.js";
 import { v4 } from "uuid";
-import { configureEnvBackupRestore } from "./test-helpers/envhelper";
+import { configureEnvBackupRestore } from "./test-helpers/envhelper.js";
 
 describe("MailService", () => {
 

--- a/test/integration/services/notification.service.spec.ts
+++ b/test/integration/services/notification.service.spec.ts
@@ -1,7 +1,7 @@
-import { MailService } from "../../../src/logion/services/mail.service";
-import { NotificationService, templateValues, Template } from "../../../src/logion/services/notification.service";
-import { configureEnvBackupRestore } from "./test-helpers/envhelper";
-import { notificationData } from "../../unit/services/notification-test-data";
+import { MailService } from "../../../src/logion/services/mail.service.js";
+import { NotificationService, templateValues, Template } from "../../../src/logion/services/notification.service.js";
+import { configureEnvBackupRestore } from "./test-helpers/envhelper.js";
+import { notificationData } from "../../unit/services/notification-test-data.js";
 
 describe("NotificationService", () => {
 

--- a/test/unit/controllers/config.controller.spec.ts
+++ b/test/unit/controllers/config.controller.spec.ts
@@ -1,0 +1,38 @@
+import { TestApp } from "@logion/rest-api-core";
+import { ConfigController } from "../../../src/logion/controllers/config.controller.js";
+import request from "supertest";
+
+const { setupApp } = TestApp;
+
+describe("ConfigController", () => {
+
+    it("provides config without iDenfy integration", async () => {
+        const app = setupApp(ConfigController, () => {});
+        delete process.env.IDENFY_SECRET;
+        delete process.env.IDENFY_API_KEY;
+        delete process.env.IDENFY_API_SECRET;
+
+        await request(app)
+            .get(`/api/config`)
+            .expect(200)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.integrations.iDenfy).toBeFalse();
+            });
+    });
+
+    it("provides config with iDenfy integration", async () => {
+        const app = setupApp(ConfigController, () => {});
+        process.env.IDENFY_SECRET = "some-secret";
+        process.env.IDENFY_API_KEY = "some-api-key";
+        process.env.IDENFY_API_SECRET = "some-api-secret";
+
+        await request(app)
+            .get(`/api/config`)
+            .expect(200)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.integrations.iDenfy).toBeTrue();
+            });
+    });
+});

--- a/test/unit/controllers/idenfy.controller.spec.ts
+++ b/test/unit/controllers/idenfy.controller.spec.ts
@@ -1,0 +1,83 @@
+import { TestApp } from "@logion/rest-api-core";
+import { ALICE, BOB } from "@logion/rest-api-core/dist/TestApp.js";
+import { Container } from "inversify";
+import request from "supertest";
+import { It, Mock, Times } from "moq.ts";
+import { IdenfyController } from "../../../src/logion/controllers/idenfy.controller.js";
+import { LocRequestAggregateRoot, LocRequestRepository } from "../../../src/logion/model/locrequest.model.js";
+import { IdenfyService } from "../../../src/logion/services/idenfy/idenfy.service.js";
+
+const { setupApp } = TestApp;
+
+describe("IdenfyController", () => {
+
+    it("creates verification session for LOC requester", async () => {
+        const app = setupApp(IdenfyController, container => mockVerification(container, ALICE));
+
+        await request(app)
+            .post(`/api/idenfy/verification-session/${ REQUEST_ID }`)
+            .expect(200)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.url).toBe(REDIRECT_URL);
+            });
+    });
+
+    it("fails at creating verification session for others", async () => {
+        const app = setupApp(IdenfyController, container => mockVerification(container, BOB));
+
+        await request(app)
+            .post(`/api/idenfy/verification-session/${ REQUEST_ID }`)
+            .expect(401);
+    });
+
+    it("provides iDenfy callback", async () => {
+        const app = setupApp(IdenfyController, mockCallback);
+
+        await request(app)
+            .post(`/api/idenfy/callback/${ SHARED_SECRET }`)
+            .expect(200);
+
+        service.verify(service => service.callback(It.IsAny(), It.IsAny()));
+    });
+
+    it("detects bad secret on callback", async () => {
+        const app = setupApp(IdenfyController, mockCallback);
+
+        await request(app)
+            .post(`/api/idenfy/callback/another-secret`)
+            .expect(403);
+
+        service.verify(service => service.callback(It.IsAny(), It.IsAny()), Times.Never());
+    });
+});
+
+function mockVerification(container: Container, requester: string) {
+    const locRequest = new Mock<LocRequestAggregateRoot>();
+    locRequest.setup(instance => instance.requesterAddress).returns(requester);
+
+    const repository = new Mock<LocRequestRepository>();
+    repository.setup(instance => instance.findById(REQUEST_ID)).returnsAsync(locRequest.object());
+    container.bind(LocRequestRepository).toConstantValue(repository.object());
+
+    service = new Mock<IdenfyService>();
+    service.setup(instance => instance.createVerificationSession(locRequest.object())).returnsAsync({ url: REDIRECT_URL })
+    container.bind(IdenfyService).toConstantValue(service.object());
+}
+
+const REQUEST_ID = "d47d151e-3174-4ab0-846c-088d104ddc1a";
+const REDIRECT_URL = "https://ivs.idenfy.com/api/v2/redirect?authToken=tSfnDiNBT16iP7ThpP6K8QfF2maTK0Vvkxfvq4YV";
+let service: Mock<IdenfyService>;
+
+function mockCallback(container: Container) {
+    process.env.IDENFY_SECRET = SHARED_SECRET;
+
+    const repository = new Mock<LocRequestRepository>();
+    container.bind(LocRequestRepository).toConstantValue(repository.object());
+
+    service = new Mock<IdenfyService>();
+    service.setup(instance => instance.callback(It.IsAny(), It.IsAny())).returnsAsync();
+    container.bind(IdenfyService).toConstantValue(service.object());
+}
+
+const SHARED_SECRET = "some-secret";

--- a/test/unit/services/idenfy/idenfy.service.spec.ts
+++ b/test/unit/services/idenfy/idenfy.service.spec.ts
@@ -1,0 +1,315 @@
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosResponseHeaders, CreateAxiosDefaults } from "axios";
+import { transcode } from "buffer";
+import { It, Mock, PlayTimes } from "moq.ts";
+import { LocRequestAggregateRoot, LocRequestDescription, LocRequestRepository, FileDescription } from "src/logion/model/locrequest.model.js";
+import { AxiosFactory } from "src/logion/services/axiosfactory.service.js";
+import { FileStorageService } from "src/logion/services/file.storage.service.js";
+import { LocRequestService } from "src/logion/services/locrequest.service.js";
+import { ALICE } from "../../../helpers/addresses.js";
+import { DisabledIdenfyService, EnabledIdenfyService } from "../../../../src/logion/services/idenfy/idenfy.service.js";
+import { IdenfyVerificationSession } from "../../../../src/logion/services/idenfy/idenfy.types.js";
+import { NonTransactionalLocRequestService } from "../../../../src/logion/services/locrequest.service.js";
+import { Readable } from "stream";
+
+describe("DisabledIdenfyService", () => {
+
+    it("throws on session creation", async () => {
+        const service = new DisabledIdenfyService();
+        await expectAsync(service.createVerificationSession()).toBeRejectedWithError(Error, "iDenfy integration is disabled");
+    });
+
+    it("throws on callback", async () => {
+        const service = new DisabledIdenfyService();
+        await expectAsync(service.callback()).toBeRejectedWithError(Error, "iDenfy integration is disabled");
+    });
+});
+
+describe("EnabledIdenfyService", () => {
+
+    beforeEach(setupProcessEnv)
+    afterEach(tearDownProcessEnv)
+
+    it("creates verification session", async () => {
+        const { locRequest, idenfyService, authenticatedAxios, locRequestRepository } = mockEnabledIdenfyService();
+        const session: IdenfyVerificationSession = {
+            authToken: "pgYQX0z2T8mtcpNj9I20uWVCLKNuG0vgr12f0wAC",
+            scanRef: IDENFY_SCAN_REF,
+        };
+        authenticatedAxios.setup(instance => instance.post("/token", It.Is<any>(
+            data => data.clientId === REQUEST_ID
+            && data.firstName === "John"
+            && data.lastName === "Doe"
+            && data.successUrl === `${ BASE_URL }/idenfy/success`
+            && data.errorUrl === `${ BASE_URL }/idenfy/error`
+            && data.unverifiedUrl === `${ BASE_URL }/idenfy/unverified`
+            && data.callbackUrl === `${ BASE_URL }/api/idenfy/callback/${ IDENFY_SECRET }`
+        ))).returnsAsync({
+            data: session,
+        } as AxiosResponse);
+
+        const redirect = await idenfyService.createVerificationSession(locRequest.object());
+
+        expect(redirect.url).toBe(`${ EnabledIdenfyService.IDENFY_BASE_URL }/redirect?authToken=${ session.authToken }`);
+        locRequest.verify(instance => instance.initIdenfyVerification(session));
+        locRequestRepository.verify(instance => instance.save(locRequest.object()));
+    });
+
+    it("handles callback", async () => {
+        const { locRequest, idenfyService, locRequestRepository } = mockEnabledIdenfyService();
+
+        const json = JSON.parse(RAW_IDENFY_PAYLOAD);
+        await idenfyService.callback(json, transcode(Buffer.from(RAW_IDENFY_PAYLOAD), "utf8", "utf16le"));
+
+        locRequest.verify(instance => instance.updateIdenfyVerification(json, RAW_IDENFY_PAYLOAD));
+        for(const fileType of Object.keys(EXPECTED_FILES)) {
+            locRequest.verify(instance => instance.addFile(It.Is<FileDescription>(
+                file => file.cid === EXPECTED_FILES[fileType].cid
+                && file.contentType === EXPECTED_FILES[fileType].contentType
+                && file.nature === EXPECTED_FILES[fileType].nature
+                && file.name === EXPECTED_FILES[fileType].name
+                && file.submitter === LOC_OWNER
+            )));
+        }
+        locRequestRepository.verify(instance => instance.save(locRequest.object()));
+    });
+});
+
+function setupProcessEnv() {
+    process.env.IDENFY_SECRET = IDENFY_SECRET;
+    process.env.IDENFY_API_KEY = IDENFY_API_KEY;
+    process.env.IDENFY_API_SECRET = IDENFY_API_SECRET;
+    process.env.BASE_URL = BASE_URL;
+}
+
+function tearDownProcessEnv() {
+    delete process.env.GOERLI_ALCHEMY_KEY;
+}
+
+const REQUEST_ID = "21cc7dbf-7af1-4014-acfd-05bc4a110c82";
+const BASE_URL = "https://node.logion.network";
+const IDENFY_SECRET = "some-secret";
+const IDENFY_API_KEY = "api-key";
+const IDENFY_API_SECRET = "api-secret";
+const IDENFY_SCAN_REF = "3af0b5c9-8ef3-4815-8796-5ab3ed942917";
+const LOC_OWNER = ALICE;
+
+function mockEnabledIdenfyService(): {
+    locRequest: Mock<LocRequestAggregateRoot>,
+    locRequestRepository: Mock<LocRequestRepository>,
+    locRequestService: Mock<LocRequestService>,
+    fileStorageService: Mock<FileStorageService>,
+    axiosFactory: Mock<AxiosFactory>,
+    idenfyService: EnabledIdenfyService,
+    authenticatedAxios: Mock<AxiosInstance>,
+} {
+    const locRequest = new Mock<LocRequestAggregateRoot>();
+    locRequest.setup(instance => instance.id).returns(REQUEST_ID);
+    locRequest.setup(instance => instance.ownerAddress).returns(LOC_OWNER);
+    const description = new Mock<LocRequestDescription>();
+    description.setup(instance => instance.userIdentity).returns({
+        firstName: "John",
+        lastName: "Doe",
+        email: "john@logion.network",
+        phoneNumber: "+1234",
+    });
+    locRequest.setup(instance => instance.getDescription()).returns(description.object());
+    locRequest.setup(instance => instance.canInitIdenfyVerification()).returns({ result: true });
+    locRequest.setup(instance => instance.initIdenfyVerification(It.IsAny())).returns();
+    locRequest.setup(instance => instance.updateIdenfyVerification(It.IsAny(), It.IsAny())).returns();
+    locRequest.setup(instance => instance.addFile(It.IsAny())).returns();
+
+    const locRequestRepository = new Mock<LocRequestRepository>();
+    locRequestRepository.setup(instance => instance.findById(REQUEST_ID)).returnsAsync(locRequest.object());
+    locRequestRepository.setup(instance => instance.save(It.IsAny())).returnsAsync();
+
+    const locRequestService = new Mock<LocRequestService>();
+
+    const fileStorageService = new Mock<FileStorageService>();
+    // In reverse order of actual addition by service, otherwise CIDs won't match
+    fileStorageService
+        .setup(instance => instance.importFile(It.IsAny()))
+        .play(PlayTimes.Once())
+        .returnsAsync(EXPECTED_FILES.FACE.cid!);
+    fileStorageService
+        .setup(instance => instance.importFile(It.IsAny()))
+        .play(PlayTimes.Once())
+        .returnsAsync(EXPECTED_FILES.BACK.cid!);
+    fileStorageService
+        .setup(instance => instance.importFile(It.IsAny()))
+        .play(PlayTimes.Once())
+        .returnsAsync(EXPECTED_FILES.FRONT.cid!);
+    fileStorageService
+        .setup(instance => instance.importFile(It.IsAny()))
+        .play(PlayTimes.Once())
+        .returnsAsync(EXPECTED_FILES.PAYLOAD.cid!);
+
+    const axiosFactory = new Mock<AxiosFactory>();
+    const authenticatedAxios = new Mock<AxiosInstance>();
+    axiosFactory.setup(instance => instance.create(It.Is<CreateAxiosDefaults>(
+        config => config.baseURL === EnabledIdenfyService.IDENFY_BASE_URL
+        && config.auth?.username === IDENFY_API_KEY
+        && config.auth?.password === IDENFY_API_SECRET
+    ))).returns(authenticatedAxios.object());
+
+    const defaultAxios = new Mock<AxiosInstance>();
+    defaultAxios.setup(instance => instance.get(FRONT_URL, It.Is<AxiosRequestConfig<any>>(config => config.responseType === "stream")))
+        .returnsAsync(buildStreamResponse("front"));
+    defaultAxios.setup(instance => instance.get(BACK_URL, It.Is<AxiosRequestConfig<any>>(config => config.responseType === "stream")))
+        .returnsAsync(buildStreamResponse("back"));
+    defaultAxios.setup(instance => instance.get(FACE_URL, It.Is<AxiosRequestConfig<any>>(config => config.responseType === "stream")))
+        .returnsAsync(buildStreamResponse("face"));
+    axiosFactory.setup(instance => instance.create()).returns(defaultAxios.object());
+
+    const idenfyService = new EnabledIdenfyService(
+        locRequestRepository.object(),
+        new NonTransactionalLocRequestService(locRequestRepository.object()),
+        fileStorageService.object(),
+        axiosFactory.object(),
+    );
+    return {
+        locRequest,
+        locRequestRepository,
+        locRequestService,
+        fileStorageService,
+        axiosFactory,
+        idenfyService,
+        authenticatedAxios,
+    };
+}
+
+// based on https://documentation.idenfy.com/callbacks/ResultCallback#examples
+const FRONT_URL = "https://s3.eu-west-1.amazonaws.com/production.users.storage/users_storage/users/some-hash/FRONT.png?AWSAccessKeyId=some-key&Signature=some-sig&Expires=1671104387";
+const BACK_URL = "https://s3.eu-west-1.amazonaws.com/production.users.storage/users_storage/users/some-hash/BACK.png?AWSAccessKeyId=some-key&Signature=some-sig&Expires=1671104387";
+const FACE_URL = "https://s3.eu-west-1.amazonaws.com/production.users.storage/users_storage/users/some-hash/FACE.png?AWSAccessKeyId=some-key&Signature=some-sig&Expires=1671104387";
+const RAW_IDENFY_PAYLOAD = `{
+    "clientId": "${ REQUEST_ID }",
+    "scanRef": "${ IDENFY_SCAN_REF }",
+    "externalRef": "external-ref",
+    "platform": "MOBILE_APP",
+    "startTime": 1554726960, 
+    "finishTime": 1554727002,
+    "clientIp": "192.0.2.0",
+    "clientIpCountry": "LT",
+    "clientLocation": "Kaunas, Lithuania",
+    "final": true,
+    "status": {
+        "overall": "APPROVED",
+        "suspicionReasons": [],
+        "mismatchTags": [],
+        "fraudTags": [],
+        "autoDocument": "DOC_VALIDATED",
+        "autoFace": "FACE_MATCH",
+        "manualDocument": "DOC_VALIDATED",
+        "manualFace": "FACE_MATCH",
+        "additionalSteps": null
+    },
+    "data": {
+        "docFirstName": "FIRST-NAME-EXAMPLE",
+        "docLastName": "LAST-NAME-EXAMPLE",
+        "docNumber": "XXXXXXXXX",
+        "docPersonalCode": "XXXXXXXXX",
+        "docExpiry": "YYYY-MM-DD",
+        "docDob": "YYYY-MM-DD",
+        "docType": "ID_CARD",
+        "docSex": "UNDEFINED",
+        "docNationality": "LT",
+        "docIssuingCountry": "LT",
+        "manuallyDataChanged": false,
+        "fullName": "FULL-NAME-EXAMPLE",
+        "selectedCountry": "LT",
+        "orgFirstName": "FIRST-NAME-EXAMPLE",
+        "orgLastName":  "LAST-NAME-EXAMPLE",
+        "orgNationality": "LIETUVOS",
+        "orgBirthPlace": "ŠILUVA",
+        "orgAuthority": null,
+        "orgAddress": null,
+        "selectedCountry": "LT",
+        "ageEstimate": "UNDER_13",
+        "clientIpProxyRiskLevel": "LOW",
+        "duplicateDocFaces": null,
+        "duplicateFaces": null,
+        "additionalData": {
+            "UTILITY_BILL": {
+                "ssn": {
+                    "value": "ssn number",
+                    "status": "MATCH"
+                }
+            }
+        },
+        "manualAddress": null,
+        "manualAddressMatch": false
+    },
+    "fileUrls": {
+        "FRONT": "${ FRONT_URL }",
+        "BACK": "${ BACK_URL }",
+        "FACE": "${ FACE_URL }"
+    },
+    "AML": [
+        {
+            "status": {
+                "serviceSuspected": false,
+                "checkSuccessful": true,
+                "serviceFound": true,
+                "serviceUsed": true,
+                "overallStatus": "NOT_SUSPECTED"
+            },
+            "data": [],
+            "serviceName": "PilotApiAmlV2",
+            "serviceGroupType": "AML",
+            "uid": "OHT8GR5ESRF5XROWE5ZGCC123",
+            "errorMessage": null
+        }
+    ],
+    "LID": [
+        {
+            "status": {
+                "serviceSuspected": false,
+                "checkSuccessful": true,
+                "serviceFound": true,
+                "serviceUsed": true,
+                "overallStatus": "NOT_SUSPECTED"
+            },
+            "data": [],
+            "serviceName": "IrdInvalidPapers",
+            "serviceGroupType": "LID",
+            "uid": "OHT8GR5ESRF5XROWE5ZGCC123",
+            "errorMessage": null
+        }
+    ]
+}`;
+
+const EXPECTED_FILES: Record<string, Partial<FileDescription>> = {
+    FACE: {
+        cid: "cid-3",
+        contentType: "image/png",
+        nature: "iDenfy FACE",
+        name: "FACE.png",
+    },
+    BACK: {
+        cid: "cid-2",
+        contentType: "image/png",
+        nature: "iDenfy BACK",
+        name: "BACK.png",
+    },
+    FRONT: {
+        cid: "cid-1",
+        contentType: "image/png",
+        nature: "iDenfy FRONT",
+        name: "FRONT.png",
+    },
+    PAYLOAD: {
+        cid: "cid-0",
+        contentType: "application/json",
+        nature: "iDenfy Verification Result",
+        name: "idenfy-callback-payload.json",
+    },
+};
+
+function buildStreamResponse(data: string): AxiosResponse {
+    const response = new Mock<AxiosResponse>();
+    response.setup(instance => instance.data).returns(Readable.from(Buffer.from(data)));
+    const headers = new Mock<AxiosResponseHeaders>();
+    headers.setup(instance => instance["content-type"]).returns("image/png");
+    response.setup(instance => instance.headers).returns(headers.object());
+    return response.object();
+}


### PR DESCRIPTION
* Fixes a few remaining issues with ES module packaging (migrations, integration tests).
* Adds integration with iDenfy (ability to request a verification session and webhook to receive data).

logion-network/logion-internal#710