### PR TITLE
Add originalFileHash to resource checking one single collection file delivery

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -91,6 +91,17 @@
                     "$ref": "#/components/schemas/CheckLatestDeliveryResponse"
                 }]
             },
+            "CheckCollectionDeliveryWitheOriginalResponse": {
+                "type": "object",
+                "allOf": [{
+                    "$ref": "#/components/schemas/CheckCollectionDeliveryResponse"
+                }],
+                "properties": {
+                    "originalFileHash": {
+                        "type": "string"
+                    }
+                }
+            },
             "Config": {
                 "description": "Backend configuration which impacts clients",
                 "type": "object",

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -46,6 +46,9 @@ export interface components {
       belongsToCurrentOwner?: boolean;
     } & components["schemas"]["CheckLatestDeliveryResponse"];
     CheckCollectionDeliveryResponse: components["schemas"]["CheckLatestDeliveryResponse"];
+    CheckCollectionDeliveryWitheOriginalResponse: {
+      originalFileHash?: string;
+    } & components["schemas"]["CheckCollectionDeliveryResponse"];
     /** @description Backend configuration which impacts clients */
     Config: {
       /** @description Available features and their status (enabled/disabled) */

--- a/test/unit/controllers/collection.controller.spec.ts
+++ b/test/unit/controllers/collection.controller.spec.ts
@@ -576,7 +576,7 @@ describe("CollectionController - collection files - ", () => {
             .expect(200)
             .expect('Content-Type', /application\/json/)
             .then(response => {
-                checkDelivery(response.body);
+                checkDelivery(response.body, SOME_DATA_HASH);
             });
     })
 
@@ -591,14 +591,15 @@ describe("CollectionController - collection files - ", () => {
             .expect(400)
             .expect('Content-Type', /application\/json/)
             .then(response => {
-                expect(response.body.errorMessage).toEqual("Provided copyHash is not from a delivered copy of a in the collection")
+                expect(response.body.errorMessage).toEqual("Provided copyHash is not from a delivered copy of a file from the collection")
             });
     })
 
-    function checkDelivery(delivery: any) {
+    function checkDelivery(delivery: any, originalFileHash?: string) {
         expect(delivery.copyHash).toBe(DELIVERY_HASH);
         expect(delivery.generatedOn).toBeDefined();
         expect(delivery.owner).toBe(ITEM_TOKEN_OWNER);
+        expect(delivery.originalFileHash).toBe(originalFileHash);
     }
 })
 


### PR DESCRIPTION
* Add `originalFileHash` to resource checking one single collection file delivery
* Fixes incomplete doc.

logion-network/logion-internal#758
logion-network/logion-internal#738