### PR TITLE
Enable large file download

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "body-parser": "^1.20.1",
         "bson": "^4.7.0",
         "cors": "^2.8.5",
-        "ipfs-client": "^0.9.2",
+        "ipfs-client": "^0.10.0",
         "moment": "^2.29.4",
         "node-fetch": "^3.3.0",
         "nodemailer": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,32 +1577,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ipld/dag-cbor@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@ipld/dag-cbor@npm:8.0.0"
+"@ipld/dag-cbor@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@ipld/dag-cbor@npm:9.0.0"
   dependencies:
-    cborg: ^1.6.0
-    multiformats: ^10.0.2
-  checksum: ebf2f9c3d0bbcdd6511e9c49b3a33dd788be2a7d7f114dc2ec9ecd5b04fdd4fc7b8e6f01a1a1afe396deb1196c1da3cef23c94e82812c8e2bc317d51c7f70ee5
+    cborg: ^1.10.0
+    multiformats: ^11.0.0
+  checksum: 8f432c018b5176812a150fcecfd96ec9cfae3d1fe267a32439d037f8fb27d25bba920ee82ed034cc26ff1a624848a0028ebbf09cd36157033fff618b5e9801a3
   languageName: node
   linkType: hard
 
-"@ipld/dag-json@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "@ipld/dag-json@npm:9.0.1"
+"@ipld/dag-json@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@ipld/dag-json@npm:10.0.0"
   dependencies:
-    cborg: ^1.5.4
-    multiformats: ^10.0.2
-  checksum: e4bc27dfa8489eec6783467f76314bf19f2d6764def3ad8d8ebaf0c85e770d4c296444f10bc2e8f4fb4a4adb702621ea9d3a778222502405d6965528801e1624
+    cborg: ^1.10.0
+    multiformats: ^11.0.0
+  checksum: d496b09c84e817ef88b97247df1cce9cad2200b5d92e2c6a5e9315ab04fec57f82adc11fe77f29681f605ec069057b9f91eade4e6c2f0a742ac7404ca880838a
   languageName: node
   linkType: hard
 
-"@ipld/dag-pb@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "@ipld/dag-pb@npm:3.0.1"
+"@ipld/dag-pb@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@ipld/dag-pb@npm:4.0.0"
   dependencies:
-    multiformats: ^10.0.2
-  checksum: e5b109a463a3c196dd6dcd3584f2e6ee8f71ff24d1b6bba10330d268fd46b401f89215e90946216a71745981ca086fc2101baec8b4f1684c33f999101e736636
+    multiformats: ^11.0.0
+  checksum: d148a86b46e04ad5860a7e7716069b017385a048762b2f87d3f630b841b1a7641f6ff0138bf5f99ac170f118a3c46dc0b729eb3e3f6bf51784bfd9fa63ef16e5
   languageName: node
   linkType: hard
 
@@ -1712,21 +1712,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@libp2p/interface-keychain@npm:^1.0.3":
-  version: 1.0.5
-  resolution: "@libp2p/interface-keychain@npm:1.0.5"
+"@libp2p/interface-keychain@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "@libp2p/interface-keychain@npm:2.0.3"
   dependencies:
-    multiformats: ^10.0.0
-  checksum: 5e2d7d1ecf92b074a0a5cd4dd4faf5ad3f58e257f989015a5f042f0168a62725dd3617b3f6e2c00977953f12f8d95ef9d0c9eca0a068cad2efed446558762a58
+    "@libp2p/interface-peer-id": ^2.0.0
+    multiformats: ^11.0.0
+  checksum: 61ec8eb5aa978b952a6ac8fbf00c03b43bab229d94cdca57875c8bbba7327d775c281fdf42e8b5ac434ea9e9a9e916a1bc0be964d8b5ce7d042b5bb7c1527e75
   languageName: node
   linkType: hard
 
