### PR TITLE
Add address type to Loc Request Files and Metadata submitter.

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -554,7 +554,7 @@
                     "Ethereum"
                 ]
             },
-            "RequesterAddress": {
+            "SupportedAccountId": {
                 "type": "object",
                 "properties": {
                     "type": {
@@ -576,7 +576,7 @@
                 "properties": {
                     "requesterAddress": {
                         "description": "The address of the requester (this is only taken into account when created by the owner, which is needed when replacing a voided LOC)",
-                        "$ref": "#/components/schemas/RequesterAddress"
+                        "$ref": "#/components/schemas/SupportedAccountId"
                     },
                     "requesterIdentityLoc": {
                         "type": "string",
@@ -640,8 +640,8 @@
                         "description": "The date-time of addition (chain time)"
                     },
                     "submitter": {
-                        "type": "string",
-                        "description": "The SS58 address of the file submitter"
+                        "description": "The address of the submitter",
+                        "$ref": "#/components/schemas/SupportedAccountId"
                     },
                     "restrictedDelivery": {
                         "type": "boolean",
@@ -681,8 +681,8 @@
                         "description": "The date-time of addition (chain time)"
                     },
                     "submitter": {
-                        "type": "string",
-                        "description": "The SS58 address of the file submitter"
+                        "description": "The address of the submitter",
+                        "$ref": "#/components/schemas/SupportedAccountId"
                     },
                     "fees": {
                         "$ref": "#/components/schemas/FeesView"
@@ -698,7 +698,7 @@
                     },
                     "requesterAddress": {
                         "description": "The address of the requester",
-                        "$ref": "#/components/schemas/RequesterAddress"
+                        "$ref": "#/components/schemas/SupportedAccountId"
                     },
                     "requesterIdentityLoc": {
                         "type": "string",
@@ -859,7 +859,7 @@
                     },
                     "requesterAddress": {
                         "description": "The address of the requester",
-                        "$ref": "#/components/schemas/RequesterAddress"
+                        "$ref": "#/components/schemas/SupportedAccountId"
                     },
                     "requesterIdentityLoc": {
                         "type": "string",
@@ -901,8 +901,8 @@
                                     "description": "The date-time of addition (chain time)"
                                 },
                                 "submitter": {
-                                    "type": "string",
-                                    "description": "The SS58 address of the file submitter"
+                                    "description": "The address of the submitter",
+                                    "$ref": "#/components/schemas/SupportedAccountId"
                                 },
                                 "contentType": {
                                     "type": "string",
@@ -960,8 +960,8 @@
                                     "description": "The date-time of addition (chain time)"
                                 },
                                 "submitter": {
-                                    "type": "string",
-                                    "description": "The SS58 address of the metadata item submitter"
+                                    "description": "The address of the submitter",
+                                    "$ref": "#/components/schemas/SupportedAccountId"
                                 }
                             }
                         }

--- a/src/logion/controllers/adapters/locrequestadapter.ts
+++ b/src/logion/controllers/adapters/locrequestadapter.ts
@@ -8,6 +8,7 @@ import { components } from "../components.js";
 import { VoteRepository, VoteAggregateRoot } from "../../model/vote.model.js";
 import { VerifiedThirdPartySelectionAggregateRoot, VerifiedThirdPartySelectionRepository } from "../../model/verifiedthirdpartyselection.model.js";
 import { Fees } from "@logion/node-api";
+import { SupportedAccountId } from "../../model/supportedaccountid.model.js";
 
 export type UserPrivateData = {
     identityLocId: string | undefined,
@@ -30,7 +31,7 @@ export class LocRequestAdapter {
         private verifiedThirdPartySelectionRepository: VerifiedThirdPartySelectionRepository,
     ) {}
 
-    async toView(request: LocRequestAggregateRoot, viewer: string, userPrivateDataArg?: UserPrivateData): Promise<LocRequestView> {
+    async toView(request: LocRequestAggregateRoot, viewer: SupportedAccountId, userPrivateDataArg?: UserPrivateData): Promise<LocRequestView> {
         let userPrivateData: UserPrivateData;
         if(userPrivateDataArg) {
             userPrivateData = userPrivateDataArg;

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -313,7 +313,7 @@ export interface components {
      * @enum {string}
      */
     AddressType: "Polkadot" | "Ethereum";
-    RequesterAddress: {
+    SupportedAccountId: {
       /** @description The type of the address of the requester */
       type: components["schemas"]["AddressType"];
       /** @description The address. Depending on type, either a Polkadot address (SS58 format) or Ethereum (usual '0x' prefixed hexadecimal format) */
@@ -325,7 +325,7 @@ export interface components {
      */
     CreateLocRequestView: {
       /** @description The address of the requester (this is only taken into account when created by the owner, which is needed when replacing a voided LOC) */
-      requesterAddress?: components["schemas"]["RequesterAddress"];
+      requesterAddress?: components["schemas"]["SupportedAccountId"];
       /**
        * Format: uuid 
        * @description The ID of the LOC identifying the requester
@@ -360,8 +360,8 @@ export interface components {
        * @description The date-time of addition (chain time)
        */
       addedOn?: string;
-      /** @description The SS58 address of the file submitter */
-      submitter?: string;
+      /** @description The address of the submitter */
+      submitter?: components["schemas"]["SupportedAccountId"];
       /** @description true if the file can be downloaded by collection item owner. Applicable only for collection. */
       restrictedDelivery?: boolean;
       /** @description The file's size, in bytes. */
@@ -382,8 +382,8 @@ export interface components {
        * @description The date-time of addition (chain time)
        */
       addedOn?: string;
-      /** @description The SS58 address of the file submitter */
-      submitter?: string;
+      /** @description The address of the submitter */
+      submitter?: components["schemas"]["SupportedAccountId"];
       fees?: components["schemas"]["FeesView"];
     };
     /**
@@ -394,7 +394,7 @@ export interface components {
       /** @description The SS58 address of the legal officer that will own the LOC upon acceptance */
       ownerAddress?: string;
       /** @description The address of the requester */
-      requesterAddress?: components["schemas"]["RequesterAddress"];
+      requesterAddress?: components["schemas"]["SupportedAccountId"];
       /**
        * Format: uuid 
        * @description The ID of the LOC identifying the requester (populated for LOGION identity only)
@@ -492,7 +492,7 @@ export interface components {
       /** @description The SS58 address of the legal officer that will own the LOC upon acceptance */
       ownerAddress?: string;
       /** @description The address of the requester */
-      requesterAddress?: components["schemas"]["RequesterAddress"];
+      requesterAddress?: components["schemas"]["SupportedAccountId"];
       /**
        * Format: uuid 
        * @description The ID of the LOC identifying the requester
@@ -524,8 +524,8 @@ export interface components {
            * @description The date-time of addition (chain time)
            */
           addedOn?: string;
-          /** @description The SS58 address of the file submitter */
-          submitter?: string;
+          /** @description The address of the submitter */
+          submitter?: components["schemas"]["SupportedAccountId"];
           /** @description The file's content type (MIME) */
           contentType?: string;
         })[];
@@ -555,8 +555,8 @@ export interface components {
            * @description The date-time of addition (chain time)
            */
           addedOn?: string;
-          /** @description The SS58 address of the metadata item submitter */
-          submitter?: string;
+          /** @description The address of the submitter */
+          submitter?: components["schemas"]["SupportedAccountId"];
         })[];
       /** @description Data about LOC voiding */
       voidInfo?: {

--- a/src/logion/migration/1681743107271-AddItemSubmitterType.ts
+++ b/src/logion/migration/1681743107271-AddItemSubmitterType.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddItemSubmitterType1681743107271 implements MigrationInterface {
+    name = 'AddItemSubmitterType1681743107271'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request_file" RENAME COLUMN "submitter" TO "submitter_address"`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" RENAME COLUMN "submitter" TO "submitter_address"`);
+
+        await queryRunner.query(`ALTER TABLE "loc_request_file" ADD "submitter_address_type" character varying(255)`);
+        await queryRunner.query(`UPDATE "loc_request_file" SET "submitter_address_type" = 'Polkadot'`);
+        await queryRunner.query(`ALTER TABLE "loc_request_file" ALTER COLUMN "submitter_address_type" SET NOT NULL`);
+
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" ADD "submitter_address_type" character varying(255)`);
+        await queryRunner.query(`UPDATE "loc_metadata_item" SET "submitter_address_type" = 'Polkadot'`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" ALTER COLUMN "submitter_address_type" SET NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" DROP COLUMN "submitter_address_type"`);
+        await queryRunner.query(`ALTER TABLE "loc_request_file" DROP COLUMN "submitter_address_type"`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" RENAME COLUMN "submitter_address" TO "submitter"`);
+        await queryRunner.query(`ALTER TABLE "loc_request_file" RENAME COLUMN "submitter_address" TO "submitter"`);
+    }
+
+}

--- a/src/logion/model/supportedaccountid.model.ts
+++ b/src/logion/model/supportedaccountid.model.ts
@@ -1,0 +1,52 @@
+import { components } from "../controllers/components.js";
+import { Column } from "typeorm";
+
+export type SupportedAccountId = components["schemas"]["SupportedAccountId"];
+type AddressType = components["schemas"]["AddressType"];
+
+export class EmbeddableSupportedAccountId {
+
+    @Column({ length: 255, name: "_address_type" })
+    type?: string;
+
+    @Column({ length: 255, name: "_address" })
+    address?: string;
+
+    toSupportedAccountId(): SupportedAccountId {
+        return {
+            type: (this.type || "Polkadot") as AddressType,
+            address: this.address || "",
+        }
+    }
+
+    static from(supportedAccountId: SupportedAccountId): EmbeddableSupportedAccountId {
+        const embeddable = new EmbeddableSupportedAccountId();
+        embeddable.type = supportedAccountId.type;
+        embeddable.address = supportedAccountId.address;
+        return embeddable;
+    }
+}
+
+type AnyAccountId = {
+    type?: string | AddressType;
+    address?: string;
+}
+
+export function accountEquals(left: AnyAccountId | undefined, right: AnyAccountId | undefined): boolean {
+    if (
+        left === undefined || right === undefined ||
+        left.address === undefined || right.address === undefined ||
+        left.type === undefined || right.type === undefined
+    ) {
+        return false;
+    }
+    return left.type === right.type &&
+        left.address === right.address;
+}
+
+export function polkadotAccount(address: string): SupportedAccountId {
+    return {
+        type: "Polkadot",
+        address
+    }
+}

--- a/src/logion/services/idenfy/idenfy.service.ts
+++ b/src/logion/services/idenfy/idenfy.service.ts
@@ -161,7 +161,7 @@ export class EnabledIdenfyService extends IdenfyService {
 
         const clientId = json.clientId;
         const request = requireDefined(await this.locRequestRepository.findById(clientId));
-        const submitter = requireDefined(request.ownerAddress);
+        const submitter = request.getOwner();
 
         const randomPrefix = DateTime.now().toMillis().toString();
         const { hash, cid, size } = await this.storePayload(randomPrefix, raw);

--- a/test/helpers/addresses.ts
+++ b/test/helpers/addresses.ts
@@ -1,4 +1,8 @@
+import { polkadotAccount } from "../../src/logion/model/supportedaccountid.model.js";
+
 export const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 export const DEFAULT_LEGAL_OFFICER = ALICE;
 export const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 export const CHARLY = "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y";
+
+export const ALICE_ACCOUNT = polkadotAccount(ALICE);

--- a/test/integration/model/loc_requests.sql
+++ b/test/integration/model/loc_requests.sql
@@ -22,10 +22,10 @@ VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUi
 -- Loc with files, metadata and links
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
 VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-10', 'OPEN', 'Transaction');
-INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter, size)
-VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', 'a file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 0, TRUE, 'some nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', 123);
-INSERT INTO loc_metadata_item (request_id, "index", name, "value_text", added_on, draft, submitter)
-VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', 0, 'a name', 'a value', '2021-10-06T11:16:00.000', true, '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw');
+INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter_address, submitter_address_type, size)
+VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', 'a file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 0, TRUE, 'some nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', 'Polkadot', 123);
+INSERT INTO loc_metadata_item (request_id, "index", name, "value_text", added_on, draft, submitter_address, submitter_address_type)
+VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', 0, 'a name', 'a value', '2021-10-06T11:16:00.000', true, '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', 'Polkadot');
 INSERT INTO loc_link (request_id, "index", target, added_on, draft, nature)
 VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', 0, 'ec126c6c-64cf-4eb8-bfa6-2a98cd19ad5d', '2021-10-06T11:16:00.000', true, 'link-nature');
 -- Open Polkadot Identity locs
@@ -66,8 +66,8 @@ VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUi
 -- Closed Identity LOC of VTP
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
 VALUES ('15ed922d-5960-4147-a73f-97d362cb7c46', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-27', 'CLOSED', 'Identity');
-INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter, restricted_delivery, size)
-VALUES ('15ed922d-5960-4147-a73f-97d362cb7c46', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', 'a file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 0, TRUE, 'some nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', TRUE, 456);
+INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter_address, submitter_address_type, restricted_delivery, size)
+VALUES ('15ed922d-5960-4147-a73f-97d362cb7c46', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', 'a file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 0, TRUE, 'some nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', 'Polkadot', TRUE, 456);
 INSERT INTO loc_request_file_delivered (id, request_id, hash, delivered_file_hash, generated_on, owner)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '15ed922d-5960-4147-a73f-97d362cb7c46', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', '0xf35e4bcbc1b0ce85af90914e04350cce472a2f01f00c0f7f8bc5c7ba04da2bf2', '2021-10-06T12:16:00.000', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw');
 INSERT INTO loc_request_file_delivered (id, request_id, hash, delivered_file_hash, generated_on, owner)
@@ -75,8 +75,8 @@ VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '15ed922d-5960-414
 INSERT INTO loc_request_file_delivered (id, request_id, hash, delivered_file_hash, generated_on, owner)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '15ed922d-5960-4147-a73f-97d362cb7c46', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', '0xc14d46b478dcb21833b90dc9880aa3a7507b01aa5d033c64051df999f3c3bba0', '2021-10-07T12:16:00.000', '5Eewz58eEPS81847EezkiFENE3kG8fxrx1BdRWyFJAudPC6m');
 
-INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter, restricted_delivery, size)
-VALUES ('15ed922d-5960-4147-a73f-97d362cb7c46', '0x5a60f0a435fa1c508ccc7a7dd0a0fe8f924ba911b815b10c9ef0ddea0c49052e', 'another file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 1, TRUE, 'some other nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', TRUE, 789);
+INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", draft, nature, submitter_address, submitter_address_type, restricted_delivery, size)
+VALUES ('15ed922d-5960-4147-a73f-97d362cb7c46', '0x5a60f0a435fa1c508ccc7a7dd0a0fe8f924ba911b815b10c9ef0ddea0c49052e', 'another file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 1, TRUE, 'some other nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', 'Polkadot', TRUE, 789);
 INSERT INTO loc_request_file_delivered (id, request_id, hash, delivered_file_hash, generated_on, owner)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '15ed922d-5960-4147-a73f-97d362cb7c46', '0x5a60f0a435fa1c508ccc7a7dd0a0fe8f924ba911b815b10c9ef0ddea0c49052e', '0xdbfaa07666457afd3cdc6fb2726a94cde7a0f613a0f354e695b315372a098e8a', '2021-10-06T12:16:00.000', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw');
 

--- a/test/integration/model/loc_requests_order.sql
+++ b/test/integration/model/loc_requests_order.sql
@@ -1,30 +1,30 @@
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-1', 'Transaction', 'REQUESTED', '2022-10-01', null, null, null, null);
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-2', 'Transaction', 'REQUESTED', '2022-10-02', null, null, null, null);
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-9', 'Transaction', 'REJECTED', '2022-10-01', '2022-10-02', null, null, null);
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-10', 'Transaction', 'REJECTED', '2022-10-02', '2022-10-03', null, null, null);
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-3', 'Transaction', 'OPEN', '2022-10-01', '2022-10-02', '2022-10-03', null, null);
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-4', 'Transaction', 'OPEN', '2022-10-02', '2022-10-03', '2022-10-04', null, null);
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-5', 'Transaction', 'CLOSED', '2022-10-01', '2022-10-02', '2022-10-03', '2022-10-04', null);
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-6', 'Transaction', 'CLOSED', '2022-10-02', '2022-10-03', '2022-10-04', '2022-10-05', null);
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-7', 'Transaction', 'CLOSED', '2022-10-01', '2022-10-02', '2022-10-03', '2022-10-04', '2022-10-05'); -- VOID
-INSERT INTO loc_request (id, owner_address, requester_address, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ',
+INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-8', 'Transaction', 'CLOSED', '2022-10-02', '2022-10-03', '2022-10-04', '2022-10-05', '2022-10-06'); -- VOID

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -13,8 +13,9 @@ import {
 import { ALICE, BOB } from "../../helpers/addresses.js";
 import { v4 as uuid } from "uuid";
 import { LocRequestService, TransactionalLocRequestService } from "../../../src/logion/services/locrequest.service.js";
+import { polkadotAccount } from "../../../src/logion/model/supportedaccountid.model.js";
 
-const SUBMITTER = "5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw";
+const SUBMITTER = polkadotAccount("5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw");
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 const ENTITIES = [ LocRequestAggregateRoot, LocFile, LocMetadataItem, LocLink, LocFileDelivered ];
 
@@ -100,7 +101,7 @@ describe('LocRequestRepository - read accesses', () => {
         const request = await repository.findById(LOC_WITH_FILES);
         checkDescription([request!], "Transaction", "loc-10");
 
-        expect(request!.getFiles(request?.ownerAddress).length).toBe(1);
+        expect(request!.getFiles(request?.getOwner()).length).toBe(1);
         expect(request!.hasFile(hash)).toBe(true);
         const file = request!.getFile(hash);
         expect(file.name).toBe("a file");
@@ -111,14 +112,14 @@ describe('LocRequestRepository - read accesses', () => {
         expect(file.size).toBe(123);
         expect(request!.files![0].draft).toBe(true);
 
-        const metadata = request!.getMetadataItems(request?.ownerAddress);
+        const metadata = request!.getMetadataItems(request?.getOwner());
         expect(metadata.length).toBe(1);
         expect(metadata[0].name).toBe("a name");
         expect(metadata[0].value).toBe("a value");
         expect(metadata[0].addedOn!.isSame(moment("2021-10-06T11:16:00.000"))).toBe(true);
         expect(request!.metadata![0].draft).toBe(true);
 
-        const links = request!.getLinks(request?.ownerAddress);
+        const links = request!.getLinks(request?.getOwner());
         expect(links.length).toBe(1);
         expect(links[0].target).toBe("ec126c6c-64cf-4eb8-bfa6-2a98cd19ad5d");
         expect(links[0].addedOn!.isSame(moment("2021-10-06T11:16:00.000"))).toBe(true);

--- a/test/unit/controllers/collection.controller.spec.ts
+++ b/test/unit/controllers/collection.controller.spec.ts
@@ -35,6 +35,7 @@ import {
     LocRequestService,
     NonTransactionalLocRequestService
 } from "../../../src/logion/services/locrequest.service.js";
+import { polkadotAccount, EmbeddableSupportedAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
 
 const collectionLocId = "d61e2e12-6c06-4425-aeee-2a0e969ac14e";
 const collectionLocOwner = ALICE;
@@ -586,7 +587,7 @@ function mockModel(
         collectionFile.cid = CID;
         collectionFile.request = collectionLoc;
         collectionFile.requestId = collectionLocId;
-        collectionFile.submitter = collectionRequester;
+        collectionFile.submitter = EmbeddableSupportedAccountId.from(polkadotAccount(collectionRequester));
         collectionFile.index = 0;
         collectionFile.name = FILE_NAME;
         collectionFile.contentType = CONTENT_TYPE;

--- a/test/unit/controllers/idenfy.controller.spec.ts
+++ b/test/unit/controllers/idenfy.controller.spec.ts
@@ -6,6 +6,8 @@ import { It, Mock, Times } from "moq.ts";
 import { IdenfyController } from "../../../src/logion/controllers/idenfy.controller.js";
 import { LocRequestAggregateRoot, LocRequestRepository } from "../../../src/logion/model/locrequest.model.js";
 import { IdenfyService } from "../../../src/logion/services/idenfy/idenfy.service.js";
+import { mockRequester } from "./locrequest.controller.shared.js";
+import { polkadotAccount } from "../../../src/logion/model/supportedaccountid.model.js";
 
 const { setupApp } = TestApp;
 
@@ -54,7 +56,7 @@ describe("IdenfyController", () => {
 
 function mockVerification(container: Container, requester: string) {
     const locRequest = new Mock<LocRequestAggregateRoot>();
-    locRequest.setup(instance => instance.requesterAddress).returns(requester);
+    mockRequester(locRequest, polkadotAccount(requester));
 
     const repository = new Mock<LocRequestRepository>();
     repository.setup(instance => instance.findById(REQUEST_ID)).returnsAsync(locRequest.object());

--- a/test/unit/controllers/locrequest.controller.sof.spec.ts
+++ b/test/unit/controllers/locrequest.controller.sof.spec.ts
@@ -17,9 +17,9 @@ import {
     REQUEST_ID,
     setupRequest,
     testDataWithUserIdentityWithType,
-    setupSelectedVtp
+    setupSelectedVtp, mockOwner
 } from "./locrequest.controller.shared.js";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT } from "../../helpers/addresses.js";
 
 const { setupApp } = TestApp;
 
@@ -76,7 +76,7 @@ function mockModelForCreateSofRequest(container: Container, factory: Mock<LocReq
     const targetLoc = mockRequest("CLOSED", testDataWithUserIdentityWithType(locType));
     targetLoc.setup(instance => instance.id).returns(locId.toString());
     targetLoc.setup(instance => instance.locType).returns(locType);
-    targetLoc.setup(instance => instance.ownerAddress).returns(ALICE);
+    mockOwner(targetLoc, ALICE_ACCOUNT);
     repository.setup(instance => instance.findById(locId.toString()))
         .returns(Promise.resolve(targetLoc.object()));
 

--- a/test/unit/controllers/records.controller.spec.ts
+++ b/test/unit/controllers/records.controller.spec.ts
@@ -14,7 +14,7 @@ import { GetCollectionItemParams, LogionNodeCollectionService } from "../../../s
 import { fileExists } from "../../helpers/filehelper.js";
 import { OwnershipCheckService } from "../../../src/logion/services/ownershipcheck.service.js";
 import { RestrictedDeliveryService } from "../../../src/logion/services/restricteddelivery.service.js";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import { TokensRecordController } from "../../../src/logion/controllers/records.controller.js";
 import {
     TokensRecordRepository,
@@ -493,7 +493,7 @@ function mockModel(
     container.bind(TokensRecordService).toConstantValue(new NonTransactionalTokensRecordService(tokensRecordRepository.object()));
 
     const locAuthorityService = new Mock<LocAuthorizationService>();
-    locAuthorityService.setup(instance => instance.ensureContributor(It.IsAny(), It.IsAny())).returnsAsync(ALICE);
+    locAuthorityService.setup(instance => instance.ensureContributor(It.IsAny(), It.IsAny())).returnsAsync(ALICE_ACCOUNT);
     locAuthorityService.setup(instance => instance.isContributor(It.IsAny(), It.IsAny())).returnsAsync(true);
     container.bind(LocAuthorizationService).toConstantValue(locAuthorityService.object());
 }

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from "uuid";
-import { ALICE, DEFAULT_LEGAL_OFFICER } from "../../helpers/addresses.js";
+import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import moment, { Moment } from "moment";
 import {
     LocRequestDescription,
@@ -19,8 +19,12 @@ import { PostalAddress } from "../../../src/logion/model/postaladdress.js";
 import { Seal, PersonalInfoSealService, PublicSeal, LATEST_SEAL_VERSION } from "../../../src/logion/services/seal.service.js";
 import { UUID } from "bson";
 import { IdenfyVerificationSession, IdenfyVerificationStatus } from "src/logion/services/idenfy/idenfy.types.js";
+import { SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
 
-const SUBMITTER = "5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw";
+const SUBMITTER: SupportedAccountId = {
+    type: "Polkadot",
+    address: "5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw"
+};
 
 const PUBLIC_SEAL: PublicSeal = {
     hash: "0x48aedf4e08e46b24970d97db566bfa6668581cc2f37791bac0c9817a4508607a",
@@ -442,7 +446,7 @@ describe("LocRequestAggregateRoot (metadata)", () => {
 
     it("submitter removes previously added metadata item", () => testRemovesItem(SUBMITTER));
 
-    function testRemovesItem(remover: string) {
+    function testRemovesItem(remover: SupportedAccountId) {
         givenRequestWithStatus('OPEN');
         const items: MetadataItemDescription[] = [
             {
@@ -472,7 +476,7 @@ describe("LocRequestAggregateRoot (metadata)", () => {
         thenHasExpectedMetadataIndices();
     }
 
-    it("owner removes previously added metadata item", () => testRemovesItem(OWNER));
+    it("owner removes previously added metadata item", () => testRemovesItem(OWNER_ACCOUNT));
 
     it("confirms metadata item", () => {
         givenRequestWithStatus('OPEN');
@@ -496,7 +500,7 @@ describe("LocRequestAggregateRoot (metadata)", () => {
             {
                 name,
                 value: "value-1",
-                submitter: OWNER,
+                submitter: OWNER_ACCOUNT,
             }
         ])
         thenMetadataIsVisibleToRequester(name);
@@ -549,7 +553,7 @@ describe("LocRequestAggregateRoot (links)", () => {
             }
         ];
         whenAddingLinks(links);
-        whenRemovingLink(OWNER, "target-1")
+        whenRemovingLink(OWNER_ACCOUNT, "target-1")
 
         const newLinks: LinkDescription[] = [
             {
@@ -657,7 +661,7 @@ describe("LocRequestAggregateRoot (files)", () => {
 
     it("submitter removes previously added files", () => testRemovesFile(SUBMITTER));
 
-    function testRemovesFile(remover: string) {
+    function testRemovesFile(remover: SupportedAccountId) {
         givenRequestWithStatus('OPEN');
         const files: FileDescription[] = [
             {
@@ -703,7 +707,7 @@ describe("LocRequestAggregateRoot (files)", () => {
         thenHasExpectedFileIndices();
     }
 
-    it("owner removes previously added files", () => testRemovesFile(OWNER));
+    it("owner removes previously added files", () => testRemovesFile(OWNER_ACCOUNT));
 
     it("confirms file", () => {
         givenRequestWithStatus('OPEN');
@@ -735,7 +739,7 @@ describe("LocRequestAggregateRoot (files)", () => {
                 contentType: "text/plain",
                 cid: "cid-1234",
                 nature: "nature1",
-                submitter: OWNER,
+                submitter: OWNER_ACCOUNT,
                 restrictedDelivery: false,
                 size: 123,
             }
@@ -879,7 +883,7 @@ function givenClosedCollectionLocWithFile(hash: string) {
         contentType: "text/plain",
         cid: "cid-1234",
         nature: "nature1",
-        submitter: OWNER,
+        submitter: OWNER_ACCOUNT,
         restrictedDelivery: true,
         size: 123,
     });
@@ -1019,7 +1023,7 @@ describe("LocRequestAggregateRoot (processes)", () => {
             contentType: "text/plain",
             oid: 1235,
             nature: "nature2",
-            submitter: OWNER,
+            submitter: OWNER_ACCOUNT,
             restrictedDelivery: false,
             size: 123,
         });
@@ -1037,7 +1041,7 @@ describe("LocRequestAggregateRoot (processes)", () => {
         request.addMetadataItem({
             name: "Some other name",
             value: "Some other value",
-            submitter: OWNER,
+            submitter: OWNER_ACCOUNT,
         });
         request.confirmMetadataItem("Some other name");
         request.setMetadataItemAddedOn("Some other name", moment()); // Sync
@@ -1064,10 +1068,12 @@ function givenRequestWithStatus(status: LocRequestStatus) {
     request.metadata = [];
     request.links = [];
     request.ownerAddress = OWNER;
-    request.requesterAddress = SUBMITTER;
+    request.requesterAddress = SUBMITTER.address;
+    request.requesterAddressType = SUBMITTER.type;
 }
 
-const OWNER = DEFAULT_LEGAL_OFFICER;
+const OWNER = ALICE;
+const OWNER_ACCOUNT = ALICE_ACCOUNT;
 
 let request: LocRequestAggregateRoot;
 
@@ -1298,15 +1304,15 @@ function thenExposesLocCreatedDate(expectedDate: Moment) {
     expect(request.getLocCreatedDate().isSame(expectedDate)).toBe(true);
 }
 
-function whenRemovingMetadataItem(remover: string, name: string) {
+function whenRemovingMetadataItem(remover: SupportedAccountId, name: string) {
     request.removeMetadataItem(remover, name);
 }
 
-function whenRemovingLink(remover: string, target: string) {
+function whenRemovingLink(remover: SupportedAccountId, target: string) {
     request.removeLink(remover, target);
 }
 
-function whenRemovingFile(remover: string, hash: string) {
+function whenRemovingFile(remover: SupportedAccountId, hash: string) {
     removedFile = request.removeFile(remover, hash);
 }
 

--- a/test/unit/services/idenfy/idenfy.service.spec.ts
+++ b/test/unit/services/idenfy/idenfy.service.spec.ts
@@ -9,6 +9,11 @@ import { DisabledIdenfyService, EnabledIdenfyService } from "../../../../src/log
 import { IdenfyVerificationSession } from "../../../../src/logion/services/idenfy/idenfy.types.js";
 import { NonTransactionalLocRequestService } from "../../../../src/logion/services/locrequest.service.js";
 import { Readable } from "stream";
+import { mockOwner } from "../../controllers/locrequest.controller.shared.js";
+import {
+    accountEquals,
+    polkadotAccount
+} from "../../../../src/logion/model/supportedaccountid.model.js";
 
 describe("DisabledIdenfyService", () => {
 
@@ -66,7 +71,7 @@ describe("EnabledIdenfyService", () => {
                 && file.contentType === EXPECTED_FILES[fileType].contentType
                 && file.nature === EXPECTED_FILES[fileType].nature
                 && file.name === EXPECTED_FILES[fileType].name
-                && file.submitter === LOC_OWNER
+                && accountEquals(file.submitter, LOC_OWNER_ACCOUNT)
             )));
         }
         locRequestRepository.verify(instance => instance.save(locRequest.object()));
@@ -92,7 +97,7 @@ const IDENFY_API_KEY = "api-key";
 const IDENFY_API_SECRET = "api-secret";
 const IDENFY_SIGNING_KEY = "signing-key";
 const IDENFY_SCAN_REF = "3af0b5c9-8ef3-4815-8796-5ab3ed942917";
-const LOC_OWNER = ALICE;
+const LOC_OWNER_ACCOUNT = polkadotAccount(ALICE);
 
 function mockEnabledIdenfyService(): {
     locRequest: Mock<LocRequestAggregateRoot>,
@@ -105,7 +110,7 @@ function mockEnabledIdenfyService(): {
 } {
     const locRequest = new Mock<LocRequestAggregateRoot>();
     locRequest.setup(instance => instance.id).returns(REQUEST_ID);
-    locRequest.setup(instance => instance.ownerAddress).returns(LOC_OWNER);
+    mockOwner(locRequest, LOC_OWNER_ACCOUNT)
     const description = new Mock<LocRequestDescription>();
     description.setup(instance => instance.userIdentity).returns({
         firstName: "John",


### PR DESCRIPTION
* Add address type to LOC Request files et metadata submitters.
* Introduces `EmbeddableSupportedAccountId`, used in both `LocFile` and `LocMetadataItem`.

**Not covered by this PR, to do later on...**
* `EmbeddableSupportedAccountId` might probably be used also in `LocRequestAggregateRoot`and `SessionAggregateRoot` (in this latter case it must be moved to `logion-rest-api-core`.
* Do the same job for attribute `owner` of delivered files.

logion-network/logion-internal#851