### PR TITLE
Accept requester on LOC creation by owner

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -574,6 +574,10 @@
             "CreateLocRequestView": {
                 "type": "object",
                 "properties": {
+                    "requesterAddress": {
+                        "description": "The address of the requester (this is only taken into account when created by the owner, which is needed when replacing a voided LOC)",
+                        "$ref": "#/components/schemas/RequesterAddress"
+                    },
                     "requesterIdentityLoc": {
                         "type": "string",
                         "format": "uuid",

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -324,6 +324,8 @@ export interface components {
      * @description A LOC Request to create
      */
     CreateLocRequestView: {
+      /** @description The address of the requester (this is only taken into account when created by the owner, which is needed when replacing a voided LOC) */
+      requesterAddress?: components["schemas"]["RequesterAddress"];
       /**
        * Format: uuid 
        * @description The ID of the LOC identifying the requester

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -135,7 +135,7 @@ export class LocRequestController extends ApiController {
         const requesterAddress = authenticatedUser.address !== ownerAddress ? {
             type: authenticatedUser.type,
             address: authenticatedUser.address,
-        } : undefined;
+        } : createLocRequestView.requesterAddress;
         const description: LocRequestDescription = {
             requesterAddress,
             requesterIdentityLoc: createLocRequestView.requesterIdentityLoc,


### PR DESCRIPTION
* Passing requester address in the body is actually required when a LOC is directly created by the LLO, which happens in 2 situations:
  * Logion Identity LOC
  * Creation of a new LOC to replace a to be voided one

logion-network/logion-internal#852