-"@libp2p/interface-peer-id@npm:^1.0.0, @libp2p/interface-peer-id@npm:^1.0.2, @libp2p/interface-peer-id@npm:^1.0.4":
+"@libp2p/interface-peer-id@npm:^1.0.0, @libp2p/interface-peer-id@npm:^1.0.2":
   version: 1.1.0
   resolution: "@libp2p/interface-peer-id@npm:1.1.0"
   dependencies:
     multiformats: ^10.0.0
   checksum: e078e907c6a2a4fb4326f8c25de9d3e55d53dfc67b28a896434ec463e3ef3c92573480ddff73845c47120a7bf692112f22a19f04f05d78ddcc5923e5b5cd4a4f
+  languageName: node
+  linkType: hard
+
+"@libp2p/interface-peer-id@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "@libp2p/interface-peer-id@npm:2.0.1"
+  dependencies:
+    multiformats: ^11.0.0
+  checksum: 05e286725be50a6397a11b03f3edd6e64ec311782d96732f1185c0a9e94af6f879944198cd75d73b9883bb86b2fd91de9bf10e0462943e1f6b4a6f5d8126d186
   languageName: node
   linkType: hard
 
@@ -1760,6 +1770,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@libp2p/interfaces@npm:^3.2.0":
+  version: 3.3.1
+  resolution: "@libp2p/interfaces@npm:3.3.1"
+  checksum: bc307cfb3e6cae6cb6be9fac7210180f031d85a8dd6c0b4d93ee8f0c4162b35355afd6c825586d9591869a94d04b71ed22a60d4dbce54c51d9ce144aac2d0161
+  languageName: node
+  linkType: hard
+
 "@libp2p/logger@npm:^2.0.0":
   version: 2.0.2
   resolution: "@libp2p/logger@npm:2.0.2"
@@ -1772,15 +1789,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@libp2p/peer-id@npm:^1.1.10":
-  version: 1.1.17
-  resolution: "@libp2p/peer-id@npm:1.1.17"
+"@libp2p/peer-id@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "@libp2p/peer-id@npm:2.0.1"
   dependencies:
-    "@libp2p/interface-peer-id": ^1.0.0
-    err-code: ^3.0.1
-    multiformats: ^10.0.0
+    "@libp2p/interface-peer-id": ^2.0.0
+    "@libp2p/interfaces": ^3.2.0
+    multiformats: ^11.0.0
     uint8arrays: ^4.0.2
-  checksum: 210cce4d2403af0e9a31267920f2311ff73ce7bddbb97dd8c5ef42b8b21d0e841be04072ae10004056e9066b91c2feb71a55c311eb1c9e69f020381b2d38fb64
+  checksum: 51a055d887f30685cfabf42d4974b2f78ca3e50ea9cbb4b61163f1f166d3a5ca452de90ae58415227a0f87cf61452495bee78247c26772f9673df92152358262
   languageName: node
   linkType: hard
 
@@ -3213,6 +3230,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browser-readablestream-to-it@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "browser-readablestream-to-it@npm:1.0.3"
+  checksum: 07895bbc54cdeea62c8e9b7e32d374ec5c340ed1d0bc0c6cd6f1e0561ad931b160a3988426c763672ddf38ac1f75e45b9d8ae267b43f387183edafcad625f30a
+  languageName: node
+  linkType: hard
+
 "browser-readablestream-to-it@npm:^2.0.0":
   version: 2.0.0
   resolution: "browser-readablestream-to-it@npm:2.0.0"
@@ -3441,12 +3465,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cborg@npm:^1.5.4, cborg@npm:^1.6.0":
-  version: 1.9.4
-  resolution: "cborg@npm:1.9.4"
+"cborg@npm:^1.10.0":
+  version: 1.10.0
+  resolution: "cborg@npm:1.10.0"
   bin:
     cborg: cli.js
-  checksum: bc9cf6907fe1806d8276b6226790c2f57b6794e96b82635face5f6cadb8b2d82564ab8de954b24da531068cc06feb57d38b07b4dce1545e3dfadacf40519984b
+  checksum: e93ce1135e1bf2cf6a4fa33bc7577b699ce306c6bbf53cfc1c34fca652b95a6f440f6ef0fe123097e3ef6e424a798abbb79a543cf2bd0ca0aeadc384f492a81a
   languageName: node
   linkType: hard
 
