### PR TITLE
Ensure void reason is always set

### DIFF
--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -641,7 +641,7 @@ export class LocRequestController extends ApiController {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
         await this.locRequestService.update(requestId, async request => {
             authenticatedUser.require(user => user.is(request.ownerAddress));
-            request.preVoid(body.reason!);
+            request.preVoid(body.reason || "");
         });
         this.response.sendStatus(204);
     }

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -539,11 +539,15 @@ export class LocRequestAggregateRoot {
     }
 
     preVoid(reason: string) {
-        if (this.voidInfo !== undefined && this.voidInfo.reason !== null) {
+        if (this.isVoid()) {
             throw new Error("LOC is already void")
         }
         this.voidInfo = new EmbeddableVoidInfo();
         this.voidInfo.reason = reason;
+    }
+
+    isVoid(): boolean {
+        return this.voidInfo !== undefined && (this.voidInfo.reason !== null && this.voidInfo.reason !== undefined);
     }
 
     voidLoc(timestamp: Moment) {
@@ -558,10 +562,10 @@ export class LocRequestAggregateRoot {
     }
 
     getVoidInfo(): VoidInfo | null {
-        if (this.voidInfo !== undefined && this.voidInfo.reason !== null) {
+        if (this.isVoid()) {
             return {
-                reason: this.voidInfo.reason || "",
-                voidedOn: this.voidInfo.voidedOn ? moment(this.voidInfo.voidedOn) : null
+                reason: this.voidInfo?.reason || "",
+                voidedOn: this.voidInfo?.voidedOn ? moment(this.voidInfo.voidedOn) : null
             };
         } else {
             return null;


### PR DESCRIPTION
* An empty void reason is enforced if the reason field was not provided in the request.

logion-network/logion-internal#903