### PR TITLE
LOC opened by Polakdot requester

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -537,8 +537,9 @@
                 "description": "The request's status",
                 "enum": [
                     "OPEN",
-                    "REQUESTED",
-                    "REJECTED",
+                    "REVIEW_PENDING",
+                    "REVIEW_REJECTED",
+                    "REVIEW_ACCEPTED",
                     "CLOSED",
                     "DRAFT"
                 ]

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -304,7 +304,7 @@ export interface components {
      * @description The request's status 
      * @enum {string}
      */
-    LocRequestStatus: "OPEN" | "REQUESTED" | "REJECTED" | "CLOSED" | "DRAFT";
+    LocRequestStatus: "OPEN" | "REVIEW_PENDING" | "REVIEW_REJECTED" | "REVIEW_ACCEPTED" | "CLOSED" | "DRAFT";
     /**
      * @description The LOC's type 
      * @enum {string}

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -191,7 +191,7 @@ export class LocRequestController extends ApiController {
         }
         await this.locRequestService.addNewRequest(request);
         const { userIdentity, userPostalAddress, identityLocId } = await this.locRequestAdapter.findUserPrivateData(request);
-        if (request.status === "REQUESTED" && !accountEquals(authenticatedUser, owner)) {
+        if (request.status === "REVIEW_PENDING" && !accountEquals(authenticatedUser, owner)) {
             this.notify("LegalOfficer", "loc-requested", request.getDescription(), userIdentity)
         }
         return this.locRequestAdapter.toView(request, authenticatedUser, { userIdentity, userPostalAddress, identityLocId });

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -191,7 +191,7 @@ export class LocRequestController extends ApiController {
         }
         await this.locRequestService.addNewRequest(request);
         const { userIdentity, userPostalAddress, identityLocId } = await this.locRequestAdapter.findUserPrivateData(request);
-        if (request.status === "REVIEW_PENDING" && !accountEquals(authenticatedUser, owner)) {
+        if (request.status === "REVIEW_PENDING") {
             this.notify("LegalOfficer", "loc-requested", request.getDescription(), userIdentity)
         }
         return this.locRequestAdapter.toView(request, authenticatedUser, { userIdentity, userPostalAddress, identityLocId });
@@ -418,10 +418,8 @@ export class LocRequestController extends ApiController {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
         const request = await this.locRequestService.update(requestId, async request => {
             authenticatedUser.require(user => user.is(request.ownerAddress));
-            if (request.canOpen(request.getRequester())) {
-                request.accept(moment());
-            } else {
-                request.accept(moment());
+            request.accept(moment());
+            if (!request.canOpen(request.getRequester())) {
                 request.open();
             }
         });

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -418,7 +418,12 @@ export class LocRequestController extends ApiController {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
         const request = await this.locRequestService.update(requestId, async request => {
             authenticatedUser.require(user => user.is(request.ownerAddress));
-            request.accept(moment());
+            if (request.canOpen(request.getRequester())) {
+                request.accept(moment());
+            } else {
+                request.accept(moment());
+                request.open();
+            }
         });
         const { userIdentity } = await this.locRequestAdapter.findUserPrivateData(request);
         this.notify("WalletUser", "loc-accepted", request.getDescription(), userIdentity, request.getDecision());
@@ -656,6 +661,26 @@ export class LocRequestController extends ApiController {
         await this.locRequestService.update(requestId, async request => {
             authenticatedUser.require(user => user.is(request.ownerAddress));
             request.confirmFileAcknowledged(hash)
+        });
+        this.response.sendStatus(204);
+    }
+
+    static openLoc(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/loc-request/{requestId}/open"].post!;
+        operationObject.summary = "Opens a LOC";
+        operationObject.description = "The authenticated user must be the Polkadot requester of the LOC.";
+        operationObject.responses = getDefaultResponsesNoContent();
+        setPathParameters(operationObject, { 'requestId': "The ID of the LOC" });
+    }
+
+    @HttpPost('/:requestId/open')
+    @Async()
+    @SendsResponse()
+    async openLoc(_body: any, requestId: string) {
+        const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
+        await this.locRequestService.update(requestId, async request => {
+            authenticatedUser.require(user => request.canOpen(authenticatedUser), "LOC must be opened by Polkadot requester");
+            request.open();
         });
         this.response.sendStatus(204);
     }

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -259,7 +259,7 @@ export class LocRequestAggregateRoot {
 
     reject(reason: string, rejectedOn: Moment): void {
         if (this.status != 'REVIEW_PENDING') {
-            throw new Error("Cannot reject already decided request");
+            throw new Error(`Cannot reject request with status ${ this.status }`);
         }
 
         this.status = 'REVIEW_REJECTED';
@@ -286,7 +286,7 @@ export class LocRequestAggregateRoot {
 
     open(createdOn?: Moment): void {
         if (this.status != 'REVIEW_ACCEPTED' && this.status != 'OPEN') {
-            throw new Error("Cannot accept already decided request");
+            throw new Error(`Cannot open request with status ${ this.status }`);
         }
         this.status = 'OPEN';
         if (createdOn) {
@@ -841,7 +841,8 @@ export class LocRequestAggregateRoot {
     canOpen(user: SupportedAccountId | undefined): boolean {
         return user !== undefined
             && accountEquals(user, this.getRequester())
-            && user.type === 'Polkadot';
+            && user.type === 'Polkadot'
+            && (this.status === 'REVIEW_ACCEPTED' || this.status === 'OPEN')
     }
 
     @PrimaryColumn({ type: "uuid" })

--- a/test/integration/model/loc_requests.sql
+++ b/test/integration/model/loc_requests.sql
@@ -1,10 +1,10 @@
 -- Requested Transaction locs
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-1', 'REQUESTED', 'Transaction');
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-1', 'REVIEW_PENDING', 'Transaction');
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-2', 'REQUESTED', 'Transaction');
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-2', 'REVIEW_PENDING', 'Transaction');
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-3', 'REQUESTED', 'Transaction');
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-3', 'REVIEW_PENDING', 'Transaction');
 -- Open Transaction locs
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-4', 'OPEN', 'Transaction');
@@ -14,11 +14,11 @@ INSERT INTO loc_request (id, owner_address, requester_address, requester_address
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-6', 'OPEN', 'Transaction');
 -- Rejected locs
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, reject_reason, first_name, last_name, email, phone_number, loc_type)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-7', 'REJECTED', 'Not a valid case', 'John', 'Doe', 'john.doe@logion.network', '+123456', 'Transaction');
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-7', 'REVIEW_REJECTED', 'Not a valid case', 'John', 'Doe', 'john.doe@logion.network', '+123456', 'Transaction');
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, reject_reason, loc_type)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-8', 'REJECTED', 'Not a valid case', 'Transaction');
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-8', 'REVIEW_REJECTED', 'Not a valid case', 'Transaction');
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, reject_reason, loc_type)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-9', 'REJECTED', 'Not a valid case', 'Transaction');
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-9', 'REVIEW_REJECTED', 'Not a valid case', 'Transaction');
 -- Loc with files, metadata and links
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
 VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-10', 'OPEN', 'Transaction');
@@ -51,11 +51,11 @@ INSERT INTO loc_request (id, requester_identity_loc, owner_address, description,
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '518536e4-71e6-4c4f-82db-b16cbfb495ed', '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', 'loc-19', 'OPEN', 'Transaction');
 -- Requested Collection locs
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-21', 'REQUESTED', 'Collection');
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-21', 'REVIEW_PENDING', 'Collection');
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-22', 'REQUESTED', 'Collection');
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-22', 'REVIEW_PENDING', 'Collection');
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
-VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-23', 'REQUESTED', 'Collection');
+VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', 'Polkadot', 'loc-23', 'REVIEW_PENDING', 'Collection');
 -- Open Collection locs
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, status, loc_type)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-24', 'OPEN', 'Collection');

--- a/test/integration/model/loc_requests_order.sql
+++ b/test/integration/model/loc_requests_order.sql
@@ -1,15 +1,15 @@
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
-        'ordered-loc-1', 'Transaction', 'REQUESTED', '2022-10-01', null, null, null, null);
+        'ordered-loc-1', 'Transaction', 'REVIEW_PENDING', '2022-10-01', null, null, null, null);
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
-        'ordered-loc-2', 'Transaction', 'REQUESTED', '2022-10-02', null, null, null, null);
+        'ordered-loc-2', 'Transaction', 'REVIEW_PENDING', '2022-10-02', null, null, null, null);
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
-        'ordered-loc-9', 'Transaction', 'REJECTED', '2022-10-01', '2022-10-02', null, null, null);
+        'ordered-loc-9', 'Transaction', 'REVIEW_REJECTED', '2022-10-01', '2022-10-02', null, null, null);
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
-        'ordered-loc-10', 'Transaction', 'REJECTED', '2022-10-02', '2022-10-03', null, null, null);
+        'ordered-loc-10', 'Transaction', 'REVIEW_REJECTED', '2022-10-02', '2022-10-03', null, null, null);
 INSERT INTO loc_request (id, owner_address, requester_address, requester_address_type, description, loc_type, status, created_on, decision_on, loc_created_on, closed_on, voided_on)
 VALUES (md5(random()::text || clock_timestamp()::text)::uuid, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 
         'ordered-loc-3', 'Transaction', 'OPEN', '2022-10-01', '2022-10-02', '2022-10-03', null, null);

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -41,7 +41,7 @@ describe('LocRequestRepository - read accesses', () => {
     it("find by owner, status and type", async () => {
         const query: FetchLocRequestsSpecification = {
             expectedOwnerAddress: ALICE,
-            expectedStatuses: [ "OPEN", "REQUESTED" ],
+            expectedStatuses: [ "OPEN", "REVIEW_PENDING" ],
             expectedLocTypes: [ "Transaction" ]
         }
         const requests = await repository.findBy(query);
@@ -87,7 +87,7 @@ describe('LocRequestRepository - read accesses', () => {
     it("find by requester and status", async () => {
         const query: FetchLocRequestsSpecification = {
             expectedRequesterAddress: "5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ",
-            expectedStatuses: [ "REJECTED" ],
+            expectedStatuses: [ "REVIEW_REJECTED" ],
         }
         const requests = await repository.findBy(query);
         checkDescription(requests, "Transaction", "loc-7")
@@ -101,7 +101,7 @@ describe('LocRequestRepository - read accesses', () => {
             email: 'john.doe@logion.network',
             phoneNumber: '+123456',
         });
-        expect(requests[0].status).toBe("REJECTED");
+        expect(requests[0].status).toBe("REVIEW_REJECTED");
 
         expect(await repository.existsBy(query)).toBeTrue();
     })
@@ -342,7 +342,7 @@ describe('LocRequestRepository - LOC correctly ordered', () => {
         const locs = await repository.findBy({
             expectedLocTypes: ["Collection", "Identity", "Transaction"],
             expectedOwnerAddress: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-            expectedStatuses: ["CLOSED", "OPEN", "REJECTED", "REQUESTED"]
+            expectedStatuses: ["CLOSED", "OPEN", "REVIEW_REJECTED", "REVIEW_PENDING"]
         });
 
         const descriptions = locs.map(loc => loc.description);

--- a/test/unit/controllers/locrequest.controller.creation.spec.ts
+++ b/test/unit/controllers/locrequest.controller.creation.spec.ts
@@ -101,7 +101,7 @@ describe('LocRequestController - Creation -', () => {
             .expect('Content-Type', /application\/json/)
             .then(response => {
                 expect(response.body.id).toBeDefined();
-                expect(response.body.status).toBe("REQUESTED");
+                expect(response.body.status).toBe("REVIEW_PENDING");
                 expect(response.body.locType).toBe("Transaction");
                 expect(response.body.requesterAddress).toBeUndefined();
                 expect(response.body.requesterIdentityLoc).toBe(expectedUserPrivateData.identityLocId);
@@ -163,7 +163,7 @@ async function testLocRequestCreationWithEmbeddedUserIdentity(isLegalOfficer: bo
         .then(response => {
             if (expectedStatus === 200) {
                 expect(response.body.id).toBeDefined();
-                expect(response.body.status).toBe("REQUESTED");
+                expect(response.body.status).toBe("REVIEW_PENDING");
                 expect(response.body.locType).toBe(locType);
                 checkPrivateData(response, expectedUserPrivateData);
                 expect(response.body.seal).toEqual(SEAL.hash)
@@ -189,7 +189,7 @@ async function testLocRequestCreationWithPolkadotIdentityLoc(isLegalOfficer: boo
         .expect('Content-Type', /application\/json/)
         .then(response => {
             expect(response.body.id).toBeDefined();
-            expect(response.body.status).toBe("REQUESTED");
+            expect(response.body.status).toBe("REVIEW_PENDING");
             expect(response.body.locType).toBe(locType);
             checkPrivateData(response, expectedUserPrivateData);
         });
@@ -218,7 +218,7 @@ function mockModelForCreation(container: Container, locType: LocType, notificati
     repository.setup(instance => instance.save(draft.object()))
         .returns(Promise.resolve());
 
-    const requested = mockRequest("REQUESTED", hasPolkadotIdentityLoc ? testDataWithType(locType) : testDataWithUserIdentityWithType(locType));
+    const requested = mockRequest("REVIEW_PENDING", hasPolkadotIdentityLoc ? testDataWithType(locType) : testDataWithUserIdentityWithType(locType));
     factory.setup(instance => instance.newLocRequest(It.Is<NewUserLocRequestParameters>(params =>
         params.description.requesterAddress?.address === testData.requesterAddress?.address &&
         params.description.requesterAddress?.type === testData.requesterAddress?.type &&
@@ -230,7 +230,7 @@ function mockModelForCreation(container: Container, locType: LocType, notificati
     repository.setup(instance => instance.save(requested.object()))
         .returns(Promise.resolve());
 
-    const requestByLO = mockRequest("REQUESTED", hasPolkadotIdentityLoc ? testDataWithType(locType) : testDataWithUserIdentityWithType(locType));
+    const requestByLO = mockRequest("REVIEW_PENDING", hasPolkadotIdentityLoc ? testDataWithType(locType) : testDataWithUserIdentityWithType(locType));
     factory.setup(instance => instance.newLOLocRequest(It.Is<NewLocRequestParameters>(params =>
         params.description.ownerAddress == ALICE &&
         params.description.description == testData.description
@@ -255,7 +255,7 @@ function mockModelForCreationWithLogionIdentityLoc(container: Container): void {
     mockLogionIdentityLoc(repository, true);
     mockPolkadotIdentityLoc(repository, false);
 
-    const request = mockRequest("REQUESTED", { ...testDataWithLogionIdentity, requesterIdentityLocId: testDataWithLogionIdentity.requesterIdentityLoc });
+    const request = mockRequest("REVIEW_PENDING", { ...testDataWithLogionIdentity, requesterIdentityLocId: testDataWithLogionIdentity.requesterIdentityLoc });
     factory.setup(instance => instance.newLOLocRequest(It.Is<NewLocRequestParameters>(params =>
         params.description.requesterIdentityLoc === userIdentities["Logion"].identityLocId &&
         params.description.ownerAddress == ALICE

--- a/test/unit/controllers/locrequest.controller.fetch.spec.ts
+++ b/test/unit/controllers/locrequest.controller.fetch.spec.ts
@@ -56,7 +56,7 @@ describe('LocRequestController - Fetch -', () => {
                 expect(request1.requesterAddress.address).toEqual(testData.requesterAddress?.address);
                 expect(request1.requesterAddress.type).toEqual(testData.requesterAddress?.type);
                 expect(request1.ownerAddress).toBe(ALICE);
-                expect(request1.status).toBe("REJECTED");
+                expect(request1.status).toBe("REVIEW_REJECTED");
                 expect(request1.rejectReason).toBe(REJECT_REASON);
                 const userIdentity = request1.userIdentity;
                 expect(userIdentity).toEqual(expectedUserPrivateData.userIdentity)
@@ -165,7 +165,7 @@ describe('LocRequestController - Fetch -', () => {
 function mockModelForFetch(container: Container): void {
     const { request, repository, loc } = buildMocksForFetch(container);
 
-    setupRequest(request, REQUEST_ID, "Transaction", "REJECTED", testDataWithUserIdentity);
+    setupRequest(request, REQUEST_ID, "Transaction", "REVIEW_REJECTED", testDataWithUserIdentity);
     mockOwner(request, ALICE_ACCOUNT);
     mockRequester(request, SUBMITTER);
 

--- a/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
+++ b/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
@@ -154,7 +154,7 @@ function mockModelForReject(container: Container, notificationService: Mock<Noti
 function buildMocksForDecision(container: Container, notificationService: Mock<NotificationService>, rejectReason?: string): Mocks {
     const mocks = buildMocksForUpdate(container, { notificationService });
 
-    setupRequest(mocks.request, REQUEST_ID, "Transaction", "REQUESTED", testData);
+    setupRequest(mocks.request, REQUEST_ID, "Transaction", "REVIEW_PENDING", testData);
     mocks.request.setup(instance => instance.getDecision())
         .returns({ decisionOn: DECISION_TIMESTAMP, rejectReason });
 
@@ -220,6 +220,6 @@ function mockModelForCancel(container: Container) {
 
 function mockModelForRework(container: Container) {
     const { request } = buildMocksForUpdate(container);
-    setupRequest(request, REQUEST_ID, "Identity", "REJECTED");
+    setupRequest(request, REQUEST_ID, "Identity", "REVIEW_REJECTED");
     request.setup(instance => instance.rework()).returns(undefined);
 }

--- a/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
+++ b/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
@@ -3,16 +3,25 @@ import { LocRequestController } from "../../../src/logion/controllers/locrequest
 import { Container } from "inversify";
 import request from "supertest";
 import { Mock, It, Times } from "moq.ts";
-import {
-    LocType, LocFile, LocFileDelivered,
-} from "../../../src/logion/model/locrequest.model.js";
+import { LocType, LocFile, } from "../../../src/logion/model/locrequest.model.js";
 import { Moment } from "moment";
 import { NotificationService } from "../../../src/logion/services/notification.service.js";
 import { UserIdentity } from "../../../src/logion/model/useridentity.js";
-import { buildMocksForUpdate, mockPolkadotIdentityLoc, Mocks, REQUEST_ID, setupRequest, testData, testDataWithType, userIdentities } from "./locrequest.controller.shared.js";
+import {
+    buildMocksForUpdate,
+    mockPolkadotIdentityLoc,
+    Mocks,
+    REQUEST_ID,
+    setupRequest,
+    testData,
+    testDataWithType,
+    userIdentities,
+    REQUESTER_ADDRESS, ETHEREUM_REQUESTER
+} from "./locrequest.controller.shared.js";
 import { BOB } from "../../helpers/addresses.js";
+import { SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model";
 
-const { setupApp, mockLegalOfficerOnNode, mockAuthenticationWithAuthenticatedUser } = TestApp;
+const { setupApp, mockLegalOfficerOnNode, mockAuthenticationWithAuthenticatedUser, mockAuthenticatedUser } = TestApp;
 
 describe('LocRequestController - Life Cycle - Authenticated LLO is **NOT** LOC owner', () => {
 
@@ -145,6 +154,28 @@ describe('LocRequestController - Life Cycle - Authenticated LLO is LOC owner', (
     })
 });
 
+describe("LocRequestController - Life Cycle - Authenticated user opens LOC", () => {
+
+    function authenticatePolkadotRequester(address: string) {
+        return mockAuthenticationWithAuthenticatedUser(mockAuthenticatedUser(true, address));
+    }
+
+    it('opens an accepted request', async () => {
+        const app = setupApp(LocRequestController, container => mockModelForOpen(container, "Transaction"), authenticatePolkadotRequester(REQUESTER_ADDRESS.address))
+        await request(app)
+            .post(`/api/loc-request/${ REQUEST_ID }/open`)
+            .expect(204)
+    })
+
+    it('fails to open an accepted request when not requester', async () => {
+        const app = setupApp(LocRequestController, container => mockModelForOpen(container, "Transaction"), authenticatePolkadotRequester("5CdRcqWggMitHtaGq1iFMqJCySfb8k31GSxC32txLe6KPP7z"))
+        await request(app)
+            .post(`/api/loc-request/${ REQUEST_ID }/open`)
+            .expect(401)
+    })
+
+})
+
 function mockModelForReject(container: Container, notificationService: Mock<NotificationService>): void {
     const { request } = buildMocksForDecision(container, notificationService, REJECT_REASON);
     request.setup(instance => instance.reject(It.Is<string>(reason => reason === REJECT_REASON), It.IsAny<Moment>()))
@@ -171,6 +202,8 @@ function mockModelForAccept(container: Container, notificationService: Mock<Noti
     const { request } = buildMocksForDecision(container, notificationService);
     request.setup(instance => instance.accept(It.Is<string>(It.IsAny<Moment>())))
         .returns();
+    request.setup(instance => instance.canOpen(It.IsAny<SupportedAccountId>()))
+        .returns(true);
 }
 
 function mockModelForPreClose(container: Container, locType: LocType, userIdentity?: UserIdentity) {
@@ -190,6 +223,23 @@ function mockModelForPreVoid(container: Container) {
     const { request } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Identity", "OPEN", testData);
     request.setup(instance => instance.preVoid(VOID_REASON)).returns();
+}
+
+function mockModelForOpen(container: Container, locType: LocType, userIdentity?: UserIdentity) {
+    const { request, repository } = buildMocksForUpdate(container);
+
+    const data = {
+        ...testDataWithType(locType),
+        userIdentity
+    };
+    setupRequest(request, REQUEST_ID, locType, "REVIEW_ACCEPTED", data);
+    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params.address === REQUESTER_ADDRESS.address)))
+        .returns(true);
+    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params.address !== REQUESTER_ADDRESS.address)))
+        .returns(false);
+    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params === undefined)))
+        .returns(false);
+    request.setup(instance => instance.open()).returns();
 }
 
 const VOID_REASON = "Expired";

--- a/test/unit/controllers/locrequest.controller.sof.spec.ts
+++ b/test/unit/controllers/locrequest.controller.sof.spec.ts
@@ -38,7 +38,7 @@ describe('LocRequestController - SoF -', () => {
             .expect('Content-Type', /application\/json/)
             .then(response => {
                 expect(response.body.id).toBe(REQUEST_ID);
-                expect(response.body.status).toBe("REQUESTED");
+                expect(response.body.status).toBe("REVIEW_PENDING");
             })
         factory.verify(instance => instance.newSofRequest(It.Is<NewSofRequestParameters>(param =>
                 param.description.description === `Statement of Facts for LOC ${ LOC_ID.toDecimalString() }` &&
@@ -61,7 +61,7 @@ describe('LocRequestController - SoF -', () => {
             .expect('Content-Type', /application\/json/)
             .then(response => {
                 expect(response.body.id).toBe(REQUEST_ID);
-                expect(response.body.status).toBe("REQUESTED");
+                expect(response.body.status).toBe("REVIEW_PENDING");
             })
         factory.verify(instance => instance.newSofRequest(It.Is<NewSofRequestParameters>(param =>
             param.description.description === `Statement of Facts for LOC ${ LOC_ID.toDecimalString() } - ${ itemId }` &&
@@ -80,7 +80,7 @@ function mockModelForCreateSofRequest(container: Container, factory: Mock<LocReq
     repository.setup(instance => instance.findById(locId.toString()))
         .returns(Promise.resolve(targetLoc.object()));
 
-    setupRequest(request, REQUEST_ID, locType, "REQUESTED", testDataWithUserIdentityWithType(locType));
+    setupRequest(request, REQUEST_ID, locType, "REVIEW_PENDING", testDataWithUserIdentityWithType(locType));
 
     factory.setup(instance => instance.newSofRequest(It.IsAny<NewSofRequestParameters>()))
         .returns(Promise.resolve(request.object()));

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -256,6 +256,12 @@ describe("LocRequestAggregateRoot", () => {
         thenDecisionOnIs(ACCEPTED_ON);
     });
 
+    it("opens an accepted request", () => {
+        givenRequestWithStatus('REVIEW_ACCEPTED');
+        whenOpening();
+        thenRequestStatusIs('OPEN');
+    });
+
     it("fails reject given already open", () => {
         givenRequestWithStatus('OPEN');
         expect(() => whenRejecting(REJECT_REASON, REJECTED_ON)).toThrowError();
@@ -1113,6 +1119,10 @@ function whenRejecting(rejectReason: string, rejectedOn: Moment) {
 
 function whenAccepting(acceptedOn: Moment) {
     request.accept(acceptedOn);
+}
+
+function whenOpening() {
+    request.open();
 }
 
 function thenRequestStatusIs(expectedStatus: LocRequestStatus) {

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -53,7 +53,7 @@ describe("LocRequestFactory", () => {
         givenLocDescription(description);
         await whenCreatingLocRequest(false);
         thenRequestCreatedWithDescription(description);
-        thenStatusIs("REQUESTED");
+        thenStatusIs("REVIEW_PENDING");
     });
 
     it("creates an open Transaction LOC with requester address", async () => {
@@ -96,7 +96,7 @@ describe("LocRequestFactory", () => {
         givenLocDescription(description);
         await whenCreatingLocRequest(false);
         thenRequestCreatedWithDescription(description);
-        thenStatusIs("REQUESTED");
+        thenStatusIs("REVIEW_PENDING");
     });
 
     it("creates an open Collection LOC with requester address", async () => {
@@ -157,7 +157,7 @@ describe("LocRequestFactory", () => {
         thenRequestSealIs(SEAL);
         expect(description.userIdentity).toEqual(userIdentity)
         expect(description.userPostalAddress).toEqual(userPostalAddress)
-        thenStatusIs("REQUESTED");
+        thenStatusIs("REVIEW_PENDING");
     });
 
     it("creates an open Identity LOC with requester address", async () => {
@@ -241,17 +241,17 @@ describe("LocRequestFactory", () => {
 describe("LocRequestAggregateRoot", () => {
 
     it("rejects requested", () => {
-        givenRequestWithStatus('REQUESTED');
+        givenRequestWithStatus('REVIEW_PENDING');
         whenRejecting(REJECT_REASON, REJECTED_ON);
-        thenRequestStatusIs('REJECTED');
+        thenRequestStatusIs('REVIEW_REJECTED');
         thenRequestRejectReasonIs(REJECT_REASON);
         thenDecisionOnIs(REJECTED_ON);
     });
 
     it("accepts requested", () => {
-        givenRequestWithStatus('REQUESTED');
+        givenRequestWithStatus('REVIEW_PENDING');
         whenAccepting(ACCEPTED_ON);
-        thenRequestStatusIs('OPEN');
+        thenRequestStatusIs('REVIEW_ACCEPTED');
         thenRequestRejectReasonIs(undefined);
         thenDecisionOnIs(ACCEPTED_ON);
     });
@@ -267,12 +267,12 @@ describe("LocRequestAggregateRoot", () => {
     });
 
     it("fails reject given already rejected", () => {
-        givenRequestWithStatus('REJECTED');
+        givenRequestWithStatus('REVIEW_REJECTED');
         expect(() => whenRejecting(REJECT_REASON, REJECTED_ON)).toThrowError();
     });
 
     it("fails accept given already rejected", () => {
-        givenRequestWithStatus('REJECTED');
+        givenRequestWithStatus('REVIEW_REJECTED');
         expect(() => whenAccepting(ACCEPTED_ON)).toThrowError();
     });
 
@@ -337,7 +337,7 @@ describe("LocRequestAggregateRoot", () => {
     });
 
     it("accepts if pending when setting creation date", () => {
-        givenRequestWithStatus('REQUESTED');
+        givenRequestWithStatus('REVIEW_ACCEPTED');
         const locCreatedDate = moment();
         whenSettingLocCreatedDate(locCreatedDate);
         thenStatusIs('OPEN');
@@ -346,11 +346,11 @@ describe("LocRequestAggregateRoot", () => {
     it("submits if draft", () => {
         givenRequestWithStatus('DRAFT');
         whenSubmitting();
-        thenRequestStatusIs('REQUESTED');
+        thenRequestStatusIs('REVIEW_PENDING');
     });
 
     it("fails submit given non-draft", () => {
-        givenRequestWithStatus('REQUESTED');
+        givenRequestWithStatus('REVIEW_PENDING');
         expect(() => whenSubmitting()).toThrowError();
     });
 
@@ -1013,11 +1013,11 @@ describe("LocRequestAggregateRoot (processes)", () => {
         thenMetadataItemStatusIs(itemName, "REVIEW_ACCEPTED");
 
         request.submit();
-        thenRequestStatusIs("REQUESTED");
+        thenRequestStatusIs("REVIEW_PENDING");
 
         // LLO rejects
         request.reject("Because.", moment());
-        thenRequestStatusIs("REJECTED");
+        thenRequestStatusIs("REVIEW_REJECTED");
 
         // User reworks and submits again
         request.rework();
@@ -1029,10 +1029,13 @@ describe("LocRequestAggregateRoot (processes)", () => {
 
         // LLO accepts
         request.accept(moment());
+        thenRequestStatusIs("REVIEW_ACCEPTED");
+
+        // User opens
+        request.open(moment());
         thenRequestStatusIs("OPEN");
 
-
-        // User publishes
+        // User publishes items
         request.confirmFile(fileHash);
         request.setFileAddedOn(fileHash, moment()); // Sync
         request.confirmFileAcknowledged(fileHash);
@@ -1181,7 +1184,7 @@ const repository = new Mock<LocRequestRepository>();
 
 function thenRequestCreatedWithDescription(description: LocRequestDescription) {
     expect(request.id).toBe(requestId);
-    expect(request.status).toBe('REQUESTED');
+    expect(request.status).toBe('REVIEW_PENDING');
     expect(request.getDescription()).toEqual(description);
     expect(request.decisionOn).toBeUndefined();
 }


### PR DESCRIPTION
* LOC is now opened by the requester, provided that s(he) has a Polkadot Address.
* This is therefore not applicable when the requester is an Logion Identity LOC, or an Ethereum address.
* The review status are aligned to Item's review status:
  * A requested LOC is now `REVIEW_PENDING`  (previously: `REQUESTED`).
  * If the LLO rejects, it becomes `REVIEW_REJECTED` (previously: `REJECTED`).
  * If the LLO accepts for a Polkadot requester, it becomes `REVIEW_ACCEPTED` (previously: `OPEN`).
  * If the LLO accepts for a non-Polkadot requester, it becomes `OPEN` (unchanged).

---
⚠️ This covers only the minimal yet functional requirements to start front development. Missing backend features (mainly data migration and synchronization) will come later on.

logion-network/logion-internal#908