@@ -3834,13 +3858,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dag-jose@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "dag-jose@npm:3.0.1"
+"dag-jose@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "dag-jose@npm:4.0.0"
   dependencies:
-    "@ipld/dag-cbor": ^8.0.0
-    multiformats: ^10.0.1
-  checksum: 5df23b3e90f78b6311068a3266b166ea592f280918b8e5c07528f94ae37df7afbd5d09d1ad5f0b271e4f084ac7b2fc56f9d886aea1ab8efc85602469afd12a62
+    "@ipld/dag-cbor": ^9.0.0
+    multiformats: ^11.0.0
+  checksum: 1d7c2620cf78132617dc6fa7c44417d0b88f95f469492b72d776b70bf6b8170f47f06aa67dde3b09796908fec3d5277db7e0329e400a8155ec4630e90d8c1812
   languageName: node
   linkType: hard
 
@@ -5042,38 +5066,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ipfs-client@npm:^0.9.2":
-  version: 0.9.2
-  resolution: "ipfs-client@npm:0.9.2"
+"ipfs-client@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "ipfs-client@npm:0.10.0"
   dependencies:
-    ipfs-grpc-client: ^0.12.0
-    ipfs-http-client: ^59.0.0
+    ipfs-grpc-client: ^0.13.0
+    ipfs-http-client: ^60.0.0
     merge-options: ^3.0.4
-  checksum: 204fe324480df4cd739abf0c1f7602bbb9b8cede67ba91cec19af793ad451cc4a11018b2d533ff4ad26fb2263d1b2f056212a3fbb32811e22a761359b85715ce
+  checksum: 2e3015ecf527ea0ec841c72a647f1cd4d327b2d059883b57d8002d874a13ffb95ae807fca6c705e01b81fcd424a7272d488334b4b1b1c6a9f14aa9c93792a3a5
   languageName: node
   linkType: hard
 
-"ipfs-core-types@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "ipfs-core-types@npm:0.13.0"
+"ipfs-core-types@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "ipfs-core-types@npm:0.14.0"
   dependencies:
-    "@ipld/dag-pb": ^3.0.0
-    "@libp2p/interface-keychain": ^1.0.3
-    "@libp2p/interface-peer-id": ^1.0.4
+    "@ipld/dag-pb": ^4.0.0
+    "@libp2p/interface-keychain": ^2.0.0
+    "@libp2p/interface-peer-id": ^2.0.0
     "@libp2p/interface-peer-info": ^1.0.2
     "@libp2p/interface-pubsub": ^3.0.0
     "@multiformats/multiaddr": ^11.0.0
     "@types/node": ^18.0.0
     interface-datastore: ^7.0.0
-    ipfs-unixfs: ^8.0.0
-    multiformats: ^10.0.0
-  checksum: 86e6421abe233d83e5cb8aff040246db035744abe2a96ae88caa0a43769e9e10a4eae7fb5cb1fb6b49e3cbb58aa9025b447d7ce250776a851efaaab0e68414be
+    ipfs-unixfs: ^9.0.0
+    multiformats: ^11.0.0
+  checksum: f5aedde56336cf5d30bfc4067605b0ebc2f4be76fab5d5cca3addc9fbb969ae1fce32de7095dc0ee511baacd38020234704b8ea5e0b30ade7100a9e1c41eaa37
   languageName: node
   linkType: hard
 
-"ipfs-core-utils@npm:^0.17.0":
-  version: 0.17.0
-  resolution: "ipfs-core-utils@npm:0.17.0"
+"ipfs-core-utils@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "ipfs-core-utils@npm:0.18.0"
   dependencies:
     "@libp2p/logger": ^2.0.0
     "@multiformats/multiaddr": ^11.0.0
