### PR TITLE
LOC template

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -566,6 +566,10 @@
                     "draft": {
                         "type": "boolean",
                         "description": "LOC will be created with initial status DRAFT if true, REQUESTED otherwise (false or undefined)"
+                    },
+                    "template": {
+                        "type": "string",
+                        "description": "The LOC's template or undefined"
                     }
                 },
                 "title": "CreateLocRequestView",

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -323,6 +323,8 @@ export interface components {
       company?: string;
       /** @description LOC will be created with initial status DRAFT if true, REQUESTED otherwise (false or undefined) */
       draft?: boolean;
+      /** @description The LOC's template or undefined */
+      template?: string;
     };
     LocFileView: {
       /** @description The file's name */

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -143,6 +143,7 @@ export class LocRequestController extends ApiController {
             userIdentity: locType === "Identity" ? this.fromUserIdentityView(createLocRequestView.userIdentity) : undefined,
             userPostalAddress: locType === "Identity" ? this.fromUserPostalAddressView(createLocRequestView.userPostalAddress) : undefined,
             company: createLocRequestView.company,
+            template: createLocRequestView.template,
         }
         if (locType === "Identity") {
             if ((await this.existsValidPolkadotIdentityLoc(description.requesterAddress, ownerAddress))) {

--- a/src/logion/migration/1677148843394-LocTemplate.ts
+++ b/src/logion/migration/1677148843394-LocTemplate.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class LocTemplate1677148843394 implements MigrationInterface {
+    name = 'LocTemplate1677148843394'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request" ADD "template" character varying(255)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request" DROP COLUMN "template"`);
+    }
+
+}

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -35,6 +35,7 @@ export interface LocRequestDescription {
     readonly locType: LocType;
     readonly seal?: PublicSeal;
     readonly company?: string;
+    readonly template?: string;
 }
 
 export interface LocRequestDecision {
@@ -192,6 +193,7 @@ export class LocRequestAggregateRoot {
             locType: this.locType!,
             seal: toPublicSeal(this.seal),
             company: this.company!,
+            template: this.template,
         }
     }
 
@@ -713,6 +715,9 @@ export class LocRequestAggregateRoot {
     @Column(() => EmbeddableIdenfyVerification, { prefix: ""} )
     iDenfyVerification?: EmbeddableIdenfyVerification;
 
+    @Column({ length: 255, name: "template", nullable: true })
+    template?: string;
+
     _filesToDelete: LocFile[] = [];
     _linksToDelete: LocLink[] = [];
     _metadataToDelete: LocMetadataItem[] = [];
@@ -1088,7 +1093,14 @@ export class LocRequestFactory {
     }
 
     async newSofRequest(params: NewSofRequestParameters): Promise<LocRequestAggregateRoot> {
-        const request = await this.newLocRequest({ ...params, draft: true });
+        const request = await this.newLocRequest({
+            ...params,
+            draft: true,
+            description: {
+                ...params.description,
+                template: "STATEMENT_OF_FACTS"
+            }
+        });
         request.addLink(params);
         request.submit();
         return request;
@@ -1138,6 +1150,7 @@ export class LocRequestFactory {
         request.files = [];
         request.metadata = [];
         request.links = [];
+        request.template = description.template;
         return request;
     }
 

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -197,7 +197,10 @@ describe("LocRequestFactory", () => {
         const target = "target-loc"
         const nature = "Original LOC"
         await whenCreatingSofRequest(target, nature);
-        thenRequestCreatedWithDescription(description);
+        thenRequestCreatedWithDescription({
+            ...description,
+            template: "STATEMENT_OF_FACTS"
+        });
         expect(request.links?.length).toBe(1)
         expect(request.links![0].target).toEqual(target)
         expect(request.links![0].nature).toEqual(nature)
@@ -223,6 +226,7 @@ describe("LocRequestFactory", () => {
             locType,
             seal,
             company: undefined,
+            template: undefined,
         };
     }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8534,11 +8534,11 @@ __metadata:
   linkType: hard
 
 "undici@npm:^5.12.0":
-  version: 5.14.0
-  resolution: "undici@npm:5.14.0"
+  version: 5.20.0
+  resolution: "undici@npm:5.20.0"
   dependencies:
     busboy: ^1.6.0
-  checksum: 7a076e44d84b25844b4eb657034437b8b9bb91f17d347de474fdea1d4263ce7ae9406db79cd30de5642519277b4893f43073258bcc8fed420b295da3fdd11b26
+  checksum: 25412a785b2bd0b12f0bb0ec47ef00aa7a611ca0e570cb7af97cffe6a42e0d78e4b15190363a43771e9002defc3c6647c1b2d52201b3f64e2196819db4d150d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Add template field to LOC requests.
* The field is unconstrained (but still limited to 255 characters) text as everything is handled frontend-side. One exception: the SOF template value is automatically injected by the LOC request factory.
* The purpose of not using an enumeration is to fully delegate the handling of LOC templates to the frontend. Indeed, the constraints linked to a LOC template will only be managed frontend-side which enables a higher flexibility.
* LOC templates are more a way to describe best practices rather than imposing some data invariant.