### PR TITLE
Improve deliveries

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -29,6 +29,15 @@
             },
             "CollectionDeliveriesResponse": {
                 "type": "object",
+                "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/components/schemas/CheckLatestCollectionDeliveryResponse"
+                    }
+                }
+            },
+            "CollectionFileDeliveriesResponse": {
+                "type": "object",
                 "properties": {
                     "deliveries": {
                         "type": "array",

--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -637,6 +637,10 @@
                                 "restrictedDelivery": {
                                     "type": "boolean",
                                     "description": "true if the file can be downloaded by collection item owner. Applicable only for collection."
+                                },
+                                "size": {
+                                    "type": "number",
+                                    "description": "The file's size, in bytes."
                                 }
                             }
                         }

--- a/src/logion/controllers/adapters/locrequestadapter.ts
+++ b/src/logion/controllers/adapters/locrequestadapter.ts
@@ -76,6 +76,7 @@ export class LocRequestAdapter {
                 submitter: file.submitter,
                 restrictedDelivery: file.restrictedDelivery,
                 contentType: file.contentType,
+                size: file.size,
             })),
             metadata: request.getMetadataItems(viewer).map(item => ({
                 name: item.name,

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -384,6 +384,8 @@ export interface components {
           submitter?: string;
           /** @description true if the file can be downloaded by collection item owner. Applicable only for collection. */
           restrictedDelivery?: boolean;
+          /** @description The file's size, in bytes. */
+          size?: number;
         })[];
       /** @description The links attached to this request's LOC */
       links?: ({
@@ -482,6 +484,8 @@ export interface components {
           addedOn?: string;
           /** @description The SS58 address of the file submitter */
           submitter?: string;
+          /** @description The file's content type (MIME) */
+          contentType?: string;
         })[];
       /** @description The links attached to this request's LOC */
       links?: ({

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -22,6 +22,9 @@ export interface components {
       [key: string]: (components["schemas"]["CheckLatestItemDeliveryResponse"])[] | undefined;
     };
     CollectionDeliveriesResponse: {
+      [key: string]: (components["schemas"]["CheckLatestCollectionDeliveryResponse"])[] | undefined;
+    };
+    CollectionFileDeliveriesResponse: {
       deliveries?: (components["schemas"]["CheckLatestCollectionDeliveryResponse"])[];
     };
     CheckLatestDeliveryResponse: {

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -525,6 +525,7 @@ export class LocRequestController extends ApiController {
                     nature: addFileView.nature || "",
                     submitter: contributor,
                     restrictedDelivery: addFileView.restrictedDelivery || false,
+                    size: file.size,
                 });
             });
         } catch(e) {

--- a/src/logion/migration/1674830602953-AddLocFileSize.ts
+++ b/src/logion/migration/1674830602953-AddLocFileSize.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddLocFileSize1674830602953 implements MigrationInterface {
+    name = 'AddLocFileSize1674830602953'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request_file" ADD "size" bigint NULL`);
+        await queryRunner.query(`UPDATE "loc_request_file" set size = 0`);
+        await queryRunner.query(`ALTER TABLE "loc_request_file" ALTER COLUMN "size" SET NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request_file" DROP COLUMN "size"`);
+    }
+
+}

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -53,6 +53,7 @@ export interface FileDescription {
     readonly addedOn?: Moment;
     readonly submitter: string;
     readonly restrictedDelivery: boolean;
+    readonly size: number;
 }
 
 export interface MetadataItemDescription {
@@ -220,7 +221,8 @@ export class LocRequestAggregateRoot {
         file.contentType = fileDescription.contentType;
         file.draft = true;
         file.nature = fileDescription.nature;
-        file.submitter = fileDescription.submitter
+        file.submitter = fileDescription.submitter;
+        file.size = fileDescription.size.toString();
         file.delivered = [];
         file._toAdd = true;
         this.files!.push(file);
@@ -269,6 +271,7 @@ export class LocRequestAggregateRoot {
             submitter: file!.submitter!,
             addedOn: file!.addedOn !== undefined ? moment(file!.addedOn) : undefined,
             restrictedDelivery: file!.restrictedDelivery || false,
+            size: parseInt(file.size!)
         };
     }
 
@@ -770,6 +773,9 @@ export class LocFile extends Child implements HasIndex, Submitted {
 
     @Column("boolean", { name: "restricted_delivery", default: false })
     restrictedDelivery?: boolean;
+
+    @Column("bigint", { nullable: false })
+    size?: string;
 
     @OneToMany(() => LocFileDelivered, deliveredFile => deliveredFile.file, {
         eager: true,

--- a/test/integration/model/loc_requests.sql
+++ b/test/integration/model/loc_requests.sql
@@ -22,8 +22,8 @@ VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUi
 -- Loc with files, metadata and links
 INSERT INTO loc_request (id, owner_address, requester_address, description, status, loc_type)
 VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'loc-10', 'OPEN', 'Transaction');
-INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter)
-VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', 'a file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 0, TRUE, 'some nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw');
+INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter, size)
+VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', 'a file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 0, TRUE, 'some nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', 123);
 INSERT INTO loc_metadata_item (request_id, "index", name, "value_text", added_on, draft, submitter)
 VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', 0, 'a name', 'a value', '2021-10-06T11:16:00.000', true, '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw');
 INSERT INTO loc_link (request_id, "index", target, added_on, draft, nature)
@@ -66,8 +66,8 @@ VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUi
 -- Closed Identity LOC of VTP
 INSERT INTO loc_request (id, owner_address, requester_address, description, status, loc_type, verified_third_party)
 VALUES ('15ed922d-5960-4147-a73f-97d362cb7c46', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'loc-27', 'CLOSED', 'Identity', TRUE);
-INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter, restricted_delivery)
-VALUES ('15ed922d-5960-4147-a73f-97d362cb7c46', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', 'a file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 0, TRUE, 'some nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', TRUE);
+INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter, restricted_delivery, size)
+VALUES ('15ed922d-5960-4147-a73f-97d362cb7c46', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', 'a file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 0, TRUE, 'some nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', TRUE, 456);
 INSERT INTO loc_request_file_delivered (id, request_id, hash, delivered_file_hash, generated_on, owner)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '15ed922d-5960-4147-a73f-97d362cb7c46', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', '0xf35e4bcbc1b0ce85af90914e04350cce472a2f01f00c0f7f8bc5c7ba04da2bf2', '2021-10-06T12:16:00.000', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw');
 INSERT INTO loc_request_file_delivered (id, request_id, hash, delivered_file_hash, generated_on, owner)