@@ -5082,112 +5106,114 @@ __metadata:
     blob-to-it: ^2.0.0
     browser-readablestream-to-it: ^2.0.0
     err-code: ^3.0.1
-    ipfs-core-types: ^0.13.0
-    ipfs-unixfs: ^8.0.0
-    ipfs-utils: ^9.0.6
+    ipfs-core-types: ^0.14.0
+    ipfs-unixfs: ^9.0.0
+    ipfs-utils: ^9.0.13
     it-all: ^2.0.0
     it-map: ^2.0.0
     it-peekable: ^2.0.0
     it-to-stream: ^1.0.0
     merge-options: ^3.0.4
-    multiformats: ^10.0.0
+    multiformats: ^11.0.0
     nanoid: ^4.0.0
     parse-duration: ^1.0.0
     timeout-abort-controller: ^3.0.0
     uint8arrays: ^4.0.2
-  checksum: 01360173080292a1c7bfea7913db3c55aeb5b5c776535e4e1ac1e7760554cf8c6094d6b549538ff450d91297236cedac7e70581d09cdcb6d7cce0806659aaede
+  checksum: 43ffed719da05703a0e3245dacecc079e81c9501dea210cc2e02bbe41c41f4cbac54b2b11e3c5ca6150760b02635b4cb9b064799377183b0bf184e11a4d1d1a2
   languageName: node
   linkType: hard
 
-"ipfs-grpc-client@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "ipfs-grpc-client@npm:0.12.0"
+"ipfs-grpc-client@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "ipfs-grpc-client@npm:0.13.0"
   dependencies:
     "@improbable-eng/grpc-web": ^0.15.0
     "@libp2p/logger": ^2.0.0
-    "@libp2p/peer-id": ^1.1.10
+    "@libp2p/peer-id": ^2.0.0
     "@multiformats/multiaddr": ^11.0.0
     change-case: ^4.1.1
     err-code: ^3.0.1
-    ipfs-core-types: ^0.13.0
-    ipfs-core-utils: ^0.17.0
-    ipfs-grpc-protocol: ^0.7.0
-    ipfs-unixfs: ^8.0.0
+    ipfs-core-types: ^0.14.0
+    ipfs-core-utils: ^0.18.0
+    ipfs-grpc-protocol: ^0.8.0
+    ipfs-unixfs: ^9.0.0
     it-first: ^2.0.0
     it-pushable: ^3.0.0
-    multiformats: ^10.0.0
+    multiformats: ^11.0.0
     p-defer: ^4.0.0
     protobufjs: ^7.0.0
     uint8arrays: ^4.0.2
     wherearewe: ^2.0.1
     ws: ^8.5.0
-  checksum: 335808aba07a3689ffb2f998b7b5e8060fc99e4e3ad41be28aa32c977ed703ffef106d900958dfa5764b87a66f54e9447f6572609a8d629c964c643351a0c561
+  checksum: 75839e3eeef7a94b9b0f41b3e0d97de9c25f1cf9f523d05c60ec4f20ca8c20754039c312743ea7fab0054cc7be92f2ed3f37b0c5a5a676dbb67d587aa9311c02
   languageName: node
   linkType: hard
 
-"ipfs-grpc-protocol@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "ipfs-grpc-protocol@npm:0.7.0"
-  checksum: 81d4ae2325754f685cc6d6a8ca78285bcdf6e07ef856863e8e5c794ba3759383fa3683a99c90c076ec51d84074256727842d3a189548b986fe533429c58f7fe3
+"ipfs-grpc-protocol@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "ipfs-grpc-protocol@npm:0.8.0"
+  checksum: aaad02af3b1ba3eb6e20b25948c47d1895e45ecaa922411af4c80df6026a07357b4fb07fe2ea23a7c95bcccc23433952c587844cd373182db5ad3bdd178cf798
   languageName: node
   linkType: hard
 
-"ipfs-http-client@npm:^59.0.0":
-  version: 59.0.0
-  resolution: "ipfs-http-client@npm:59.0.0"
+"ipfs-http-client@npm:^60.0.0":
+  version: 60.0.0
+  resolution: "ipfs-http-client@npm:60.0.0"
   dependencies:
