### PR TITLE
Add tokens record API and model

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -1365,6 +1365,47 @@
                         "description": "Tells if the issuer was selected for a given LOC (undefined if not relevant)"
                     }
                 }
+            },
+            "TokensRecordView": {
+                "type": "object",
+                "properties": {
+                    "collectionLocId": {
+                        "type": "string",
+                        "description": "The id of the collection loc",
+                        "example": "5e4ef4bb-8657-444c-9880-d89e9403fc85"
+                    },
+                    "recordId": {
+                        "type": "string",
+                        "description": "The id of the collection item",
+                        "example": "0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705"
+                    },
+                    "addedOn": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The creation timestamp"
+                    },
+                    "files": {
+                        "type": "array",
+                        "description": "The files present in DB",
+                        "items": {
+                            "type": "string",
+                            "description": "The hash of a file present in DB",
+                            "example": "0x6dec991b1b61b44550769ae3c4b7f54f7cd618391f32bab2bc4e3a96cbb2b198"
+                        }
+                    }
+                }
+            },
+            "TokensRecordsView": {
+                "type": "object",
+                "properties": {
+                    "records": {
+                        "type": "array",
+                        "description": "The items of a given collection",
+                        "items": {
+                            "$ref": "#/components/schemas/TokensRecordView"
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/logion/app.support.ts
+++ b/src/logion/app.support.ts
@@ -22,6 +22,7 @@ import { fillInSpec as fillInSpecVerifiedThirdParty, VerifiedThirdPartyControlle
 import { fillInSpec as fillInSpecConfig, ConfigController } from "./controllers/config.controller.js";
 import { fillInSpec as fillInSpecIdenfy, IdenfyController } from "./controllers/idenfy.controller.js";
 import { fillInSpec as fillInSpecVote, VoteController } from "./controllers/vote.controller.js";
+import { fillInSpec as fillInSpecTokensRecord, TokensRecordController } from "./controllers/records.controller.js";
 
 const { logger } = Log;
 
@@ -58,6 +59,7 @@ export function predefinedSpec(spec: OpenAPIV3.Document): OpenAPIV3.Document {
     fillInSpecConfig(spec);
     fillInSpecIdenfy(spec);
     fillInSpecVote(spec);
+    fillInSpecTokensRecord(spec);
 
     return spec;
 }
@@ -118,6 +120,7 @@ export function setupApp(expressConfig?: ExpressConfig): Express {
     dino.registerController(ConfigController);
     dino.registerController(IdenfyController);
     dino.registerController(VoteController);
+    dino.registerController(TokensRecordController);
 
     dino.dependencyResolver<Container>(AppContainer,
         (injector, type) => {

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -54,6 +54,10 @@ import { VoteController } from "../controllers/vote.controller.js";
 import { VoteRepository, VoteFactory } from "../model/vote.model.js";
 import { VoteService, TransactionalVoteService } from "../services/vote.service.js";
 import { VoteSynchronizer } from "../services/votesynchronization.service.js";
+import { TokensRecordController } from "../controllers/records.controller.js";
+import { TokensRecordFactory, TokensRecordRepository } from "../model/tokensrecord.model.js";
+import { LogionNodeTokensRecordService, TokensRecordService, TransactionalTokensRecordService } from "../services/tokensrecord.service.js";
+import { LocAuthorizationService } from "../services/locauthorization.service.js";
 
 let container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -131,6 +135,12 @@ container.bind(VoteRepository).toSelf();
 container.bind(VoteService).toService(TransactionalVoteService);
 container.bind(TransactionalVoteService).toSelf();
 container.bind(VoteSynchronizer).toSelf();
+container.bind(TokensRecordRepository).toSelf()
+container.bind(TokensRecordFactory).toSelf()
+container.bind(LogionNodeTokensRecordService).toSelf();
+container.bind(TokensRecordService).toService(TransactionalTokensRecordService);
+container.bind(TransactionalTokensRecordService).toSelf();
+container.bind(LocAuthorizationService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();
@@ -142,5 +152,6 @@ container.bind(VerifiedThirdPartyController).toSelf().inTransientScope();
 container.bind(ConfigController).toSelf().inTransientScope();
 container.bind(IdenfyController).toSelf().inTransientScope();
 container.bind(VoteController).toSelf().inTransientScope();
+container.bind(TokensRecordController).toSelf().inTransientScope();
 
 export { container as AppContainer };

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -793,6 +793,29 @@ export interface components {
       /** @description Tells if the issuer was selected for a given LOC (undefined if not relevant) */
       selected?: boolean;
     };
+    TokensRecordView: {
+      /**
+       * @description The id of the collection loc 
+       * @example 5e4ef4bb-8657-444c-9880-d89e9403fc85
+       */
+      collectionLocId?: string;
+      /**
+       * @description The id of the collection item 
+       * @example 0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705
+       */
+      recordId?: string;
+      /**
+       * Format: date-time 
+       * @description The creation timestamp
+       */
+      addedOn?: string;
+      /** @description The files present in DB */
+      files?: (string)[];
+    };
+    TokensRecordsView: {
+      /** @description The items of a given collection */
+      records?: (components["schemas"]["TokensRecordView"])[];
+    };
   };
   responses: never;
   parameters: never;

--- a/src/logion/controllers/records.controller.ts
+++ b/src/logion/controllers/records.controller.ts
@@ -1,0 +1,391 @@
+import { AuthenticatedUser } from "@logion/authenticator";
+import { injectable } from "inversify";
+import { Controller, ApiController, Async, HttpGet, HttpPost, SendsResponse } from "dinoloop";
+import {
+    TokensRecordRepository,
+    TokensRecordFactory,
+    TokensRecordDescription,
+    TokensRecordAggregateRoot,
+    TokensRecordFileDelivered
+} from "../model/tokensrecord.model.js";
+import { components } from "./components.js";
+import { OpenAPIV3 } from "express-oas-generator";
+import moment from "moment";
+import {
+    LocRequestRepository,
+} from "../model/locrequest.model.js";
+import { getUploadedFile } from "./fileupload.js";
+import { sha256File } from "../lib/crypto/hashing.js";
+import { FileStorageService } from "../services/file.storage.service.js";
+import {
+    requireDefined,
+    badRequest,
+    forbidden,
+    addTag,
+    setControllerTag,
+    getPublicResponses,
+    setPathParameters,
+    getDefaultResponsesWithAnyBody,
+    AuthenticationService,
+    getRequestBody,
+    getDefaultResponsesNoContent,
+    getDefaultResponses,
+} from "@logion/rest-api-core";
+import { TokensRecordFile } from "@logion/node-api";
+import os from "os";
+import path from "path";
+import { OwnershipCheckService } from "../services/ownershipcheck.service.js";
+import { RestrictedDeliveryService } from "../services/restricteddelivery.service.js";
+import { downloadAndClean } from "../lib/http.js";
+import { GetTokensRecordFileParams, LogionNodeTokensRecordService, TokensRecordService } from "../services/tokensrecord.service.js";
+import { LogionNodeCollectionService } from "../services/collection.service.js";
+import { LocAuthorizationService } from "../services/locauthorization.service.js";
+
+type TokensRecordView = components["schemas"]["TokensRecordView"];
+type TokensRecordsView = components["schemas"]["TokensRecordsView"];
+type CheckLatestItemDeliveryResponse = components["schemas"]["CheckLatestItemDeliveryResponse"];
+type ItemDeliveriesResponse = components["schemas"]["ItemDeliveriesResponse"];
+type FileUploadData = components["schemas"]["FileUploadData"];
+
+export function fillInSpec(spec: OpenAPIV3.Document): void {
+    const tagName = 'Tokens Records';
+    addTag(spec, {
+        name: tagName,
+        description: "Handling of Tokens Records"
+    });
+    setControllerTag(spec, /^\/api\/records.*/, tagName);
+
+    TokensRecordController.getTokensRecords(spec)
+    TokensRecordController.getTokensRecord(spec)
+    TokensRecordController.addFile(spec)
+    TokensRecordController.downloadItemFile(spec)
+    TokensRecordController.getAllItemDeliveries(spec)
+    TokensRecordController.downloadFileSource(spec)
+}
+
+@injectable()
+@Controller('/records')
+export class TokensRecordController extends ApiController {
+
+    constructor(
+        private tokensRecordRepository: TokensRecordRepository,
+        private locRequestRepository: LocRequestRepository,
+        private authenticationService: AuthenticationService,
+        private tokensRecordFactory: TokensRecordFactory,
+        private fileStorageService: FileStorageService,
+        private logionNodeTokensRecordService: LogionNodeTokensRecordService,
+        private ownershipCheckService: OwnershipCheckService,
+        private restrictedDeliveryService: RestrictedDeliveryService,
+        private tokensRecordService: TokensRecordService,
+        private logionNodeCollectionService: LogionNodeCollectionService,
+        private locAuthorizationService: LocAuthorizationService,
+    ) {
+        super();
+    }
+
+    static getTokensRecords(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/records/{collectionLocId}"].get!;
+        operationObject.summary = "Gets the info of all tokens records in a collection";
+        operationObject.description = "Must be authenticated as the owner, requester of the collection.";
+        operationObject.responses = getPublicResponses("TokensRecordView");
+        setPathParameters(operationObject, {
+            'collectionLocId': "The id of the collection loc",
+        });
+    }
+
+    @HttpGet('/:collectionLocId')
+    @Async()
+    async getTokensRecords(_body: any, collectionLocId: string): Promise<TokensRecordsView> {
+        await this.authenticationService.authenticatedUser(this.request);
+        const records = await this.tokensRecordRepository.findAllBy(collectionLocId);
+        return {
+            records: records.map(record => record.getDescription()).map(this.toView),
+        }
+    }
+
+    private toView(record: TokensRecordDescription): TokensRecordView {
+        const { collectionLocId, recordId, addedOn, files } = record;
+        return {
+            collectionLocId,
+            recordId,
+            addedOn: addedOn?.toISOString(),
+            files: files?.map(file => file.hash),
+        }
+    }
+
+    static getTokensRecord(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/records/{collectionLocId}/record/{recordId}"].get!;
+        operationObject.summary = "Gets the info of a published Collection Item";
+        operationObject.description = "No authentication required.";
+        operationObject.responses = getPublicResponses("TokensRecordView");
+        setPathParameters(operationObject, {
+            'collectionLocId': "The id of the collection loc",
+            'recordId': "The id of the collection item"
+        });
+    }
+
+    @HttpGet('/:collectionLocId/record/:recordId')
+    @Async()
+    async getTokensRecord(_body: any, collectionLocId: string, recordId: string): Promise<TokensRecordView> {
+        requireDefined(
+            await this.logionNodeTokensRecordService.getTokensRecord({ collectionLocId, recordId }),
+            () => badRequest(`Tokens Record ${ collectionLocId }/${ recordId } not found`));
+
+        const collectionItem = await this.tokensRecordRepository.findBy(collectionLocId, recordId);
+        if (collectionItem) {
+            return this.toView(collectionItem.getDescription())
+        } else {
+            return this.toView({
+                collectionLocId,
+                recordId,
+                files: []
+            })
+        }
+    }
+
+    static addFile(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/records/{collectionLocId}/{recordId}/files"].post!;
+        operationObject.summary = "Adds a file to a Collection Item";
+        operationObject.description = "The authenticated user must be the requester of the LOC.";
+        operationObject.responses = getDefaultResponsesNoContent();
+        operationObject.requestBody = getRequestBody({
+            description: "File upload data",
+            view: "FileUploadData",
+        });
+        setPathParameters(operationObject, {
+                'collectionLocId': "The ID of the Collection LOC",
+                'recordId': "The ID of the Collection Item",
+            });
+    }
+
+    @HttpPost('/:collectionLocId/:recordId/files')
+    @Async()
+    async addFile(body: FileUploadData, collectionLocId: string, recordId: string): Promise<void> {
+        const collectionLoc = requireDefined(await this.locRequestRepository.findById(collectionLocId),
+            () => badRequest(`Collection ${ collectionLocId } not found`));
+
+        await this.locAuthorizationService.ensureContributor(this.request, collectionLoc);
+
+        const publishedTokensRecord = await this.logionNodeTokensRecordService.getTokensRecord({ collectionLocId, recordId })
+        if (!publishedTokensRecord) {
+            throw badRequest("Tokens Record not found on chain")
+        }
+
+        const hash = requireDefined(body.hash, () => badRequest("No hash found for upload file"));
+        const file = await getUploadedFile(this.request, hash);
+
+        const publishedTokensRecordFile = await this.getTokensRecordFile({
+            collectionLocId,
+            recordId,
+            hash
+        });
+        if (file.size.toString() !== publishedTokensRecordFile.size) {
+            throw badRequest(`Invalid size. Actually uploaded ${ file.size } bytes while expecting ${ publishedTokensRecordFile.size } bytes`);
+        }
+        if (file.name !== publishedTokensRecordFile.name) {
+            throw badRequest(`Invalid name. Actually uploaded ${ file.name } while expecting ${ publishedTokensRecordFile.name }`);
+        }
+
+        const tokensRecord = await this.tokensRecordService.createIfNotExist(collectionLocId, recordId, () =>
+            this.tokensRecordFactory.newTokensRecord({ collectionLocId, recordId } )
+        )
+        if (tokensRecord.hasFile(hash)) {
+            throw badRequest("File is already uploaded")
+        }
+        const cid = await this.fileStorageService.importFile(file.tempFilePath);
+
+        await this.tokensRecordService.update(collectionLocId, recordId, async item => {
+            item.addFile({ hash, cid });
+        });
+    }
+
+    private async getTokensRecordFile(params: GetTokensRecordFileParams): Promise<TokensRecordFile> {
+        const publishedTokensRecordFile = await this.logionNodeTokensRecordService.getTokensRecordFile(params);
+        if (publishedTokensRecordFile) {
+            return publishedTokensRecordFile;
+        } else {
+            throw badRequest("Tokens Record File not found on chain");
+        }
+    }
+
+    static downloadItemFile(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/records/{collectionLocId}/{recordId}/files/{hash}/{itemId}"].get!;
+        operationObject.summary = "Downloads a copy of a file of the Collection Item";
+        operationObject.description = "The authenticated user must be the owner of the underlying token";
+        operationObject.responses = getDefaultResponsesWithAnyBody();
+        setPathParameters(operationObject, {
+            'collectionLocId': "The ID of the Collection LOC",
+            'recordId': "The ID of the Collection Item",
+            'hash': "The hash of the file",
+        });
+    }
+
+    @HttpGet('/:collectionLocId/:recordId/files/:hash/:itemId')
+    @Async()
+    @SendsResponse()
+    async downloadItemFile(_body: any, collectionLocId: string, recordId: string, hash: string, itemId: string): Promise<void> {
+        const authenticated = await this.authenticationService.authenticatedUser(this.request);
+        const collectionItem = await this.checkCanDownloadTokensRecordFile(authenticated, collectionLocId, recordId, hash, itemId);
+
+        const publishedTokensRecordFile = await this.getTokensRecordFile({
+            collectionLocId,
+            recordId,
+            hash
+        });
+
+        const file = collectionItem.getFile(hash);
+        const tempFilePath = TokensRecordController.tempFilePath({ collectionLocId, recordId, hash });
+        await this.fileStorageService.exportFile(file, tempFilePath);
+
+        const generatedOn = moment();
+        const owner = authenticated.address;
+        await this.restrictedDeliveryService.setMetadata({
+            file: tempFilePath,
+            metadata: {
+                owner,
+                generatedOn,
+            }
+        });
+        const deliveredFileHash = await sha256File(tempFilePath);
+
+        await this.tokensRecordService.update(collectionLocId, recordId, async item => {
+            const file = item.getFile(hash);
+            file.addDeliveredFile({ deliveredFileHash, generatedOn, owner });
+        });
+
+        downloadAndClean({
+            response: this.response,
+            path: tempFilePath,
+            name: publishedTokensRecordFile.name,
+            contentType: publishedTokensRecordFile.contentType,
+        });
+    }
+
+    private async checkCanDownloadTokensRecordFile(authenticated: AuthenticatedUser, collectionLocId: string, recordId: string, hash: string, itemId: string): Promise<TokensRecordAggregateRoot> {
+        const item = requireDefined(await this.logionNodeCollectionService.getCollectionItem({
+            collectionLocId,
+            itemId
+        }), () => badRequest(`Collection item ${ collectionLocId } not found on-chain`));
+
+        const tokensRecord = await this.getTokensRecordWithFile(collectionLocId, recordId, hash);
+
+        if(! await this.ownershipCheckService.isOwner(authenticated.address, item)) {
+            throw forbidden(`${authenticated.address} does not seem to be the owner of related item's underlying token`);
+        } else {
+            return tokensRecord;
+        }
+    }
+
+    private async getTokensRecordWithFile(collectionLocId: string, recordId: string, hash: string): Promise<TokensRecordAggregateRoot> {
+        const tokensRecord = requireDefined(
+            await this.tokensRecordRepository.findBy(collectionLocId, recordId),
+            () => badRequest(`Tokens Record ${ collectionLocId }/${ recordId } not found in DB`));
+        if (!tokensRecord.hasFile(hash)) {
+            throw badRequest("Trying to download a file that is not uploaded yet.")
+        }
+        return tokensRecord;
+    }
+
+    static tempFilePath(params: { collectionLocId: string, recordId: string, hash: string } ) {
+        const { collectionLocId, recordId, hash } = params
+        return path.join(os.tmpdir(), `download-${ collectionLocId }-${ recordId }-${ hash }`)
+    }
+
+    private async getItemDeliveries(query: { collectionLocId: string, recordId: string, fileHash?: string, limitPerFile?: number }): Promise<ItemDeliveriesResponse> {
+        const { collectionLocId, recordId, fileHash, limitPerFile } = query;
+        const delivered = await this.tokensRecordRepository.findLatestDeliveries({ collectionLocId, recordId, fileHash });
+        if(!delivered) {
+            throw badRequest("Original file not found or it was never delivered yet");
+        } else {
+            return this.mapTokensRecordFilesDelivered(delivered, limitPerFile);
+        }
+    }
+
+    private async mapTokensRecordFilesDelivered(delivered: Record<string, TokensRecordFileDelivered[]>, limitPerFile?: number): Promise<ItemDeliveriesResponse> {
+        const owners = new Set<string>();
+        for(const fileHash of Object.keys(delivered)) {
+            const owner = delivered[fileHash][0].owner; // Only check latest owners
+            if(owner) {
+                owners.add(owner);
+            }
+        }
+
+        const view: ItemDeliveriesResponse = {};
+        for(const fileHash of Object.keys(delivered)) {
+            view[fileHash] = delivered[fileHash].slice(0, limitPerFile).map(delivery => this.mapTokensRecordFileDelivered(delivery));
+        }
+        return view;
+    }
+
+    private mapTokensRecordFileDelivered(delivered: TokensRecordFileDelivered): CheckLatestItemDeliveryResponse {
+        return {
+            copyHash: delivered.deliveredFileHash,
+            generatedOn: moment(delivered.generatedOn).toISOString(),
+            owner: delivered.owner,
+        }
+    }
+
+    static getAllItemDeliveries(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/records/{collectionLocId}/{recordId}/deliveries"].get!;
+        operationObject.summary = "Provides information about all delivered copies of a collection file";
+        operationObject.description = "Only collection LOC owner is authorized";
+        operationObject.responses = getDefaultResponses("ItemDeliveriesResponse");
+        setPathParameters(operationObject, {
+            'collectionLocId': "The ID of the Collection LOC",
+            'recordId': "The ID of the Collection Item",
+        });
+    }
+
+    @HttpGet('/:collectionLocId/:recordId/deliveries')
+    @Async()
+    async getAllItemDeliveries(_body: any, collectionLocId: string, recordId: string): Promise<ItemDeliveriesResponse> {
+        const collectionLoc = requireDefined(await this.locRequestRepository.findById(collectionLocId),
+            () => badRequest(`Collection ${ collectionLocId } not found`));
+        await this.authenticationService.authenticatedUserIsOneOf(this.request, collectionLoc.ownerAddress, collectionLoc.requesterAddress);
+
+        return this.getItemDeliveries({ collectionLocId, recordId });
+    }
+
+    static downloadFileSource(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/records/{collectionLocId}/{recordId}/files-sources/{hash}"].get!;
+        operationObject.summary = "Downloads the source of a file of the Collection Item";
+        operationObject.description = "The authenticated user must be the owner or the requester of the LOC";
+        operationObject.responses = getDefaultResponsesWithAnyBody();
+        setPathParameters(operationObject, {
+            'collectionLocId': "The ID of the Collection LOC",
+            'recordId': "The ID of the Collection Item",
+            'hash': "The hash of the file",
+        });
+    }
+
+    @HttpGet('/:collectionLocId/:recordId/files-sources/:hash')
+    @Async()
+    @SendsResponse()
+    async downloadFileSource(_body: any, collectionLocId: string, recordId: string, hash: string): Promise<void> {
+        const authenticated = await this.authenticationService.authenticatedUser(this.request);
+        const collectionLoc = requireDefined(await this.locRequestRepository.findById(collectionLocId),
+            () => badRequest("Collection LOC not found"));
+        authenticated.require(user => user.isOneOf([
+            collectionLoc.ownerAddress,
+            requireDefined(collectionLoc.requesterAddress)
+        ]));
+
+        const publishedTokensRecordFile = await this.getTokensRecordFile({
+            collectionLocId,
+            recordId,
+            hash
+        });
+
+        const tokensRecord = await this.getTokensRecordWithFile(collectionLocId, recordId, hash);
+        const file = tokensRecord.getFile(hash);
+        const tempFilePath = TokensRecordController.tempFilePath({ collectionLocId, recordId, hash });
+        await this.fileStorageService.exportFile(file, tempFilePath);
+
+        downloadAndClean({
+            response: this.response,
+            path: tempFilePath,
+            name: publishedTokensRecordFile.name,
+            contentType: publishedTokensRecordFile.contentType,
+        });
+    }
+}

--- a/src/logion/migration/1676475638637-TokensRecord.ts
+++ b/src/logion/migration/1676475638637-TokensRecord.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class TokensRecord1676475638637 implements MigrationInterface {
+    name = 'TokensRecord1676475638637'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "tokens_record" ("collection_loc_id" uuid NOT NULL, "record_id" character varying NOT NULL, "added_on" TIMESTAMP, CONSTRAINT "PK_tokens_record" PRIMARY KEY ("collection_loc_id", "record_id"))`);
+        await queryRunner.query(`CREATE TABLE "tokens_record_file" ("collection_loc_id" uuid NOT NULL, "record_id" character varying NOT NULL, "hash" character varying NOT NULL, "cid" character varying(255) NOT NULL, CONSTRAINT "PK_tokens_record_file" PRIMARY KEY ("collection_loc_id", "record_id", "hash"))`);
+        await queryRunner.query(`CREATE TABLE "tokens_record_file_delivered" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "collection_loc_id" uuid NOT NULL, "record_id" character varying NOT NULL, "hash" character varying NOT NULL, "delivered_file_hash" character varying(255) NOT NULL, "generated_on" TIMESTAMP, "owner" character varying(255) NOT NULL, CONSTRAINT "PK_tokens_record_file_delivered" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IX_tokens_record_file_delivered_collection_loc_id_record_id_has" ON "tokens_record_file_delivered" ("collection_loc_id", "record_id", "hash") `);
+        await queryRunner.query(`ALTER TABLE "tokens_record_file" ADD CONSTRAINT "FK_tokens_record_file_collection_loc_id_record_id" FOREIGN KEY ("collection_loc_id", "record_id") REFERENCES "tokens_record"("collection_loc_id","record_id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "tokens_record_file_delivered" ADD CONSTRAINT "FK_tokens_record_file_delivered_collection_loc_id_record_id_has" FOREIGN KEY ("collection_loc_id", "record_id", "hash") REFERENCES "tokens_record_file"("collection_loc_id","record_id","hash") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tokens_record_file_delivered" DROP CONSTRAINT "FK_tokens_record_file_delivered_collection_loc_id_record_id_has"`);
+        await queryRunner.query(`ALTER TABLE "tokens_record_file" DROP CONSTRAINT "FK_tokens_record_file_collection_loc_id_record_id"`);
+        await queryRunner.query(`DROP INDEX "public"."IX_tokens_record_file_delivered_collection_loc_id_record_id_has"`);
+        await queryRunner.query(`DROP TABLE "tokens_record_file_delivered"`);
+        await queryRunner.query(`DROP TABLE "tokens_record_file"`);
+        await queryRunner.query(`DROP TABLE "tokens_record"`);
+    }
+
+}

--- a/src/logion/model/tokensrecord.model.ts
+++ b/src/logion/model/tokensrecord.model.ts
@@ -1,0 +1,293 @@
+import {
+    Entity,
+    PrimaryColumn,
+    Column,
+    Repository,
+    OneToMany,
+    ManyToOne,
+    JoinColumn,
+    Index
+} from "typeorm";
+import moment, { Moment } from "moment";
+import { injectable } from "inversify";
+
+import { appDataSource } from "@logion/rest-api-core";
+import { Child, saveChildren } from "./child.js";
+
+export interface TokensRecordDescription {
+    readonly collectionLocId: string;
+    readonly recordId: string;
+    readonly addedOn?: Moment;
+    readonly files?: TokensRecordFileDescription[];
+}
+
+export interface TokensRecordFileDescription {
+    readonly hash: string;
+    readonly cid: string;
+}
+
+@Entity("tokens_record")
+export class TokensRecordAggregateRoot {
+
+    getDescription(): TokensRecordDescription {
+        return {
+            collectionLocId: this.collectionLocId!,
+            recordId: this.recordId!,
+            addedOn: moment(this.addedOn),
+            files: this.files?.map(file => file.getDescription()) || []
+        }
+    }
+
+    addFile(fileDescription: TokensRecordFileDescription): TokensRecordFile {
+        const { hash, cid } = fileDescription
+        const file = new TokensRecordFile();
+        file.collectionLocId = this.collectionLocId;
+        file.recordId = this.recordId;
+        file.hash = hash;
+        file.cid = cid;
+        file.collectionItem = this;
+        file._toAdd = true;
+        this.files?.push(file);
+        return file
+    }
+
+    setAddedOn(addedOn: Moment) {
+        if(this.addedOn) {
+            throw new Error("Already set");
+        }
+        this.addedOn = addedOn.toDate();
+    }
+
+    @PrimaryColumn({ type: "uuid", name: "collection_loc_id" })
+    collectionLocId?: string;
+
+    @PrimaryColumn({ name: "record_id" })
+    recordId?: string;
+
+    @OneToMany(() => TokensRecordFile, file => file.collectionItem, {
+        eager: true,
+        cascade: false,
+        persistence: false
+    })
+    files?: TokensRecordFile[];
+
+    @Column("timestamp without time zone", { name: "added_on", nullable: true })
+    addedOn?: Date;
+
+    hasFile(hash: string): boolean {
+        return this.file(hash) !== undefined;
+    }
+
+    file(hash: string): TokensRecordFile | undefined {
+        return this.files!.find(file => file.hash === hash)
+    }
+
+    getFile(hash: string): TokensRecordFile {
+        return this.file(hash)!;
+    }
+}
+
+@Entity("tokens_record_file")
+export class TokensRecordFile extends Child {
+
+    getDescription(): TokensRecordFileDescription {
+        return {
+            hash: this.hash!,
+            cid: this.cid!,
+        }
+    }
+    @PrimaryColumn({ type: "uuid", name: "collection_loc_id" })
+    collectionLocId?: string;
+
+    @PrimaryColumn({ name: "record_id" })
+    recordId?: string;
+
+    @PrimaryColumn({ name: "hash" })
+    hash?: string;
+
+    @Column({ length: 255 })
+    cid?: string;
+
+    @ManyToOne(() => TokensRecordAggregateRoot, request => request.files)
+    @JoinColumn([
+        { name: "collection_loc_id", referencedColumnName: "collectionLocId" },
+        { name: "record_id", referencedColumnName: "recordId" },
+    ])
+    collectionItem?: TokensRecordAggregateRoot;
+
+    addDeliveredFile(params: {
+        deliveredFileHash: string,
+        generatedOn: Moment,
+        owner: string,
+    }): TokensRecordFileDelivered {
+        const { deliveredFileHash, generatedOn, owner } = params;
+        const deliveredFile = new TokensRecordFileDelivered();
+
+        deliveredFile.collectionLocId = this.collectionLocId;
+        deliveredFile.recordId = this.recordId;
+        deliveredFile.hash = this.hash;
+
+        deliveredFile.deliveredFileHash = deliveredFileHash;
+        deliveredFile.generatedOn = generatedOn.toDate();
+        deliveredFile.owner = owner;
+
+        deliveredFile.tokensRecordFile = this;
+        deliveredFile._toAdd = true;
+        this.delivered?.push(deliveredFile);
+        return deliveredFile;
+    }
+
+    @OneToMany(() => TokensRecordFileDelivered, deliveredFile => deliveredFile.tokensRecordFile, {
+        eager: true,
+        cascade: false,
+        persistence: false
+    })
+    delivered?: TokensRecordFileDelivered[];
+}
+
+@Entity("tokens_record_file_delivered")
+@Index([ "collectionLocId", "recordId", "hash" ])
+export class TokensRecordFileDelivered extends Child {
+
+    @PrimaryColumn({ type: "uuid", name: "id", default: () => "gen_random_uuid()", generated: "uuid" })
+    id?: string;
+
+    @Column({ type: "uuid", name: "collection_loc_id" })
+    collectionLocId?: string;
+
+    @Column({ name: "record_id" })
+    recordId?: string;
+
+    @Column({ name: "hash" })
+    hash?: string;
+
+    @Column({ name: "delivered_file_hash", length: 255 })
+    deliveredFileHash?: string;
+
+    @Column("timestamp without time zone", { name: "generated_on", nullable: true })
+    generatedOn?: Date;
+
+    @Column({ length: 255 })
+    owner?: string;
+
+    @ManyToOne(() => TokensRecordFile, file => file.delivered)
+    @JoinColumn([
+        { name: "collection_loc_id", referencedColumnName: "collectionLocId" },
+        { name: "record_id", referencedColumnName: "recordId" },
+        { name: "hash", referencedColumnName: "hash" },
+    ])
+    tokensRecordFile?: TokensRecordFile;
+}
+
+@injectable()
+export class TokensRecordRepository {
+
+    constructor() {
+        this.repository = appDataSource.getRepository(TokensRecordAggregateRoot);
+        this.fileRepository = appDataSource.getRepository(TokensRecordFile);
+        this.deliveredRepository = appDataSource.getRepository(TokensRecordFileDelivered);
+    }
+
+    readonly repository: Repository<TokensRecordAggregateRoot>;
+    readonly fileRepository: Repository<TokensRecordFile>;
+    readonly deliveredRepository: Repository<TokensRecordFileDelivered>;
+
+    public async save(root: TokensRecordAggregateRoot): Promise<void> {
+        await this.repository.save(root);
+        await this.saveFiles(root);
+    }
+
+    private async saveFiles(root: TokensRecordAggregateRoot): Promise<void> {
+        if(root.files) {
+            await saveChildren({
+                children: root.files,
+                entityManager: this.repository.manager,
+                entityClass: TokensRecordFile,
+            });
+            for(const file of root.files) {
+                await this.saveDelivered(file);
+            }
+        }
+    }
+
+    private async saveDelivered(root: TokensRecordFile): Promise<void> {
+        await saveChildren({
+            children: root.delivered,
+            entityManager: this.repository.manager,
+            entityClass: TokensRecordFileDelivered,
+        });
+    }
+
+    public async createIfNotExist(collectionLocId: string, recordId: string, creator: () => TokensRecordAggregateRoot): Promise<TokensRecordAggregateRoot> {
+        const existingTokensRecord = await this.repository.manager.findOneBy(TokensRecordAggregateRoot, {
+            collectionLocId,
+            recordId
+        });
+        if (existingTokensRecord) {
+            return existingTokensRecord;
+        } else {
+            const newTokensRecord = creator();
+            await this.repository.manager.insert(TokensRecordAggregateRoot, newTokensRecord);
+            return newTokensRecord;
+        }
+    }
+
+    public async findBy(collectionLocId: string, recordId: string): Promise<TokensRecordAggregateRoot | null> {
+        return this.repository.findOneBy({ collectionLocId, recordId })
+    }
+
+    public async findAllBy(collectionLocId: string): Promise<TokensRecordAggregateRoot[]> {
+        const builder = this.repository.createQueryBuilder("record");
+        builder.where("record.collection_loc_id = :collectionLocId", { collectionLocId });
+        builder.orderBy("record.added_on", "DESC");
+        return builder.getMany();
+    }
+
+    public async findLatestDelivery(query: { collectionLocId: string, recordId: string, fileHash: string }): Promise<TokensRecordFileDelivered | undefined> {
+        const { collectionLocId, recordId, fileHash } = query;
+        const deliveries = await this.findLatestDeliveries({ collectionLocId, recordId, fileHash, limit: 1 });
+        const deliveriesList = deliveries[fileHash];
+        if(deliveriesList) {
+            return deliveriesList[0];
+        } else {
+            return undefined;
+        }
+    }
+
+    public async findLatestDeliveries(query: { collectionLocId: string, recordId: string, fileHash?: string, limit?: number }): Promise<Record<string, TokensRecordFileDelivered[]>> {
+        const { collectionLocId, recordId, fileHash, limit } = query;
+        let builder = this.deliveredRepository.createQueryBuilder("delivery");
+        builder.where("delivery.collection_loc_id = :collectionLocId", { collectionLocId });
+        builder.andWhere("delivery.record_id = :recordId", { recordId });
+        if(fileHash) {
+            builder.andWhere("delivery.hash = :fileHash", { fileHash });
+        }
+        builder.orderBy("delivery.generated_on", "DESC");
+        if(limit) {
+            builder.limit(limit);
+        }
+        const deliveriesList = await builder.getMany();
+        const deliveries: Record<string, TokensRecordFileDelivered[]> = {};
+        for(const delivery of deliveriesList) {
+            const hash = delivery.hash!;
+            deliveries[hash] ||= [];
+            const fileDeliveries = deliveries[hash];
+            fileDeliveries.push(delivery);
+        }
+        return deliveries;
+    }
+}
+
+@injectable()
+export class TokensRecordFactory {
+
+    newTokensRecord(params: TokensRecordDescription): TokensRecordAggregateRoot {
+        const { collectionLocId, recordId, addedOn } = params;
+        const item = new TokensRecordAggregateRoot()
+        item.collectionLocId = collectionLocId;
+        item.recordId = recordId;
+        item.addedOn = addedOn?.toDate();
+        item.files = [];
+        return item;
+    }
+}

--- a/src/logion/services/locauthorization.service.ts
+++ b/src/logion/services/locauthorization.service.ts
@@ -1,0 +1,40 @@
+import { AuthenticatedUser } from "@logion/authenticator";
+import { getVerifiedIssuers, UUID } from "@logion/node-api";
+import { AuthenticationService, forbidden, PolkadotService } from '@logion/rest-api-core';
+import { Request } from 'express';
+import { injectable } from 'inversify';
+import { LocRequestAggregateRoot } from '../model/locrequest.model';
+
+@injectable()
+export class LocAuthorizationService {
+
+    constructor(
+        private authenticationService: AuthenticationService,
+        private polkadotService: PolkadotService,
+    ) {}
+
+    async ensureContributor(httpRequest: Request, request: LocRequestAggregateRoot): Promise<string> {
+        const authenticatedUser = await this.authenticationService.authenticatedUser(httpRequest);
+        if (await this.isContributor(request, authenticatedUser)) {
+            return authenticatedUser.address;
+        } else {
+            throw forbidden("Authenticated user is not allowed to contribute to this LOC");
+        }
+    }
+
+    async isContributor(request: LocRequestAggregateRoot, authenticatedUser: AuthenticatedUser): Promise<boolean> {
+        const contributor = authenticatedUser.address;
+        return (
+            request.ownerAddress === contributor ||
+            request.requesterAddress === contributor ||
+            await this.isSelectedThirdParty(request, contributor)
+        );
+    }
+
+    private async isSelectedThirdParty(request: LocRequestAggregateRoot, submitter: string): Promise<boolean> {
+        const api = await this.polkadotService.readyApi();
+        const issuers = await getVerifiedIssuers(api, new UUID(request.id));
+        const selectedParticipant = issuers.find(issuer => issuer.address === submitter);
+        return selectedParticipant !== undefined;
+    }
+}

--- a/src/logion/services/tokensrecord.service.ts
+++ b/src/logion/services/tokensrecord.service.ts
@@ -1,0 +1,86 @@
+import { injectable } from "inversify";
+import { DefaultTransactional, PolkadotService, requireDefined } from "@logion/rest-api-core";
+import { UUID, TokensRecord, toTokensRecord, TokensRecordFile } from "@logion/node-api";
+import { TokensRecordAggregateRoot, TokensRecordRepository } from "../model/tokensrecord.model.js";
+
+export interface GetTokensRecordParams {
+    collectionLocId: string,
+    recordId: string,
+}
+
+export interface GetTokensRecordFileParams extends GetTokensRecordParams {
+    hash: string
+}
+
+@injectable()
+export class LogionNodeTokensRecordService {
+
+    constructor(
+        private polkadotService: PolkadotService,
+    ) {}
+
+    async getTokensRecord(params: GetTokensRecordParams): Promise<TokensRecord | undefined> {
+        const { collectionLocId, recordId } = params;
+        const api = await this.polkadotService.readyApi();
+        const substrateObject = await api.query.logionLoc.tokensRecordsMap(new UUID(collectionLocId).toDecimalString(), recordId);
+        if(substrateObject.isSome) {
+            return toTokensRecord(substrateObject.unwrap());
+        } else {
+            return undefined;
+        }
+    }
+
+    async getTokensRecordFile(params: GetTokensRecordFileParams): Promise<TokensRecordFile | undefined> {
+        const { hash } = params;
+        const record = await this.getTokensRecord(params);
+        return record?.files.find(itemFile => itemFile.hash === hash);
+    }
+}
+
+export abstract class TokensRecordService {
+
+    constructor(
+        private tokensRecordRepository: TokensRecordRepository,
+    ) {}
+
+    async createIfNotExist(collectionLocId: string, recordId: string, creator: () => TokensRecordAggregateRoot): Promise<TokensRecordAggregateRoot> {
+        return await this.tokensRecordRepository.createIfNotExist(collectionLocId, recordId, creator);
+    }
+
+    async update(collectionLocId: string, recordId: string, mutator: (item: TokensRecordAggregateRoot) => Promise<void>): Promise<TokensRecordAggregateRoot> {
+        const item = requireDefined(await this.tokensRecordRepository.findBy(collectionLocId, recordId));
+        await mutator(item);
+        await this.tokensRecordRepository.save(item);
+        return item;
+    }
+}
+
+@injectable()
+export class TransactionalTokensRecordService extends TokensRecordService {
+
+    constructor(
+        tokensRecordRepository: TokensRecordRepository,
+    ) {
+        super(tokensRecordRepository);
+    }
+
+    @DefaultTransactional()
+    async createIfNotExist(collectionLocId: string, recordId: string, creator: () => TokensRecordAggregateRoot): Promise<TokensRecordAggregateRoot> {
+        return super.createIfNotExist(collectionLocId, recordId, creator);
+    }
+
+    @DefaultTransactional()
+    async update(collectionLocId: string, recordId: string, mutator: (item: TokensRecordAggregateRoot) => Promise<void>): Promise<TokensRecordAggregateRoot> {
+        return super.update(collectionLocId, recordId, mutator);
+    }
+}
+
+@injectable()
+export class NonTransactionalTokensRecordService extends TokensRecordService {
+
+    constructor(
+        tokensRecordRepository: TokensRecordRepository,
+    ) {
+        super(tokensRecordRepository);
+    }
+}

--- a/test/integration/migration/migration.spec.ts
+++ b/test/integration/migration/migration.spec.ts
@@ -7,7 +7,7 @@ const { connect, disconnect, queryRunner, allMigrations } = TestDb;
 
 describe('Migration', () => {
 
-    const NUM_OF_TABLES = 18;
+    const NUM_OF_TABLES = 21;
 
     beforeEach(async () => {
         await connect([ "src/logion/model/*.model.ts" ], [ "src/logion/migration/*.ts" ], false);

--- a/test/unit/controllers/locrequest.controller.shared.ts
+++ b/test/unit/controllers/locrequest.controller.shared.ts
@@ -26,11 +26,12 @@ import { PersonalInfo } from "../../../src/logion/model/personalinfo.model.js";
 import { LocRequestService, NonTransactionalLocRequestService } from "../../../src/logion/services/locrequest.service.js";
 import { DisabledIdenfyService, IdenfyService } from "../../../src/logion/services/idenfy/idenfy.service.js";
 import { VoteRepository, VoteAggregateRoot } from "../../../src/logion/model/vote.model.js";
-import { PolkadotService } from "@logion/rest-api-core";
+import { AuthenticationService, PolkadotService } from "@logion/rest-api-core";
 import { LogionNodeApi, UUID } from "@logion/node-api";
 import { Option } from "@polkadot/types-codec";
 import { PalletLogionLocVerifiedIssuer, PalletLogionLocLegalOfficerCase } from "@polkadot/types/lookup";
 import { VerifiedThirdPartySelectionRepository } from "../../../src/logion/model/verifiedthirdpartyselection.model.js";
+import { LocAuthorizationService } from "../../../src/logion/services/locauthorization.service.js";
 
 export type IdentityLocation = IdentityLocType | 'EmbeddedInLoc';
 export const REQUESTER_ADDRESS = "5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ";
@@ -171,6 +172,12 @@ export function buildMocks(container: Container, existingMocks?: Partial<Mocks>)
     polkadotService.setup(instance => instance.readyApi()).returnsAsync(nodeApi.object());
 
     const loc = existingMocks?.loc ? existingMocks.loc  : new Mock<PalletLogionLocLegalOfficerCase>();
+
+    const locAuthorizationService = new LocAuthorizationService(
+        container.get(AuthenticationService),
+        polkadotService.object(),
+    );
+    container.bind(LocAuthorizationService).toConstantValue(locAuthorizationService);
 
     return {
         factory,

--- a/test/unit/controllers/records.controller.spec.ts
+++ b/test/unit/controllers/records.controller.spec.ts
@@ -1,0 +1,501 @@
+import { TestApp } from "@logion/rest-api-core";
+import { Container } from "inversify";
+import { Mock, It } from "moq.ts";
+import { CollectionItem, TokensRecord as ChainTokensRecord, TokensRecordFile as ChainTokensRecordFile } from "@logion/node-api";
+import { writeFile } from "fs/promises";
+import moment from "moment";
+import request from "supertest";
+import {
+    LocRequestAggregateRoot,
+    LocRequestRepository,
+} from "../../../src/logion/model/locrequest.model.js";
+import { FileStorageService } from "../../../src/logion/services/file.storage.service.js";
+import { GetCollectionItemParams, LogionNodeCollectionService } from "../../../src/logion/services/collection.service.js";
+import { fileExists } from "../../helpers/filehelper.js";
+import { OwnershipCheckService } from "../../../src/logion/services/ownershipcheck.service.js";
+import { RestrictedDeliveryService } from "../../../src/logion/services/restricteddelivery.service.js";
+import { ALICE } from "../../helpers/addresses.js";
+import { TokensRecordController } from "../../../src/logion/controllers/records.controller.js";
+import {
+    TokensRecordRepository,
+    TokensRecordFactory,
+    TokensRecordAggregateRoot,
+    TokensRecordFileDelivered,
+    TokensRecordFile
+} from "../../../src/logion/model/tokensrecord.model.js";
+import { GetTokensRecordFileParams, GetTokensRecordParams, LogionNodeTokensRecordService, NonTransactionalTokensRecordService, TokensRecordService } from "../../../src/logion/services/tokensrecord.service.js";
+import { LocAuthorizationService } from "../../../src/logion/services/locauthorization.service.js";
+
+const collectionLocId = "d61e2e12-6c06-4425-aeee-2a0e969ac14e";
+const collectionLocOwner = ALICE;
+const collectionRequester = "5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX";
+const itemId = "0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705";
+const timestamp = moment();
+
+const ITEM_TOKEN_OWNER = "0x900edc98db53508e6742723988B872dd08cd09c3";
+
+const recordId = "0x59772b9c70d6cc244274937445f7c5b56ec6fe0a11292c4ed68848655515a1e6";
+const recordSubmitter = "5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb";
+const SOME_DATA = 'some data';
+const SOME_DATA_HASH = '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee';
+const FILE_NAME = "'a-file.pdf'";
+const CID = "cid-784512";
+const CONTENT_TYPE = "text/plain";
+const DELIVERY_HASH = '0xf35e4bcbc1b0ce85af90914e04350cce472a2f01f00c0f7f8bc5c7ba04da2bf2';
+
+const { setupApp, mockAuthenticationWithAuthenticatedUser, mockAuthenticatedUser } = TestApp;
+
+describe("TokensRecordController", () => {
+
+    it("gets all records in a collection", async () => {
+
+        const app = setupApp(TokensRecordController, container => mockModelForGet(container, true));
+
+        await request(app)
+            .get(`/api/records/${ collectionLocId }`)
+            .send()
+            .expect(200)
+            .then(response => {
+                expect(response.body.records.length).toBe(1)
+            })
+    })
+
+    it("gets an existing tokens record in DB", async () => {
+
+        const app = setupApp(TokensRecordController, container => mockModelForGet(container, true));
+
+        await request(app)
+            .get(`/api/records/${ collectionLocId }/record/${ recordId }`)
+            .send()
+            .expect(200)
+            .then(response => {
+                expect(response.body.collectionLocId).toEqual(collectionLocId)
+                expect(response.body.recordId).toEqual(recordId)
+                expect(response.body.addedOn).toEqual(timestamp.toISOString())
+                expect(response.body.files[0]).toEqual(SOME_DATA_HASH)
+            })
+    })
+
+    it("gets a tokens record existing on Chain only", async () => {
+
+        const app = setupApp(TokensRecordController, container => mockModelForGet(container, false));
+
+        await request(app)
+            .get(`/api/records/${ collectionLocId }/record/${ recordId }`)
+            .send()
+            .expect(200)
+            .then(response => {
+                expect(response.body.collectionLocId).toEqual(collectionLocId)
+                expect(response.body.recordId).toEqual(recordId)
+                expect(response.body.addedOn).toBeUndefined()
+                expect(response.body.files).toEqual([])
+            })
+    })
+
+    it("gets an error code when requesting non-existent tokens record", async () => {
+
+        const app = setupApp(TokensRecordController, container => mockModelForGet(container, false));
+
+        await request(app)
+            .get(`/api/records/${ collectionLocId }/record/0x12345`)
+            .send()
+            .expect(400)
+            .then(response => {
+                expect(response.body.errorMessage).toEqual("Tokens Record d61e2e12-6c06-4425-aeee-2a0e969ac14e/0x12345 not found")
+            })
+    })
+
+    it('adds file to tokens record', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: false,
+            recordPublished: true,
+            filePublished: true,
+        }));
+        const buffer = Buffer.from(SOME_DATA);
+        await request(app)
+            .post(`/api/records/${ collectionLocId }/${ recordId }/files`)
+            .field({ hash: SOME_DATA_HASH })
+            .attach('file', buffer, { filename: FILE_NAME })
+            .expect(200);
+    })
+
+    it('fails to add file to tokens record if wrong hash', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: true,
+            recordPublished: true,
+            filePublished: true,
+        }));
+        const buffer = Buffer.from(SOME_DATA);
+        await request(app)
+            .post(`/api/records/${ collectionLocId }/${ recordId }/files`)
+            .field({ hash: "wrong-hash" })
+            .attach('file', buffer, { filename: FILE_NAME })
+            .expect(400)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.errorMessage).toBe("Received hash wrong-hash does not match 0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee");
+            });
+    })
+
+    it('fails to add file to tokens record if already in DB', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: true,
+            recordPublished: true,
+            filePublished: true,
+        }));
+        const buffer = Buffer.from(SOME_DATA);
+        await request(app)
+            .post(`/api/records/${ collectionLocId }/${ recordId }/files`)
+            .field({ hash: SOME_DATA_HASH })
+            .attach('file', buffer, { filename: FILE_NAME })
+            .expect(400)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.errorMessage).toBe("File is already uploaded");
+            });
+    })
+
+    it('fails to add file to a non-existing tokens record', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: false,
+            recordPublished: false,
+            filePublished: false,
+        }));
+        const buffer = Buffer.from(SOME_DATA);
+        await request(app)
+            .post(`/api/records/${ collectionLocId }/${ recordId }/files`)
+            .field({ hash: SOME_DATA_HASH })
+            .attach('file', buffer, { filename: FILE_NAME })
+            .expect(400)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.errorMessage).toBe("Tokens Record not found on chain");
+            });
+    })
+
+    it('fails to add file to a non-existing tokens record file', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: false,
+            recordPublished: true,
+            filePublished: false,
+        }));
+        const buffer = Buffer.from(SOME_DATA);
+        await request(app)
+            .post(`/api/records/${ collectionLocId }/${ recordId }/files`)
+            .field({ hash: SOME_DATA_HASH })
+            .attach('file', buffer, { filename: FILE_NAME })
+            .expect(400)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.errorMessage).toBe("Tokens Record File not found on chain");
+            });
+    })
+
+    it('fails to add file if name does not match', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: false,
+            recordPublished: true,
+            filePublished: true,
+        }));
+        const buffer = Buffer.from(SOME_DATA);
+        await request(app)
+            .post(`/api/records/${ collectionLocId }/${ recordId }/files`)
+            .field({ hash: SOME_DATA_HASH })
+            .attach('file', buffer, { filename: "WrongName.pdf" })
+            .expect(400)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.errorMessage).toBe("Invalid name. Actually uploaded WrongName.pdf while expecting 'a-file.pdf'");
+            });
+    });
+
+    const downloadUrl = `/api/records/${ collectionLocId }/${ recordId }/files/${ SOME_DATA_HASH }/${ itemId }`;
+
+    it('fails to download non-existing file', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: false,
+            recordPublished: true,
+            filePublished: true,
+        }));
+        const filePath = TokensRecordController.tempFilePath({ collectionLocId, recordId, hash: SOME_DATA_HASH});
+        await writeFile(filePath, SOME_DATA);
+        await request(app)
+            .get(downloadUrl)
+            .expect(400)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.errorMessage).toBe("Trying to download a file that is not uploaded yet.");
+            });
+    })
+
+    it('fails to download from a non-existing file', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: false,
+            recordPublished: false,
+            filePublished: false,
+        }));
+        const filePath = TokensRecordController.tempFilePath({ collectionLocId, recordId, hash: SOME_DATA_HASH});
+        await writeFile(filePath, SOME_DATA);
+        await request(app)
+            .get(downloadUrl)
+            .expect(400)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.errorMessage).toBe("Trying to download a file that is not uploaded yet.");
+            });
+    })
+
+    it('downloads existing file given its hash and is owner', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: true,
+            recordPublished: true,
+            filePublished: true,
+            isOwner: true,
+        }));
+        const filePath = TokensRecordController.tempFilePath({ collectionLocId, recordId, hash: SOME_DATA_HASH});
+        await writeFile(filePath, SOME_DATA);
+        await request(app)
+            .get(downloadUrl)
+            .expect(200, SOME_DATA)
+            .expect('Content-Type', /text\/plain/);
+        let fileReallyExists = true;
+        for (let i = 0; i < 10; ++i) {
+            if (!await fileExists(filePath)) {
+                fileReallyExists = false;
+                break;
+            }
+        }
+        expect(fileReallyExists).toBe(false);
+    })
+
+    it('fails to download existing file given its hash and is not owner', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: true,
+            recordPublished: true,
+            filePublished: true,
+            isOwner: false,
+        }));
+        const filePath = TokensRecordController.tempFilePath({ collectionLocId, recordId, hash: SOME_DATA_HASH});
+        await writeFile(filePath, SOME_DATA);
+        await request(app)
+            .get(downloadUrl)
+            .expect(403)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.errorMessage).toBe("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY does not seem to be the owner of related item's underlying token");
+            });
+    })
+
+    it('retrieves deliveries info', async () => {
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: true,
+            recordPublished: true,
+            filePublished: true,
+            isOwner: true,
+        }));
+        await request(app)
+            .get(`/api/records/${ collectionLocId }/${ recordId }/deliveries`)
+            .expect(200)
+            .expect('Content-Type', /application\/json/)
+            .then(response => expectDeliveryInfo(response.body[SOME_DATA_HASH][0]));
+    })
+
+    it('downloads existing file source given its hash and is owner', async () => {
+        const mock = mockAuthenticationWithAuthenticatedUser(mockAuthenticatedUser(true, collectionLocOwner));
+        const app = setupApp(TokensRecordController, container => mockModel(container, {
+            recordAlreadyInDB: true,
+            fileAlreadyInDB: true,
+            recordPublished: true,
+            filePublished: true,
+            isOwner: true,
+        }), mock);
+        const filePath = TokensRecordController.tempFilePath({ collectionLocId, recordId, hash: SOME_DATA_HASH});
+        await writeFile(filePath, SOME_DATA);
+        await request(app)
+            .get(`/api/records/${ collectionLocId }/${ recordId }/files-sources/${ SOME_DATA_HASH }`)
+            .expect(200, SOME_DATA)
+            .expect('Content-Type', /text\/plain/);
+        let fileReallyExists = true;
+        for (let i = 0; i < 10; ++i) {
+            if (!await fileExists(filePath)) {
+                fileReallyExists = false;
+                break;
+            }
+        }
+        expect(fileReallyExists).toBe(false);
+    })
+})
+
+function mockModelForGet(container: Container, collectionItemAlreadyInDB: boolean): void {
+    return mockModel(container, { recordAlreadyInDB: collectionItemAlreadyInDB, fileAlreadyInDB: true, recordPublished: true, filePublished: true })
+}
+
+function mockModel(
+    container: Container,
+    params: {
+        recordAlreadyInDB: boolean,
+        fileAlreadyInDB: boolean,
+        recordPublished: boolean,
+        filePublished: boolean,
+        isOwner?: boolean,
+    }): void {
+    const { recordAlreadyInDB, fileAlreadyInDB, recordPublished, filePublished, isOwner } = params;
+    const tokensRecord = new TokensRecordAggregateRoot()
+    const collectionLoc = new LocRequestAggregateRoot();
+    collectionLoc.id = collectionLocId;
+    tokensRecord.collectionLocId = collectionLocId;
+    tokensRecord.recordId = recordId;
+    tokensRecord.addedOn = timestamp.toDate();
+    if (fileAlreadyInDB) {
+        const collectionItemFile = new TokensRecordFile();
+        collectionItemFile.collectionLocId = collectionLocId;
+        collectionItemFile.recordId = recordId;
+        collectionItemFile.hash = SOME_DATA_HASH;
+        collectionItemFile.cid = CID;
+        collectionItemFile.collectionItem = tokensRecord;
+        tokensRecord.files = [ collectionItemFile ];
+    } else {
+        tokensRecord.files = [];
+    }
+    const collectionItemFile = new Mock<TokensRecordFile>()
+    const tokensRecordRepository = new Mock<TokensRecordRepository>()
+    const locRequestRepository = new Mock<LocRequestRepository>();
+    if (recordAlreadyInDB) {
+        tokensRecordRepository.setup(instance => instance.findBy(collectionLocId, recordId))
+            .returns(Promise.resolve(tokensRecord))
+        tokensRecordRepository.setup(instance => instance.findAllBy(collectionLocId))
+            .returns(Promise.resolve([ tokensRecord ]))
+    } else {
+        tokensRecordRepository.setup(instance => instance.findBy(collectionLocId, recordId))
+            .returns(Promise.resolve(null))
+        tokensRecordRepository.setup(instance => instance.findAllBy(collectionLocId))
+            .returns(Promise.resolve([]))
+    }
+    tokensRecordRepository.setup(instance => instance.createIfNotExist(
+        It.Is<string>(param => param === collectionLocId),
+        It.Is<string>(param => param === recordId),
+        It.IsAny<() => TokensRecordAggregateRoot>(),
+    )).returns(Promise.resolve(tokensRecord));
+    tokensRecordRepository.setup(instance => instance.save(tokensRecord)).returnsAsync();
+
+    const delivered: TokensRecordFileDelivered = {
+        collectionLocId,
+        recordId,
+        hash: SOME_DATA_HASH,
+        deliveredFileHash: DELIVERY_HASH,
+        generatedOn: new Date(),
+        owner: ITEM_TOKEN_OWNER,
+        tokensRecordFile: collectionItemFile.object(),
+    };
+
+    tokensRecordRepository.setup(instance => instance.findLatestDelivery(
+        It.Is<{ collectionLocId: string, recordId: string, fileHash: string }>(query =>
+            query.collectionLocId === collectionLocId
+            && query.recordId === recordId
+            && query.fileHash === SOME_DATA_HASH
+        ))
+    ).returnsAsync(delivered);
+
+    tokensRecordRepository.setup(instance => instance.findLatestDeliveries(
+        It.Is<{ collectionLocId: string, recordId: string }>(query =>
+            query.collectionLocId === collectionLocId
+            && query.recordId === recordId
+        ))
+    ).returnsAsync({
+        [ SOME_DATA_HASH ]: [ delivered ]
+    });
+
+    container.bind(TokensRecordRepository).toConstantValue(tokensRecordRepository.object())
+
+    collectionLoc.ownerAddress = collectionLocOwner;
+    collectionLoc.requesterAddress = collectionRequester;
+    collectionLoc.locType = "Collection";
+    collectionLoc.status = "CLOSED";
+    locRequestRepository.setup(instance => instance.findById(collectionLocId))
+        .returns(Promise.resolve(collectionLoc))
+    locRequestRepository.setup(instance => instance.save(It.IsAny<LocRequestAggregateRoot>()))
+        .returns(Promise.resolve())
+    container.bind(LocRequestRepository).toConstantValue(locRequestRepository.object())
+
+    const tokensRecordFactory = new Mock<TokensRecordFactory>()
+    container.bind(TokensRecordFactory).toConstantValue(tokensRecordFactory.object())
+
+    const fileStorageService = new Mock<FileStorageService>()
+    const filePath = TokensRecordController.tempFilePath({ collectionLocId, recordId, hash: SOME_DATA_HASH });
+    fileStorageService.setup(instance => instance.importFile(filePath))
+        .returns(Promise.resolve(CID))
+    fileStorageService.setup(instance => instance.exportFile({ cid: CID }, filePath))
+        .returns(Promise.resolve())
+    container.bind(FileStorageService).toConstantValue(fileStorageService.object())
+
+    const publishedCollectionItem: CollectionItem = {
+        id: recordId,
+        description: "Item Description",
+        files: [],
+        restrictedDelivery: false,
+        termsAndConditions: [],
+    }
+    const logionNodeCollectionService = new Mock<LogionNodeCollectionService>();
+    logionNodeCollectionService.setup(instance => instance.getCollectionItem(It.Is<GetCollectionItemParams>(
+        param => param.collectionLocId === collectionLocId && param.itemId === itemId)
+    ))
+        .returns(Promise.resolve(publishedCollectionItem));
+    container.bind(LogionNodeCollectionService).toConstantValue(logionNodeCollectionService.object());
+
+    const publishedTokensRecordFile: ChainTokensRecordFile = {
+        hash: SOME_DATA_HASH,
+        name: FILE_NAME,
+        contentType: CONTENT_TYPE,
+        size: SOME_DATA.length.toString(),
+    };
+    const publishedTokensRecord: ChainTokensRecord = {
+        description: "Item Description",
+        files: [],
+        submitter: recordSubmitter,
+    }
+    if(filePublished) {
+        publishedTokensRecord.files.push(publishedTokensRecordFile);
+    }
+    const logionNodeTokensRecordService = new Mock<LogionNodeTokensRecordService>();
+    logionNodeTokensRecordService.setup(instance => instance.getTokensRecord(It.Is<GetTokensRecordParams>(
+        param => param.collectionLocId === collectionLocId && param.recordId === recordId)
+    ))
+        .returns(Promise.resolve(recordPublished ? publishedTokensRecord : undefined));
+        logionNodeTokensRecordService.setup(instance => instance.getTokensRecordFile(It.Is<GetTokensRecordFileParams>(
+        param => param.collectionLocId === collectionLocId && param.recordId === recordId && param.hash === SOME_DATA_HASH)
+    ))
+        .returns(Promise.resolve(filePublished ? publishedTokensRecordFile : undefined));
+    container.bind(LogionNodeTokensRecordService).toConstantValue(logionNodeTokensRecordService.object());
+
+    const ownershipCheckService = new Mock<OwnershipCheckService>();
+    ownershipCheckService.setup(instance => instance.isOwner(It.IsAny(), It.IsAny())).returnsAsync(isOwner || false);
+    container.bind(OwnershipCheckService).toConstantValue(ownershipCheckService.object());
+
+    const restrictedDeliveryService = new Mock<RestrictedDeliveryService>();
+    restrictedDeliveryService.setup(instance => instance.setMetadata(It.IsAny())).returnsAsync();
+    container.bind(RestrictedDeliveryService).toConstantValue(restrictedDeliveryService.object());
+
+    container.bind(TokensRecordService).toConstantValue(new NonTransactionalTokensRecordService(tokensRecordRepository.object()));
+
+    const locAuthorityService = new Mock<LocAuthorizationService>();
+    locAuthorityService.setup(instance => instance.ensureContributor(It.IsAny(), It.IsAny())).returnsAsync(ALICE);
+    locAuthorityService.setup(instance => instance.isContributor(It.IsAny(), It.IsAny())).returnsAsync(true);
+    container.bind(LocAuthorizationService).toConstantValue(locAuthorityService.object());
+}
+
+function expectDeliveryInfo(responseBody: any) {
+    expect(responseBody.copyHash).toBe(DELIVERY_HASH);
+    expect(responseBody.generatedOn).toBeDefined();
+    expect(responseBody.owner).toBe(ITEM_TOKEN_OWNER);
+}

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -16,6 +16,8 @@ import { NonTransactionalCollectionService } from "../../../src/logion/services/
 import { NotificationService } from "../../../src/logion/services/notification.service.js";
 import { DirectoryService } from "../../../src/logion/services/directory.service.js";
 import { VerifiedThirdPartySelectionService } from "src/logion/services/verifiedthirdpartyselection.service.js";
