### PR TITLE
Restricted delivery of collection files.

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -608,6 +608,10 @@
                                 "submitter": {
                                     "type": "string",
                                     "description": "The SS58 address of the file submitter"
+                                },
+                                "restrictedDelivery": {
+                                    "type": "boolean",
+                                    "description": "true if the file can be downloaded by collection item owner. Applicable only for collection."
                                 }
                             }
                         }
@@ -913,6 +917,10 @@
                     "nature": {
                         "type": "string",
                         "description": "The file's nature"
+                    },
+                    "restrictedDelivery": {
+                        "type": "boolean",
+                        "description": "true if the file can be downloaded by collection item owner. Applicable only for collection."
                     }
                 }
             },
@@ -1299,6 +1307,15 @@
                                 "No"
                             ]
                         }
+                    }
+                }
+            },
+            "UpdateCollectionFile": {
+                "type": "object",
+                "properties": {
+                    "restrictedDelivery": {
+                        "type": "boolean",
+                        "description": "true if the file can be downloaded by collection item owner. Applicable only for collection."
                     }
                 }
             }

--- a/src/logion/controllers/adapters/locrequestadapter.ts
+++ b/src/logion/controllers/adapters/locrequestadapter.ts
@@ -74,6 +74,7 @@ export class LocRequestAdapter {
                 nature: file.nature,
                 addedOn: file.addedOn?.toISOString() || undefined,
                 submitter: file.submitter,
+                restrictedDelivery: file.restrictedDelivery,
             })),
             metadata: request.getMetadataItems(viewer).map(item => ({
                 name: item.name,

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -376,6 +376,8 @@ export interface components {
           addedOn?: string;
           /** @description The SS58 address of the file submitter */
           submitter?: string;
+          /** @description true if the file can be downloaded by collection item owner. Applicable only for collection. */
+          restrictedDelivery?: boolean;
         })[];
       /** @description The links attached to this request's LOC */
       links?: ({
@@ -548,6 +550,8 @@ export interface components {
       hash?: string;
       /** @description The file's nature */
       nature?: string;
+      /** @description true if the file can be downloaded by collection item owner. Applicable only for collection. */
+      restrictedDelivery?: boolean;
     };
     AddLinkView: {
       /** @description The link's target */
@@ -771,6 +775,10 @@ export interface components {
       ballots?: {
         [key: string]: ("Yes" | "No") | undefined;
       };
+    };
+    UpdateCollectionFile: {
+      /** @description true if the file can be downloaded by collection item owner. Applicable only for collection. */
+      restrictedDelivery?: boolean;
     };
   };
   responses: never;

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -522,6 +522,7 @@ export class LocRequestController extends ApiController {
                     cid,
                     nature: addFileView.nature || "",
                     submitter: contributor,
+                    restrictedDelivery: addFileView.restrictedDelivery || false,
                 });
             });
         } catch(e) {
@@ -532,7 +533,7 @@ export class LocRequestController extends ApiController {
     static downloadFile(spec: OpenAPIV3.Document) {
         const operationObject = spec.paths["/api/loc-request/{requestId}/files/{hash}"].get!;
         operationObject.summary = "Downloads a file of the LOC";
-        operationObject.description = "The authenticated user must be the owner of the LOC.";
+        operationObject.description = "The authenticated user must be contributor or voter of the LOC.";
         operationObject.responses = getDefaultResponsesWithAnyBody();
         setPathParameters(operationObject, {
             'requestId': "The ID of the LOC",

--- a/src/logion/migration/1674555122425-AddRestrictedDeliveryToCollectionFile.ts
+++ b/src/logion/migration/1674555122425-AddRestrictedDeliveryToCollectionFile.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddRestrictedDeliveryToCollectionFile1674555122425 implements MigrationInterface {
+    name = 'AddRestrictedDeliveryToCollectionFile1674555122425'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request_file" ADD "restricted_delivery" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request_file" DROP COLUMN "restricted_delivery"`);
+    }
+
+}

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -48,6 +48,7 @@ export interface FileDescription {
     readonly nature: string;
     readonly addedOn?: Moment;
     readonly submitter: string;
+    readonly restrictedDelivery: boolean;
 }
 
 export interface MetadataItemDescription {
@@ -254,6 +255,7 @@ export class LocRequestAggregateRoot {
             nature: file!.nature!,
             submitter: file!.submitter!,
             addedOn: file!.addedOn !== undefined ? moment(file!.addedOn) : undefined,
+            restrictedDelivery: file!.restrictedDelivery || false,
         };
     }
 
@@ -720,6 +722,15 @@ export class LocFile extends Child implements HasIndex, Submitted {
     @JoinColumn({ name: "request_id", referencedColumnName: "id" })
     request?: LocRequestAggregateRoot;
 
+    @Column("boolean", { name: "restricted_delivery", default: false })
+    restrictedDelivery?: boolean;
+
+    update(restrictedDelivery: boolean) {
+        if (this.request?.locType !== 'Collection') {
+            throw Error("Can change restricted delivery of file only on Collection LOC.")
+        }
+        this.restrictedDelivery = restrictedDelivery;
+    }
 }
 
 @Entity("loc_metadata_item")

--- a/src/logion/services/idenfy/idenfy.service.ts
+++ b/src/logion/services/idenfy/idenfy.service.ts
@@ -166,6 +166,7 @@ export class EnabledIdenfyService extends IdenfyService {
             submitter,
             hash,
             cid,
+            restrictedDelivery: false,
         });
 
         for(const fileType of IdenfyCallbackPayloadFileTypes) {
@@ -179,6 +180,7 @@ export class EnabledIdenfyService extends IdenfyService {
                     contentType,
                     hash,
                     cid,
+                    restrictedDelivery: false,
                 });
             }
         }

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -270,6 +270,7 @@ function givenLoc(id: string, locType: LocType, status: "OPEN" | "DRAFT"): LocRe
         contentType: "content/type",
         nature: "nature1",
         submitter: SUBMITTER,
+        restrictedDelivery: false,
     })
     locRequest.metadata = []
     locRequest.addMetadataItem({

--- a/test/unit/controllers/collection.controller.spec.ts
+++ b/test/unit/controllers/collection.controller.spec.ts
@@ -26,6 +26,7 @@ import { fileExists } from "../../helpers/filehelper.js";
 import { OwnershipCheckService } from "../../../src/logion/services/ownershipcheck.service.js";
 import { RestrictedDeliveryService } from "../../../src/logion/services/restricteddelivery.service.js";
 import { ALICE } from "../../helpers/addresses.js";
+import { LocRequestService } from "../../../src/logion/services/locrequest.service.js";
 
 const collectionLocId = "d61e2e12-6c06-4425-aeee-2a0e969ac14e";
 const collectionLocOwner = ALICE;
@@ -588,6 +589,9 @@ function mockModel(container: Container, params: { collectionItemAlreadyInDB: bo
     container.bind(RestrictedDeliveryService).toConstantValue(restrictedDeliveryService.object());
 
     container.bind(CollectionService).toConstantValue(new NonTransactionalCollectionService(collectionRepository.object()));
+
+    const locRequestService = new Mock<LocRequestService>();
+    container.bind(LocRequestService).toConstantValue(locRequestService.object());
 }
 
 function expectDeliveryInfo(responseBody: any) {

--- a/test/unit/controllers/locrequest.controller.fetch.spec.ts
+++ b/test/unit/controllers/locrequest.controller.fetch.spec.ts
@@ -213,7 +213,8 @@ const testFile: FileDescription = {
     hash: "0x9383cd5dfeb5870027088289c665c3bae2d339281840473f35311954e984dea9",
     oid: 123,
     submitter: SUBMITTER,
-    addedOn: moment("2022-08-31T15:53:12.741Z")
+    addedOn: moment("2022-08-31T15:53:12.741Z"),
+    restrictedDelivery: false,
 }
 
 const testLink: LinkDescription = {

--- a/test/unit/controllers/locrequest.controller.items.spec.ts
+++ b/test/unit/controllers/locrequest.controller.items.spec.ts
@@ -294,7 +294,8 @@ const SOME_FILE = {
     hash: SOME_DATA_HASH,
     oid: SOME_OID,
     nature: "file-nature",
-    submitter: REQUESTER
+    submitter: REQUESTER,
+    restrictedDelivery: false,
 };
 
 async function testDownloadSuccess(app: Express) {

--- a/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
+++ b/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
@@ -4,7 +4,7 @@ import { Container } from "inversify";
 import request from "supertest";
 import { Mock, It, Times } from "moq.ts";
 import {
-    LocType,
+    LocType, LocFile,
 } from "../../../src/logion/model/locrequest.model.js";
 import { Moment } from "moment";
 import { NotificationService } from "../../../src/logion/services/notification.service.js";
@@ -205,8 +205,8 @@ function mockModelForCancel(container: Container) {
     const { request, repository, fileStorageService } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Identity", "DRAFT", testData);
 
-    const dbFile = { oid: 1 };
-    const ipfsFile = { cid: "" };
+    const dbFile: LocFile = { update(): void {}, oid: 1 };
+    const ipfsFile = { update(): void {}, cid: "" };
     request.setup(instance => instance.files).returns([ dbFile, ipfsFile ])
 
     repository.setup(instance => instance.deleteDraftOrRejected(request.object()))

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -623,6 +623,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 cid: "cid-1234",
                 nature: "nature1",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             },
             {
                 hash: "hash2",
@@ -631,6 +632,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 cid: "cid-4567",
                 nature: "nature2",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             }
         ];
         whenAddingFiles(files);
@@ -651,6 +653,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 oid: 1234,
                 nature: "nature1",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             },
             {
                 hash: "hash1",
@@ -659,6 +662,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 oid: 4567,
                 nature: "nature2",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             }
         ];
         expect(() => whenAddingFiles(files)).toThrowError();
@@ -676,6 +680,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 cid: "cid-1234",
                 nature: "nature1",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             },
             {
                 hash: "hash2",
@@ -684,6 +689,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 cid: "cid-4567",
                 nature: "nature2",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             }
         ];
         whenAddingFiles(files);
@@ -698,6 +704,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 cid: "cid-4567",
                 nature: "nature2",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             }
         ];
         thenExposesFiles(newFiles);
@@ -719,6 +726,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 cid: "cid-1234",
                 nature: "nature1",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             }
         ]);
         whenConfirmingFile(hash)
@@ -737,6 +745,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 cid: "cid-1234",
                 nature: "nature1",
                 submitter: OWNER,
+                restrictedDelivery: false,
             }
         ]);
         thenFileIsVisibleToRequester(hash)
@@ -791,6 +800,7 @@ describe("LocRequestAggregateRoot (synchronization)", () => {
                 cid: "cid-1234",
                 nature: "nature1",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             },
             {
                 hash: "hash2",
@@ -799,6 +809,7 @@ describe("LocRequestAggregateRoot (synchronization)", () => {
                 cid: "cid-4567",
                 nature: "nature2",
                 submitter: SUBMITTER,
+                restrictedDelivery: false,
             }
         ];
         whenAddingFiles(files);
@@ -813,7 +824,8 @@ describe("LocRequestAggregateRoot (synchronization)", () => {
             cid: "cid-1234",
             nature: "nature1",
             submitter: SUBMITTER,
-            addedOn: addedOn
+            addedOn: addedOn,
+            restrictedDelivery: false,
         })
     })
 })
@@ -831,6 +843,7 @@ describe("LocRequestAggregateRoot (processes)", () => {
             oid: 1234,
             nature: "nature1",
             submitter: SUBMITTER,
+            restrictedDelivery: false,
         });
         expect(request.getFiles(SUBMITTER).length).toBe(1);
         request.addMetadataItem({
@@ -869,6 +882,7 @@ describe("LocRequestAggregateRoot (processes)", () => {
             oid: 1235,
             nature: "nature2",
             submitter: OWNER,
+            restrictedDelivery: false,
         });
         request.confirmFile("hash2");
         request.setFileAddedOn("hash2", moment()); // Sync


### PR DESCRIPTION
* Add endpoint to download collection files, restricted to NFT owner.
* Add a flag to enable/disable restricted delivery.
* The provided file is still the exact copy of the source (no metadata with signature yet).

logion-network/logion-internal#740