-    "@ipld/dag-cbor": ^8.0.0
-    "@ipld/dag-json": ^9.0.0
-    "@ipld/dag-pb": ^3.0.0
+    "@ipld/dag-cbor": ^9.0.0
+    "@ipld/dag-json": ^10.0.0
+    "@ipld/dag-pb": ^4.0.0
     "@libp2p/logger": ^2.0.0
-    "@libp2p/peer-id": ^1.1.10
+    "@libp2p/peer-id": ^2.0.0
     "@multiformats/multiaddr": ^11.0.0
     any-signal: ^3.0.0
-    dag-jose: ^3.0.1
+    dag-jose: ^4.0.0
     err-code: ^3.0.1
-    ipfs-core-types: ^0.13.0
-    ipfs-core-utils: ^0.17.0
-    ipfs-utils: ^9.0.6
+    ipfs-core-types: ^0.14.0
+    ipfs-core-utils: ^0.18.0
+    ipfs-utils: ^9.0.13
     it-first: ^2.0.0
     it-last: ^2.0.0
     merge-options: ^3.0.4
-    multiformats: ^10.0.0
+    multiformats: ^11.0.0
     parse-duration: ^1.0.0
     stream-to-it: ^0.2.2
     uint8arrays: ^4.0.2
-  checksum: 6c7343ca1d75f82565176c783643ba2e108846aa5bbf40ab904071bc34a1261878d451bc9eb6803950e35c5d5f2f1b0536637722625dd4e82ac222cd4294acf4
+  checksum: cabb74aefe214fb7cfcb5a6ca8257672d67043a4b05ab594106fbce46646c7de8410cf960aeaef6f60173ae66d95062b6282806bdf4741a4e7cf43840d7078e1
   languageName: node
   linkType: hard
 
-"ipfs-unixfs@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "ipfs-unixfs@npm:8.0.0"
+"ipfs-unixfs@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "ipfs-unixfs@npm:9.0.0"
   dependencies:
     err-code: ^3.0.1
     protobufjs: ^7.0.0
-  checksum: 681d54714960c82644ef9da810c298761f70fd890a2b4cbf67e481ab76a9935477d27022c538815bc40bcd42936f728cdce650dd8446dc19662f45d5e584e001
+  checksum: d9036771f02d8238ab6b7235786cceb3d4372b3e046b69377091f6fb7a93a679df2e5823a4270d6c4d5510e1ea80001ea9913c037f9a00cabb20e36cfb4aaf3f
   languageName: node
   linkType: hard
 
-"ipfs-utils@npm:^9.0.6":
-  version: 9.0.7
-  resolution: "ipfs-utils@npm:9.0.7"
+"ipfs-utils@npm:^9.0.13":
+  version: 9.0.14
+  resolution: "ipfs-utils@npm:9.0.14"
   dependencies:
     any-signal: ^3.0.0
+    browser-readablestream-to-it: ^1.0.0
     buffer: ^6.0.1
     electron-fetch: ^1.7.2
     err-code: ^3.0.1
     is-electron: ^2.2.0
     iso-url: ^1.1.5
+    it-all: ^1.0.4
     it-glob: ^1.0.1
     it-to-stream: ^1.0.0
     merge-options: ^3.0.4
     nanoid: ^3.1.20
     native-fetch: ^3.0.0
-    node-fetch: "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz"
-    react-native-fetch-api: ^2.0.0
+    node-fetch: ^2.6.8
+    react-native-fetch-api: ^3.0.0
     stream-to-it: ^0.2.2
-  checksum: 3b60b5cda15788c1f64aea4a7b096f8914c1b247e9095059464a841377d4a326aa6be64652c303dc71957d739ee404a68bb59889b1ce6d8ce9974fa3722978e2
+  checksum: 08108e03ea7b90e0fa11b76a4e24bd29d7e027c603494b53c1cc37b367fb559eaeea7b0f10b2e83ee419d50cdcb4d8105febdf185cab75c7e55afd4c8ed51aba
   languageName: node
   linkType: hard
 