+import { NonTransactionalTokensRecordService } from "../../../src/logion/services/tokensrecord.service.js";
+import { TokensRecordFactory, TokensRecordRepository } from "../../../src/logion/model/tokensrecord.model.js";
 
 describe("LocSynchronizer", () => {
 
@@ -27,6 +29,8 @@ describe("LocSynchronizer", () => {
         directoryService = new Mock();
         polkadotService = new Mock();
         verifiedThirdPartySelectionService = new Mock();
+        tokensRecordFactory = new Mock();
+        tokensRecordRepository = new Mock();
     });
 
     it("sets LOC created date", async () => {
@@ -202,6 +206,8 @@ function locSynchronizer(): LocSynchronizer {
         directoryService.object(),
         polkadotService.object(),
         verifiedThirdPartySelectionService.object(),
+        new NonTransactionalTokensRecordService(tokensRecordRepository.object()),
+        tokensRecordFactory.object(),
     );
 }
 
@@ -209,6 +215,8 @@ let notificationService: Mock<NotificationService>;
 let directoryService: Mock<DirectoryService>;
 let polkadotService: Mock<PolkadotService>;
 let verifiedThirdPartySelectionService: Mock<VerifiedThirdPartySelectionService>;
+let tokensRecordRepository: Mock<TokensRecordRepository>;
+let tokensRecordFactory: Mock<TokensRecordFactory>;
 
 function thenLocCreateDateSet() {
     locRequest.verify(instance => instance.setLocCreatedDate(IS_BLOCK_TIME));


### PR DESCRIPTION
* Logic is almost a copy/paste of what we already have for collection items
* Main differences are:
  * Any contributor can add records (not only requester)
  * The download of a record file is linked to an actual item (enabling ownership check)
  * No ownership check at record level (it is irrelevant)

logion-network/logion-internal#773