--- a/test/integration/model/loc_requests.sql
+++ b/test/integration/model/loc_requests.sql
@@ -74,3 +74,9 @@ INSERT INTO loc_request_file_delivered (id, request_id, hash, delivered_file_has
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '15ed922d-5960-4147-a73f-97d362cb7c46', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', '0x38df2378ed26e20124d8c38a945af1b4a058656aab3b3b1f71a9d8a629cc0d81', '2021-10-05T12:16:00.000', '5H9ZP7zyJtmay2Vcstf7SzK8LD1PGe5PJ8q7xakqp4zXFEwz');
 INSERT INTO loc_request_file_delivered (id, request_id, hash, delivered_file_hash, generated_on, owner)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '15ed922d-5960-4147-a73f-97d362cb7c46', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', '0xc14d46b478dcb21833b90dc9880aa3a7507b01aa5d033c64051df999f3c3bba0', '2021-10-07T12:16:00.000', '5Eewz58eEPS81847EezkiFENE3kG8fxrx1BdRWyFJAudPC6m');
+
+INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter, restricted_delivery, size)
+VALUES ('15ed922d-5960-4147-a73f-97d362cb7c46', '0x5a60f0a435fa1c508ccc7a7dd0a0fe8f924ba911b815b10c9ef0ddea0c49052e', 'another file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 1, TRUE, 'some other nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', TRUE, 789);
+INSERT INTO loc_request_file_delivered (id, request_id, hash, delivered_file_hash, generated_on, owner)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '15ed922d-5960-4147-a73f-97d362cb7c46', '0x5a60f0a435fa1c508ccc7a7dd0a0fe8f924ba911b815b10c9ef0ddea0c49052e', '0xdbfaa07666457afd3cdc6fb2726a94cde7a0f613a0f354e695b315372a098e8a', '2021-10-06T12:16:00.000', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw');
+

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -6,7 +6,9 @@ import {
     FetchLocRequestsSpecification,
     LocFile,
     LocMetadataItem,
-    LocLink, LocType, LocFileDelivered,
+    LocLink,
+    LocType,
+    LocFileDelivered,
 } from "../../../src/logion/model/locrequest.model.js";
 import { ALICE, BOB } from "../../helpers/addresses.js";
 import { v4 as uuid } from "uuid";
@@ -318,6 +320,7 @@ function givenLoc(id: string, locType: LocType, status: "OPEN" | "DRAFT"): LocRe
         nature: "nature1",
         submitter: SUBMITTER,
         restrictedDelivery: false,
+        size: 789,
     })
     locRequest.metadata = []
     locRequest.addMetadataItem({

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -20,6 +20,9 @@ const ENTITIES = [ LocRequestAggregateRoot, LocFile, LocMetadataItem, LocLink, L
 
 describe('LocRequestRepository - read accesses', () => {
 
+    const hash = "0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee";
+    const anotherHash = "0x5a60f0a435fa1c508ccc7a7dd0a0fe8f924ba911b815b10c9ef0ddea0c49052e";
+
     beforeAll(async () => {
         await connect(ENTITIES);
         await executeScript("test/integration/model/loc_requests.sql");
@@ -95,7 +98,6 @@ describe('LocRequestRepository - read accesses', () => {
         const request = await repository.findById(LOC_WITH_FILES);
         checkDescription([request!], "Transaction", "loc-10");
 
-        const hash = "0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee";
         expect(request!.getFiles(request?.ownerAddress).length).toBe(1);
         expect(request!.hasFile(hash)).toBe(true);
         const file = request!.getFile(hash);
@@ -103,7 +105,8 @@ describe('LocRequestRepository - read accesses', () => {
         expect(file.hash).toBe(hash);
         expect(file.oid).toBe(123456);
         expect(file.addedOn!.isSame(moment("2021-10-06T11:16:00.000"))).toBe(true);
-        expect(file.nature).toBe("some nature")
+        expect(file.nature).toBe("some nature");
+        expect(file.size).toBe(123);
         expect(request!.files![0].draft).toBe(true);
 
         const metadata = request!.getMetadataItems(request?.ownerAddress);
@@ -150,7 +153,7 @@ describe('LocRequestRepository - read accesses', () => {
 
     it("finds one LOC with restricted deliveries", async () => {
         const request = requireDefined(await repository.findById("15ed922d-5960-4147-a73f-97d362cb7c46"));
-        expect(request.files?.length).toBe(1);
+        expect(request.files?.length).toBe(2);
         const file = request.files![0];
         expect(file.delivered?.length).toBe(3);
     });
@@ -161,24 +164,39 @@ describe('LocRequestRepository - read accesses', () => {
             isVerifiedThirdParty: true,
         });
         const request = requests[0];
-        expect(request.files?.length).toBe(1);
+        expect(request.files?.length).toBe(2);
         const file = request.files![0];
         expect(file.delivered?.length).toBe(3);
     });
 
-    it("finds deliveries", async () => {
+    fit("finds deliveries", async () => {
         const delivered = await repository.findAllDeliveries({
             collectionLocId: "15ed922d-5960-4147-a73f-97d362cb7c46",
-            hash: "0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee"
+            hash,
         })
-        expect(delivered.length).toEqual(3);
-        expect(delivered[0].owner).toEqual("5Eewz58eEPS81847EezkiFENE3kG8fxrx1BdRWyFJAudPC6m");
-        expect(delivered[0].deliveredFileHash).toEqual("0xc14d46b478dcb21833b90dc9880aa3a7507b01aa5d033c64051df999f3c3bba0");
-        expect(delivered[1].owner).toEqual("5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw");
-        expect(delivered[1].deliveredFileHash).toEqual("0xf35e4bcbc1b0ce85af90914e04350cce472a2f01f00c0f7f8bc5c7ba04da2bf2");
-        expect(delivered[2].owner).toEqual("5H9ZP7zyJtmay2Vcstf7SzK8LD1PGe5PJ8q7xakqp4zXFEwz");
-        expect(delivered[2].deliveredFileHash).toEqual("0x38df2378ed26e20124d8c38a945af1b4a058656aab3b3b1f71a9d8a629cc0d81");
+        checkDelivery(delivered);
+        expect(delivered[anotherHash]).toBeUndefined();
     })
+
+    fit("finds all deliveries", async () => {
+        const delivered = await repository.findAllDeliveries({
+            collectionLocId: "15ed922d-5960-4147-a73f-97d362cb7c46",
+        })
+        checkDelivery(delivered);
+        expect(delivered[anotherHash].length).toEqual(1);
+        expect(delivered[anotherHash][0].owner).toEqual("5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw");
+        expect(delivered[anotherHash][0].deliveredFileHash).toEqual("0xdbfaa07666457afd3cdc6fb2726a94cde7a0f613a0f354e695b315372a098e8a");
+    })
+
+    function checkDelivery(delivered: Record<string, LocFileDelivered[]>) {
+        expect(delivered[hash].length).toEqual(3);
+        expect(delivered[hash][0].owner).toEqual("5Eewz58eEPS81847EezkiFENE3kG8fxrx1BdRWyFJAudPC6m");
+        expect(delivered[hash][0].deliveredFileHash).toEqual("0xc14d46b478dcb21833b90dc9880aa3a7507b01aa5d033c64051df999f3c3bba0");
+        expect(delivered[hash][1].owner).toEqual("5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw");
+        expect(delivered[hash][1].deliveredFileHash).toEqual("0xf35e4bcbc1b0ce85af90914e04350cce472a2f01f00c0f7f8bc5c7ba04da2bf2");
+        expect(delivered[hash][2].owner).toEqual("5H9ZP7zyJtmay2Vcstf7SzK8LD1PGe5PJ8q7xakqp4zXFEwz");
+        expect(delivered[hash][2].deliveredFileHash).toEqual("0x38df2378ed26e20124d8c38a945af1b4a058656aab3b3b1f71a9d8a629cc0d81");
+    }
 })
 
 describe('LocRequestRepository.save()', () => {

--- a/test/unit/controllers/locrequest.controller.fetch.spec.ts
+++ b/test/unit/controllers/locrequest.controller.fetch.spec.ts
@@ -215,6 +215,7 @@ const testFile: FileDescription = {
     submitter: SUBMITTER,
     addedOn: moment("2022-08-31T15:53:12.741Z"),
     restrictedDelivery: false,
+    size: 123,
 }
 
 const testLink: LinkDescription = {

--- a/test/unit/controllers/locrequest.controller.items.spec.ts
+++ b/test/unit/controllers/locrequest.controller.items.spec.ts
@@ -296,6 +296,7 @@ const SOME_FILE = {
     nature: "file-nature",
     submitter: REQUESTER,
     restrictedDelivery: false,
+    size: 123,
 };
 
 async function testDownloadSuccess(app: Express) {

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -624,6 +624,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 nature: "nature1",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             },
             {
                 hash: "hash2",
@@ -633,6 +634,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 nature: "nature2",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             }
         ];
         whenAddingFiles(files);
@@ -654,6 +656,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 nature: "nature1",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             },
             {
                 hash: "hash1",
@@ -663,6 +666,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 nature: "nature2",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             }
         ];
         expect(() => whenAddingFiles(files)).toThrowError();
@@ -681,6 +685,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 nature: "nature1",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             },
             {
                 hash: "hash2",
@@ -690,6 +695,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 nature: "nature2",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             }
         ];
         whenAddingFiles(files);
@@ -705,6 +711,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 nature: "nature2",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             }
         ];
         thenExposesFiles(newFiles);
@@ -727,6 +734,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 nature: "nature1",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             }
         ]);
         whenConfirmingFile(hash)
@@ -746,6 +754,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 nature: "nature1",
                 submitter: OWNER,
                 restrictedDelivery: false,
+                size: 123,
             }
         ]);
         thenFileIsVisibleToRequester(hash)
@@ -841,14 +850,15 @@ describe("LocRequestAggregateRoot (files)", () => {
         givenRequestWithStatus('OPEN');
         request.locType = "Collection";
         const file: FileDescription = {
-                hash: "hash1",
-                name: "name1",
-                contentType: "text/plain",
-                cid: "cid-1234",
-                nature: "nature1",
-                submitter: SUBMITTER,
-                restrictedDelivery: false,
-            };
+            hash: "hash1",
+            name: "name1",
+            contentType: "text/plain",
+            cid: "cid-1234",
+            nature: "nature1",
+            submitter: SUBMITTER,
+            restrictedDelivery: false,
+            size: 123,
+        };
         whenAddingFiles([ file ]);
         whenUpdatingFile("hash1", false);
         thenExposesFileByHash("hash1", { ...file, restrictedDelivery: false });
@@ -860,14 +870,15 @@ describe("LocRequestAggregateRoot (files)", () => {
         givenRequestWithStatus('OPEN');
         request.locType = "Identity";
         const file: FileDescription = {
-                hash: "hash1",
-                name: "name1",
-                contentType: "text/plain",
-                cid: "cid-1234",
-                nature: "nature1",
-                submitter: SUBMITTER,
-                restrictedDelivery: false,
-            };
+            hash: "hash1",
+            name: "name1",
+            contentType: "text/plain",
+            cid: "cid-1234",
+            nature: "nature1",
+            submitter: SUBMITTER,
+            restrictedDelivery: false,
+            size: 123,
+        };
         whenAddingFiles([ file ]);
         expect(() => {
             whenUpdatingFile("hash1", true);
@@ -887,6 +898,7 @@ function givenClosedCollectionLocWithFile(hash: string) {
         nature: "nature1",
         submitter: OWNER,
         restrictedDelivery: true,
+        size: 123,
     });
     request.close(moment());
 }
@@ -940,6 +952,7 @@ describe("LocRequestAggregateRoot (synchronization)", () => {
                 nature: "nature1",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             },
             {
                 hash: "hash2",
@@ -949,6 +962,7 @@ describe("LocRequestAggregateRoot (synchronization)", () => {
                 nature: "nature2",
                 submitter: SUBMITTER,
                 restrictedDelivery: false,
+                size: 123,
             }
         ];
         whenAddingFiles(files);
@@ -965,6 +979,7 @@ describe("LocRequestAggregateRoot (synchronization)", () => {
             submitter: SUBMITTER,
             addedOn: addedOn,
             restrictedDelivery: false,
+            size: 123,
         })
     })
 })
@@ -983,6 +998,7 @@ describe("LocRequestAggregateRoot (processes)", () => {
             nature: "nature1",
             submitter: SUBMITTER,
             restrictedDelivery: false,
+            size: 123,
         });
         expect(request.getFiles(SUBMITTER).length).toBe(1);
         request.addMetadataItem({
@@ -1022,6 +1038,7 @@ describe("LocRequestAggregateRoot (processes)", () => {
             nature: "nature2",
             submitter: OWNER,
             restrictedDelivery: false,
+            size: 123,
         });
         request.confirmFile("hash2");
         request.setFileAddedOn("hash2", moment()); // Sync


### PR DESCRIPTION
* Provide new endpoint to serve all deliveries of all files of a given collection: `/api/collection/${collectionId}/file-deliveries`.
* Add new attribute to LOC files: `size`.
* Rename item GET endpoint from `/:collectionLocId/:itemId` to `/:collectionLocId/items/:itemId` to avoid "catch-all" effect.

logion-network/logion-internal#743
logion-network/logion-internal#750