@@ -5415,6 +5441,13 @@ __metadata:
     html-escaper: ^2.0.0
     istanbul-lib-report: ^3.0.0
   checksum: 7867228f83ed39477b188ea07e7ccb9b4f5320b6f73d1db93a0981b7414fa4ef72d3f80c4692c442f90fc250d9406e71d8d7ab65bb615cb334e6292b73192b89
+  languageName: node
+  linkType: hard
+
+"it-all@npm:^1.0.4":
+  version: 1.0.6
+  resolution: "it-all@npm:1.0.6"
+  checksum: 7ca9a528c08ebe2fc8a3c93a41409219d18325ed31fedb9834ebac2822f0b2a96d7abcb6cbfa092114ab4d5f08951e694c7a2c3929ce4b5300769e710ae665db
   languageName: node
   linkType: hard
 
@@ -5718,7 +5751,7 @@ __metadata:
     bson: ^4.7.0
     cors: ^2.8.5
     dotenv: ^16.0.3
-    ipfs-client: ^0.9.2
+    ipfs-client: ^0.10.0
     jasmine: ^4.5.0
     jasmine-spec-reporter: ^7.0.0
     moment: ^2.29.4
@@ -6159,10 +6192,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multiformats@npm:^10.0.0, multiformats@npm:^10.0.1, multiformats@npm:^10.0.2":
+"multiformats@npm:^10.0.0":
   version: 10.0.2
   resolution: "multiformats@npm:10.0.2"
   checksum: 8807dd130ed44f12713e9e85932e582b321e4c75be373ecb0e14393fe8c44663455357ee25d3710ad7df9bab6fd0127f8797f3ceb80f503ad664f3ff684daef3
+  languageName: node
+  linkType: hard
+
+"multiformats@npm:^11.0.0":
+  version: 11.0.1
+  resolution: "multiformats@npm:11.0.1"
+  checksum: 056dec14b5ee0570eaa43204385bc16783f93dc8668a8ddcee806c4232adfa58cfc272abb587ce94d9314627eb6f2c115e53ff01169c9909768f8c7d0deaa9e6
   languageName: node
   linkType: hard
 
@@ -6288,13 +6328,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz":
-  version: 2.6.7
-  resolution: "node-fetch@https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz"
-  checksum: 1695ebfd42e08640aac6503f15db93a53c3802b5e23f72121ad3621a7ddf5d754d2014d98eab5c76b3003e7394110206f6e39d6310ec9a095827087b67e5e091
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:^2.6.1":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
@@ -6306,6 +6339,20 @@ __metadata:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.8":
+  version: 2.6.8
+  resolution: "node-fetch@npm:2.6.8"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 91f57be68e29f9b1382750693619e199733a6936998e6d618f1aa779853ad8fc4a2facf170db7957bf1d2510bad33449edf74b5802713d81b63de5986fa3be00
   languageName: node
   linkType: hard
 
@@ -7245,12 +7292,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-fetch-api@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "react-native-fetch-api@npm:2.0.0"
+"react-native-fetch-api@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "react-native-fetch-api@npm:3.0.0"
   dependencies:
     p-defer: ^3.0.0
-  checksum: 1696e365db9fb10949f3e60d9fac7f2087fb4a0c51eedd168b6393c8c1198b507b408c56e52f470d2e7cf2c1831e1189bc8d7fed4c1574ef98ffdc3bf0ec746f
+  checksum: f10f435060551c470711ba0b3663e3d49c7701aae84ea645d66992d756b13e923fb5762b324d3583d85c1c0def4138b9cc3f686bab1c1bc10d3ad82dc7175c99
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Downloading large files from IPFS was causing a memory leak because data were downloaded faster than being written to disk.
* Implementing an explicit "back pressure" mechanism solves the issue.

logion-network/logion-internal#736