### PR TITLE
Supports for deletable Metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "typeorm": "node ./node_modules/typeorm/cli.js -d ./dist/db-tools/ormconfig.js"
     },
     "dependencies": {
-        "@logion/node-api": "^0.16.0",
+        "@logion/node-api": "^0.17.0-2",
         "@logion/node-exiftool": "^2.3.1-3",
         "@logion/rest-api-core": "^0.4.2-1",
         "@polkadot/wasm-crypto": "^7.1.1",

--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -724,6 +724,10 @@
                         "type": "string",
                         "description": "The item's name"
                     },
+                    "nameHash": {
+                        "type": "string",
+                        "description": "The item's name hash"
+                    },
                     "value": {
                         "type": "string",
                         "description": "The item's value"
@@ -760,7 +764,8 @@
                     }
                 },
                 "required": [
-                    "status"
+                    "status",
+                    "nameHash"
                 ]
             },
             "LocRequestView": {
@@ -1027,6 +1032,10 @@
                                 "name": {
                                     "type": "string",
                                     "description": "The item's name"
+                                },
+                                "nameHash": {
+                                    "type": "string",
+                                    "description": "The item's name hash"
                                 },
                                 "value": {
                                     "type": "string",

--- a/src/logion/controllers/adapters/locrequestadapter.ts
+++ b/src/logion/controllers/adapters/locrequestadapter.ts
@@ -91,6 +91,7 @@ export class LocRequestAdapter {
             })),
             metadata: request.getMetadataItems(viewer).map(item => ({
                 name: item.name,
+                nameHash: item.nameHash,
                 value: item.value,
                 submitter: item.submitter,
                 fees: toFeesView(item.fees),

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -403,6 +403,8 @@ export interface components {
     LocMetadataItemView: {
       /** @description The item's name */
       name?: string;
+      /** @description The item's name hash */
+      nameHash: string;
       /** @description The item's value */
       value?: string;
       /**
@@ -592,6 +594,8 @@ export interface components {
       metadata?: ({
           /** @description The item's name */
           name?: string;
+          /** @description The item's name hash */
+          nameHash?: string;
           /** @description The item's value */
           value?: string;
           /**

--- a/src/logion/lib/crypto/hashing.ts
+++ b/src/logion/lib/crypto/hashing.ts
@@ -1,15 +1,18 @@
 import crypto, { BinaryToTextEncoding } from 'crypto';
 import fs from 'fs';
 import Stream from 'stream';
+import { Hash } from "@logion/node-api";
 
 const algorithm = "sha256";
+
+export { Hash };
 
 export function sha256(attributes: any[]): string {
     return hash(algorithm, attributes);
 }
 
-export function sha256String(message: string): string {
-    return "0x" + hash(algorithm, [ message ], "hex");
+export function sha256String(message: string): Hash {
+    return `0x${ hash(algorithm, [ message ], "hex") }`;
 }
 
 function hash(algorithm: string, attributes: any[], encoding: BinaryToTextEncoding = "base64"): string {
@@ -18,7 +21,7 @@ function hash(algorithm: string, attributes: any[], encoding: BinaryToTextEncodi
     return hash.digest(encoding);
 }
 
-export function sha256File(fileName: string): Promise<string> {
+export function sha256File(fileName: string): Promise<Hash> {
     const hash = crypto.createHash(algorithm);
     const stream = fs.createReadStream(fileName);
     const hasherStream = new Stream.Writable();
@@ -26,9 +29,9 @@ export function sha256File(fileName: string): Promise<string> {
         hash.update(chunk);
         next();
     }
-    const promise = new Promise<string>((success, error) => {
+    const promise = new Promise<Hash>((success, error) => {
         stream.on('end', function () {
-            success("0x" + hash.digest('hex'));
+            success(`0x${ hash.digest('hex') }`);
         });
         stream.on('error', error);
     });

--- a/src/logion/lib/crypto/hashing.ts
+++ b/src/logion/lib/crypto/hashing.ts
@@ -2,10 +2,27 @@ import crypto, { BinaryToTextEncoding } from 'crypto';
 import fs from 'fs';
 import Stream from 'stream';
 import { Hash } from "@logion/node-api";
+import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
 
 const algorithm = "sha256";
 
 export { Hash };
+
+export class HashTransformer implements ValueTransformer {
+
+    public static readonly instance = new HashTransformer();
+
+    from(value: Buffer | undefined): Hash | undefined {
+        if (!value) {
+            return undefined;
+        }
+        return `0x${ value.toString('hex') }`;
+    }
+
+    to(value: Hash): Buffer {
+        return Buffer.from(value.substring(2), "hex");
+    }
+}
 
 export function sha256(attributes: any[]): string {
     return hash(algorithm, attributes);

--- a/src/logion/migration/1686924244354-AddMetadataNameHash.ts
+++ b/src/logion/migration/1686924244354-AddMetadataNameHash.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddMetadataNameHash1686924244354 implements MigrationInterface {
+    name = 'AddMetadataNameHash1686924244354'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Add and populate not null column "name_hash"
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" ADD "name_hash" bytea NULL`);
+        await queryRunner.query(`UPDATE "public"."loc_metadata_item" SET "name_hash" = sha256("name"::bytea)`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" ALTER COLUMN "name_hash" SET NOT NULL`);
+        // Re-create Primary Key
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" DROP CONSTRAINT "PK_loc_metadata_item"`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" ADD CONSTRAINT "PK_loc_metadata_item" PRIMARY KEY ("request_id", "name_hash")`);
+        // Make "name" nullable
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" ALTER COLUMN "name" DROP NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" ALTER COLUMN "name" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" DROP CONSTRAINT "PK_loc_metadata_item"`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" ADD CONSTRAINT "PK_loc_metadata_item" PRIMARY KEY ("request_id", "name")`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" DROP COLUMN "name_hash"`);
+    }
+
+}

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -26,7 +26,7 @@ import {
     polkadotAccount
 } from "./supportedaccountid.model.js";
 import { SelectQueryBuilder } from "typeorm/query-builder/SelectQueryBuilder.js";
-import { sha256String, Hash } from "../lib/crypto/hashing.js";
+import { sha256String, Hash, HashTransformer } from "../lib/crypto/hashing.js";
 
 const { logger } = Log;
 
@@ -516,7 +516,7 @@ export class LocRequestAggregateRoot {
 
     private toMetadataItemDescription(item: LocMetadataItem): MetadataItemDescription {
         return ({
-            nameHash: item.nameHash! as Hash,
+            nameHash: item.nameHash!,
             name: item.name!,
             value: item.value!,
             submitter: item.submitter!.toSupportedAccountId(),
@@ -1097,8 +1097,8 @@ export class LocMetadataItem extends Child implements HasIndex, Submitted {
     @Column({ name: "index" })
     index?: number;
 
-    @PrimaryColumn({ name: "name_hash" })
-    nameHash?: string;
+    @PrimaryColumn({ name: "name_hash", type: "bytea", transformer: HashTransformer.instance })
+    nameHash?: Hash;
 
     @Column({ length: 255, nullable: true })
     name?: string;

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -26,6 +26,7 @@ import {
     polkadotAccount
 } from "./supportedaccountid.model.js";
 import { SelectQueryBuilder } from "typeorm/query-builder/SelectQueryBuilder.js";
+import { sha256String, Hash } from "../lib/crypto/hashing.js";
 
 const { logger } = Log;
 
@@ -79,6 +80,7 @@ export interface MetadataItemParams {
 }
 
 export interface MetadataItemDescription extends MetadataItemParams, ItemLifecycle {
+    readonly nameHash: Hash;
 }
 
 export interface ItemLifecycle {
@@ -491,14 +493,16 @@ export class LocRequestAggregateRoot {
 
     addMetadataItem(itemDescription: MetadataItemParams, alreadyReviewed: boolean) {
         this.ensureEditable();
-        if (this.hasMetadataItem(itemDescription.name)) {
-            throw new Error("A metadata item with given name was already added to this LOC");
+        const nameHash = sha256String(itemDescription.name);
+        if (this.hasMetadataItem(nameHash)) {
+            throw new Error("A metadata item with given nameHash was already added to this LOC");
         }
         const item = new LocMetadataItem();
         item.request = this;
         item.requestId = this.id;
         item.index = this.metadata!.length;
         item.name = itemDescription.name;
+        item.nameHash = nameHash;
         item.value = itemDescription.value;
         item.lifecycle = EmbeddableLifecycle.from(alreadyReviewed);
         item.submitter = EmbeddableSupportedAccountId.from(itemDescription.submitter);
@@ -506,12 +510,13 @@ export class LocRequestAggregateRoot {
         this.metadata!.push(item);
     }
 
-    getMetadataItem(name: string): MetadataItemDescription {
-        return this.toMetadataItemDescription(this.metadataItem(name)!)
+    getMetadataItem(nameHash: Hash): MetadataItemDescription {
+        return this.toMetadataItemDescription(this.metadataItem(nameHash)!)
     }
 
     private toMetadataItemDescription(item: LocMetadataItem): MetadataItemDescription {
         return ({
+            nameHash: item.nameHash! as Hash,
             name: item.name!,
             value: item.value!,
             submitter: item.submitter!.toSupportedAccountId(),
@@ -524,19 +529,19 @@ export class LocRequestAggregateRoot {
         return orderAndMap(this.metadata?.filter(item => this.itemViewable(item, viewerAddress)), this.toMetadataItemDescription);
     }
 
-    setMetadataItemAddedOn(name: string, addedOn: Moment) {
-        const metadataItem = this.metadataItem(name)
+    setMetadataItemAddedOn(nameHash: Hash, addedOn: Moment) {
+        const metadataItem = this.metadataItem(nameHash)
         if (!metadataItem) {
-            logger.error(`MetadataItem with name ${ name } not found`);
+            logger.error(`MetadataItem with nameHash ${ nameHash } not found`);
             return;
         }
         metadataItem.lifecycle?.setAddedOn(addedOn);
         metadataItem._toUpdate = true;
     }
 
-    removeMetadataItem(remover: SupportedAccountId, name: string): void {
+    removeMetadataItem(remover: SupportedAccountId, nameHash: Hash): void {
         this.ensureEditable();
-        const removedItemIndex: number = this.metadata!.findIndex(link => link.name === name);
+        const removedItemIndex: number = this.metadata!.findIndex(link => link.nameHash === nameHash);
         if (removedItemIndex === -1) {
             throw new Error("No metadata item with given name");
         }
@@ -559,42 +564,42 @@ export class LocRequestAggregateRoot {
         }
     }
 
-    requestMetadataItemReview(name: string) {
-        this.mutateMetadataItem(name, item => item.lifecycle!.requestReview());
+    requestMetadataItemReview(nameHash: Hash) {
+        this.mutateMetadataItem(nameHash, item => item.lifecycle!.requestReview());
     }
 
-    acceptMetadataItem(name: string) {
+    acceptMetadataItem(nameHash: Hash) {
         this.ensureAcceptedOrOpen();
-        this.mutateMetadataItem(name, item => item.lifecycle!.accept());
+        this.mutateMetadataItem(nameHash, item => item.lifecycle!.accept());
     }
 
-    rejectMetadataItem(name: string, reason: string) {
-        this.mutateMetadataItem(name, item => item.lifecycle!.reject(reason));
+    rejectMetadataItem(nameHash: Hash, reason: string) {
+        this.mutateMetadataItem(nameHash, item => item.lifecycle!.reject(reason));
     }
 
-    confirmMetadataItem(name: string) {
-        this.mutateMetadataItem(name, item => item.lifecycle!.confirm(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toSupportedAccountId())));
+    confirmMetadataItem(nameHash: Hash) {
+        this.mutateMetadataItem(nameHash, item => item.lifecycle!.confirm(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toSupportedAccountId())));
     }
 
-    confirmMetadataItemAcknowledged(name: string, acknowledgedOn?: Moment) {
-        this.mutateMetadataItem(name, item => item.lifecycle!.confirmAcknowledged(acknowledgedOn));
+    confirmMetadataItemAcknowledged(nameHash: Hash, acknowledgedOn?: Moment) {
+        this.mutateMetadataItem(nameHash, item => item.lifecycle!.confirmAcknowledged(acknowledgedOn));
     }
 
-    private mutateMetadataItem(name: string, mutator: (item: LocMetadataItem) => void) {
+    private mutateMetadataItem(nameHash: Hash, mutator: (item: LocMetadataItem) => void) {
         const metadataItem = requireDefined(
-            this.metadataItem(name),
-            () => badRequest(`Metadata Item not found: ${ name }`)
+            this.metadataItem(nameHash),
+            () => badRequest(`Metadata Item not found: ${ nameHash }`)
         );
         mutator(metadataItem);
         metadataItem._toUpdate = true;
     }
 
-    hasMetadataItem(name: string): boolean {
-        return this.metadataItem(name) !== undefined;
+    hasMetadataItem(nameHash: Hash): boolean {
+        return this.metadataItem(nameHash) !== undefined;
     }
 
-    metadataItem(name: string): LocMetadataItem | undefined {
-        return this.metadata!.find(metadataItem => metadataItem.name === name)
+    metadataItem(nameHash: Hash): LocMetadataItem | undefined {
+        return this.metadata!.find(metadataItem => metadataItem.nameHash === nameHash)
     }
 
     setFileAddedOn(hash: string, addedOn: Moment) {
@@ -826,10 +831,10 @@ export class LocRequestAggregateRoot {
         file.setFees(fees, storageFeePaidBy);
     }
 
-    setMetadataItemFee(name: string, inclusionFee: bigint) {
-        const metadata = this.metadataItem(name);
+    setMetadataItemFee(nameHash: Hash, inclusionFee: bigint) {
+        const metadata = this.metadataItem(nameHash);
         if (!metadata) {
-            logger.error(`Data with name ${ name } not found`);
+            logger.error(`Data with nameHash ${ nameHash } not found`);
             return;
         }
         metadata.setFee(inclusionFee);
@@ -1092,7 +1097,10 @@ export class LocMetadataItem extends Child implements HasIndex, Submitted {
     @Column({ name: "index" })
     index?: number;
 
-    @PrimaryColumn({ length: 255 })
+    @PrimaryColumn({ name: "name_hash" })
+    nameHash?: string;
+
+    @Column({ length: 255, nullable: true })
     name?: string;
 
     @Column({ name: "value", length: 255, nullable: true })

--- a/src/logion/services/locsynchronization.service.ts
+++ b/src/logion/services/locsynchronization.service.ts
@@ -136,11 +136,11 @@ export class LocSynchronizer {
     }
 
     private async updateMetadataItem(loc: LocRequestAggregateRoot, timestamp: Moment, extrinsic: JsonExtrinsic) {
-        const name = Adapters.asString(Adapters.asJsonObject(extrinsic.call.args['item']).name);
-        loc.setMetadataItemAddedOn(name, timestamp);
+        const nameHash = Adapters.asHexString(Adapters.asJsonObject(extrinsic.call.args['item']).name);
+        loc.setMetadataItemAddedOn(nameHash, timestamp);
         const inclusionFee = await extrinsic.partialFee();
         if(inclusionFee) {
-            loc.setMetadataItemFee(name, BigInt(inclusionFee));
+            loc.setMetadataItemFee(nameHash, BigInt(inclusionFee));
         } else {
             throw new Error("Could not get inclusion fee");
         }
@@ -338,7 +338,7 @@ export class LocSynchronizer {
 
     private async confirmAcknowledgedMetadata(timestamp: Moment, extrinsic: JsonExtrinsic) {
         const locId = extractUuid('loc_id', extrinsic.call.args);
-        const name = Adapters.asString(extrinsic.call.args['name']);
-        await this.mutateLoc(locId, async loc => loc.confirmMetadataItemAcknowledged(name, timestamp));
+        const nameHash = Adapters.asHexString(extrinsic.call.args['name']);
+        await this.mutateLoc(locId, async loc => loc.confirmMetadataItemAcknowledged(nameHash, timestamp));
     }
 }

--- a/test/integration/model/loc_requests.sql
+++ b/test/integration/model/loc_requests.sql
@@ -24,8 +24,8 @@ INSERT INTO loc_request (id, owner_address, requester_address, requester_address
 VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ', 'Polkadot', 'loc-10', 'OPEN', 'Transaction');
 INSERT INTO loc_request_file (request_id, hash, name, oid, content_type, added_on, "index", status, nature, submitter_address, submitter_address_type, size)
 VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', 'a file', 123456, 'text/plain', '2021-10-06T11:16:00.000', 0, 'DRAFT', 'some nature', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', 'Polkadot', 123);
-INSERT INTO loc_metadata_item (request_id, "index", name, "value_text", added_on, status, submitter_address, submitter_address_type)
-VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', 0, 'a name', 'a value', '2021-10-06T11:16:00.000', 'DRAFT', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', 'Polkadot');
+INSERT INTO loc_metadata_item (request_id, "index", name, name_hash, "value_text", added_on, status, submitter_address, submitter_address_type)
+VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', 0, 'a name', sha256('a name'::bytea), 'a value', '2021-10-06T11:16:00.000', 'DRAFT', '5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw', 'Polkadot');
 INSERT INTO loc_link (request_id, "index", target, added_on, draft, nature)
 VALUES ('2b287596-f9d5-8030-b606-d1da538cb37f', 0, 'ec126c6c-64cf-4eb8-bfa6-2a98cd19ad5d', '2021-10-06T11:16:00.000', true, 'link-nature');
 -- Open Polkadot Identity locs

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -124,6 +124,7 @@ describe('LocRequestRepository - read accesses', () => {
         const metadata = request!.getMetadataItems(request?.getOwner());
         expect(metadata.length).toBe(1);
         expect(metadata[0].name).toBe("a name");
+        expect(metadata[0].nameHash).toBe("0x36e96c62633613d6f8e98943830ed5c5f814c2bb9214d8bba577386096bc926a");
         expect(metadata[0].value).toBe("a value");
         expect(metadata[0].addedOn!.isSame(moment("2021-10-06T11:16:00.000"))).toBe(true);
         expect(request!.metadata![0].status).toBe("DRAFT");

--- a/test/unit/controllers/locrequest.controller.fetch.spec.ts
+++ b/test/unit/controllers/locrequest.controller.fetch.spec.ts
@@ -33,6 +33,7 @@ import { mockAuthenticationForUserOrLegalOfficer } from "@logion/rest-api-core/d
 import { UserPrivateData } from "src/logion/controllers/adapters/locrequestadapter.js";
 import { Fees } from "@logion/node-api";
 import { polkadotAccount } from "../../../src/logion/model/supportedaccountid.model.js";
+import { sha256String } from "../../../src/logion/lib/crypto/hashing.js";
 
 const { mockAuthenticationWithCondition, setupApp } = TestApp;
 
@@ -237,6 +238,7 @@ const testLink: LinkDescription = {
 
 const testMetadataItem: MetadataItemDescription = {
     name: "test-data",
+    nameHash: sha256String("test-data"),
     value: "test-data-value",
     submitter: SUBMITTER,
     fees: DATA_LINK_FEES,

--- a/test/unit/lib/crypto/hashing.spec.ts
+++ b/test/unit/lib/crypto/hashing.spec.ts
@@ -1,4 +1,4 @@
-import { sha256, sha256File } from '../../../../src/logion/lib/crypto/hashing.js';
+import { sha256, sha256File, HashTransformer, sha256String } from '../../../../src/logion/lib/crypto/hashing.js';
 
 describe('HashingTest', () => {
 
@@ -26,6 +26,14 @@ describe('HashingTest', () => {
     it("hashes binary file", async () => {
         const hash = await sha256File("test/unit/lib/crypto/assets.png");
         expect(hash).toBe("0x68a87ced4573656b101940c90ac3bdc24b651f688c06e71c70d37f43dfc5058c");
+    });
+
+    it("convert from/to Buffer", () => {
+        const transformer = HashTransformer.instance;
+        const hash = sha256String("abc123");
+        const buffer = transformer.to(hash);
+        expect(buffer.length).toEqual(32);
+        expect(transformer.from(buffer)).toEqual(hash);
     });
 });
 

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -19,6 +19,7 @@ import { VerifiedIssuerSelectionService } from "src/logion/services/verifiedissu
 import { NonTransactionalTokensRecordService } from "../../../src/logion/services/tokensrecord.service.js";
 import { TokensRecordFactory, TokensRecordRepository } from "../../../src/logion/model/tokensrecord.model.js";
 import { ALICE } from "../../helpers/addresses.js";
+import { sha256String, Hash } from "../../../src/logion/lib/crypto/hashing.js";
 
 describe("LocSynchronizer", () => {
 
@@ -60,7 +61,7 @@ describe("LocSynchronizer", () => {
         givenLocExtrinsic("addMetadata", {
             loc_id: locId,
             item: {
-                name: METADATA_ITEM_NAME,
+                name: METADATA_ITEM_NAME_HASH,
                 value: METADATA_ITEM_VALUE,
             }
         });
@@ -167,7 +168,7 @@ describe("LocSynchronizer", () => {
     it("confirms metadata acknowledged", async () => {
         givenLocExtrinsic("acknowledgeMetadata", {
             loc_id: locId,
-            name: METADATA_ITEM_NAME,
+            name: METADATA_ITEM_NAME_HASH,
         });
         givenLocRequest();
         givenLocRequestExpectsMetadataItemAcknowledged();
@@ -286,18 +287,19 @@ function thenLocIsSaved() {
 }
 
 function givenLocRequestExpectsMetadataItemUpdated() {
-    locRequest.setup(instance => instance.setMetadataItemAddedOn(IS_EXPECTED_NAME, IS_BLOCK_TIME)).returns(undefined);
-    locRequest.setup(instance => instance.setMetadataItemFee(IS_EXPECTED_NAME, 42n)).returns(undefined);
+    locRequest.setup(instance => instance.setMetadataItemAddedOn(IS_EXPECTED_NAME_HASH, IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.setMetadataItemFee(IS_EXPECTED_NAME_HASH, 42n)).returns(undefined);
 }
 
-const IS_EXPECTED_NAME = It.Is<string>(name => name === METADATA_ITEM_NAME)
+const IS_EXPECTED_NAME_HASH = It.Is<Hash>(nameHash => nameHash === METADATA_ITEM_NAME_HASH)
 
 const METADATA_ITEM_NAME = "name";
+const METADATA_ITEM_NAME_HASH = sha256String(METADATA_ITEM_NAME);
 const METADATA_ITEM_VALUE = "value";
 
 function thenMetadataUpdated() {
-    locRequest.verify(instance => instance.setMetadataItemAddedOn(IS_EXPECTED_NAME, IS_BLOCK_TIME));
-    locRequest.verify(instance => instance.setMetadataItemFee(IS_EXPECTED_NAME, 42n));
+    locRequest.verify(instance => instance.setMetadataItemAddedOn(IS_EXPECTED_NAME_HASH, IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.setMetadataItemFee(IS_EXPECTED_NAME_HASH, 42n));
 }
 
 function givenLocRequestExpectsClose() {
@@ -349,11 +351,11 @@ function thenCollectionItemSaved() {
 }
 
 function givenLocRequestExpectsMetadataItemAcknowledged() {
-    locRequest.setup(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME, IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME_HASH, IS_BLOCK_TIME)).returns(undefined);
 }
 
 function thenMetadataAcknowledged() {
-    locRequest.verify(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME, IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME_HASH, IS_BLOCK_TIME));
 }
 
 function givenLocRequestExpectsFileAcknowledged() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,17 +1809,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.16.0":
-  version: 0.16.0
-  resolution: "@logion/node-api@npm:0.16.0"
+"@logion/node-api@npm:^0.17.0-2":
+  version: 0.17.0-2
+  resolution: "@logion/node-api@npm:0.17.0-2"
   dependencies:
-    "@polkadot/api": ^10.4.1
-    "@polkadot/util": ^12.0.1
-    "@polkadot/util-crypto": ^12.0.1
+    "@polkadot/api": ^10.9.1
+    "@polkadot/util": ^12.3.2
+    "@polkadot/util-crypto": ^12.3.2
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 800135730edbd3ce9c12687ae25e976b09bed7ee28246cf445b44a92bb1b89a5d66c1299f0930398f86d8972d0bdb25ccafca323c5035d454e8cb6f1ba3c4bf8
+  checksum: 41ca12870cdabacfc16eb6cf47a92d7a469ddd7c43cb812d36d63497f586c3737ec5f5aaefe50efe948cc26f83a817045ce3e4422a35fc7ff478ad74acb5f990
   languageName: node
   linkType: hard
 
@@ -1877,12 +1877,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@noble/curves@npm:1.0.0"
+"@noble/curves@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@noble/curves@npm:1.1.0"
   dependencies:
-    "@noble/hashes": 1.3.0
-  checksum: 6bcef44d626c640dc8961819d68dd67dffb907e3b973b7c27efe0ecdd9a5c6ce62c7b9e3dfc930c66605dced7f1ec0514d191c09a2ce98d6d52b66e3315ffa79
+    "@noble/hashes": 1.3.1
+  checksum: 2658cdd3f84f71079b4e3516c47559d22cf4b55c23ac8ee9d2b1f8e5b72916d9689e59820e0f9d9cb4a46a8423af5b56dc6bb7782405c88be06a015180508db5
   languageName: node
   linkType: hard
 
@@ -1893,10 +1893,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@noble/hashes@npm:1.3.0"
-  checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
+"@noble/hashes@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@noble/hashes@npm:1.3.1"
+  checksum: 7fdefc0f7a0c1ec27acc6ff88841793e3f93ec4ce6b8a6a12bfc0dd70ae6b7c4c82fe305fdfeda1735d5ad4a9eebe761e6693b3d355689c559e91242f4bc95b1
   languageName: node
   linkType: hard
 
@@ -1954,259 +1954,259 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/api-augment@npm:10.4.1"
+"@polkadot/api-augment@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/api-augment@npm:10.9.1"
   dependencies:
-    "@polkadot/api-base": 10.4.1
-    "@polkadot/rpc-augment": 10.4.1
-    "@polkadot/types": 10.4.1
-    "@polkadot/types-augment": 10.4.1
-    "@polkadot/types-codec": 10.4.1
-    "@polkadot/util": ^12.0.1
-    tslib: ^2.5.0
-  checksum: b47c927c8a2eb4a5d42687a7d0ed330003a26d2b7f7716dd4e73c45e325d44474a171a64302a6d1ebc02ba6ab0e13efc699cf64113b5b73221e4605320382979
+    "@polkadot/api-base": 10.9.1
+    "@polkadot/rpc-augment": 10.9.1
+    "@polkadot/types": 10.9.1
+    "@polkadot/types-augment": 10.9.1
+    "@polkadot/types-codec": 10.9.1
+    "@polkadot/util": ^12.3.1
+    tslib: ^2.5.3
+  checksum: b0aeed5ebf640c58a252a29a33f12d4c39d0dcdf10b875501012c3b4b05955ed8be85efbf75e17ad237a561e1171821979ffdddf7e6a64cb0806badb2752c190
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/api-base@npm:10.4.1"
+"@polkadot/api-base@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/api-base@npm:10.9.1"
   dependencies:
-    "@polkadot/rpc-core": 10.4.1
-    "@polkadot/types": 10.4.1
-    "@polkadot/util": ^12.0.1
-    rxjs: ^7.8.0
-    tslib: ^2.5.0
-  checksum: 7fbb5b2d5cf5d61891728642a6bc69ea5f26709ef6d26539ceac2c88b7ad6eab1e2a3eaa02b6c126d57c9f4927d9f2ca9faa4cb0b455e5e88b70c65bfaf7bd14
+    "@polkadot/rpc-core": 10.9.1
+    "@polkadot/types": 10.9.1
+    "@polkadot/util": ^12.3.1
+    rxjs: ^7.8.1
+    tslib: ^2.5.3
+  checksum: a761f4ade747a295c16b7e6f24c1bb93e1736aa7fa9f1cb3c651c84d02a99cc62658e83326fa339882423966a55bf0046b74a69a1a4e4567c8d6c1c4db4eb306
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/api-derive@npm:10.4.1"
+"@polkadot/api-derive@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/api-derive@npm:10.9.1"
   dependencies:
-    "@polkadot/api": 10.4.1
-    "@polkadot/api-augment": 10.4.1
-    "@polkadot/api-base": 10.4.1
-    "@polkadot/rpc-core": 10.4.1
-    "@polkadot/types": 10.4.1
-    "@polkadot/types-codec": 10.4.1
-    "@polkadot/util": ^12.0.1
-    "@polkadot/util-crypto": ^12.0.1
-    rxjs: ^7.8.0
-    tslib: ^2.5.0
-  checksum: b45cf05e02ef7319d51243d3b81f9d93d1958a8a170f8b4d04d0ebdd7426ca7c06120a73f63b0792aeba2f7417e70ce43371c4c653d9835e4510c3b0615cbfb6
+    "@polkadot/api": 10.9.1
+    "@polkadot/api-augment": 10.9.1
+    "@polkadot/api-base": 10.9.1
+    "@polkadot/rpc-core": 10.9.1
+    "@polkadot/types": 10.9.1
+    "@polkadot/types-codec": 10.9.1
+    "@polkadot/util": ^12.3.1
+    "@polkadot/util-crypto": ^12.3.1
+    rxjs: ^7.8.1
+    tslib: ^2.5.3
+  checksum: 072a43bcc55787beb6c29afe0f011c03cdde3a9b6ac38d972d0b13ff93a1e14198d769a926edfd324c3947735dd8c8fcb7a61629409322230fd8559e7c17a1d7
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:10.4.1, @polkadot/api@npm:^10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/api@npm:10.4.1"
+"@polkadot/api@npm:10.9.1, @polkadot/api@npm:^10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/api@npm:10.9.1"
   dependencies:
-    "@polkadot/api-augment": 10.4.1
-    "@polkadot/api-base": 10.4.1
-    "@polkadot/api-derive": 10.4.1
-    "@polkadot/keyring": ^12.0.1
-    "@polkadot/rpc-augment": 10.4.1
-    "@polkadot/rpc-core": 10.4.1
-    "@polkadot/rpc-provider": 10.4.1
-    "@polkadot/types": 10.4.1
-    "@polkadot/types-augment": 10.4.1
-    "@polkadot/types-codec": 10.4.1
-    "@polkadot/types-create": 10.4.1
-    "@polkadot/types-known": 10.4.1
-    "@polkadot/util": ^12.0.1
-    "@polkadot/util-crypto": ^12.0.1
-    eventemitter3: ^5.0.0
-    rxjs: ^7.8.0
-    tslib: ^2.5.0
-  checksum: 90d95d0689445b3520710305c124d88b099c5e00245ee044de7deb8c13ac3ffcfec49a4394edb8a9f78b674c9d6f643e18da24d6f31d00c4dd1e4bd6981c4bf7
+    "@polkadot/api-augment": 10.9.1
+    "@polkadot/api-base": 10.9.1
+    "@polkadot/api-derive": 10.9.1
+    "@polkadot/keyring": ^12.3.1
+    "@polkadot/rpc-augment": 10.9.1
+    "@polkadot/rpc-core": 10.9.1
+    "@polkadot/rpc-provider": 10.9.1
+    "@polkadot/types": 10.9.1
+    "@polkadot/types-augment": 10.9.1
+    "@polkadot/types-codec": 10.9.1
+    "@polkadot/types-create": 10.9.1
+    "@polkadot/types-known": 10.9.1
+    "@polkadot/util": ^12.3.1
+    "@polkadot/util-crypto": ^12.3.1
+    eventemitter3: ^5.0.1
+    rxjs: ^7.8.1
+    tslib: ^2.5.3
+  checksum: 6b37d9bacf0599bb7c385ddefca929547299a6f1d242ce3215f8480672297c81ec30c251bc9aac3889c5956bd9ef3918d69364819861eec308f4aa347c08110d
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/keyring@npm:12.0.1"
+"@polkadot/keyring@npm:^12.3.1":
+  version: 12.3.2
+  resolution: "@polkadot/keyring@npm:12.3.2"
   dependencies:
-    "@polkadot/util": 12.0.1
-    "@polkadot/util-crypto": 12.0.1
-    tslib: ^2.5.0
+    "@polkadot/util": 12.3.2
+    "@polkadot/util-crypto": 12.3.2
+    tslib: ^2.5.3
   peerDependencies:
-    "@polkadot/util": 12.0.1
-    "@polkadot/util-crypto": 12.0.1
-  checksum: 52a1a8fd9178b012c932ed81c57570d2fc3f8e6e5201e0b6b490bc81414cdcdb6559817e58df1274b5e2f7eb8dae0e918d33890ceea28412dedf8a88907e7d69
+    "@polkadot/util": 12.3.2
+    "@polkadot/util-crypto": 12.3.2
+  checksum: fa1238052ab6a93f4d97c0351e908ab866c128eb9089fe8829af4a4603be3d97dd964bb2b95c22248cfd120800bbc37aa93e03221ecca4f97c36818d452b44db
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:12.0.1, @polkadot/networks@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/networks@npm:12.0.1"
+"@polkadot/networks@npm:12.3.2, @polkadot/networks@npm:^12.3.1":
+  version: 12.3.2
+  resolution: "@polkadot/networks@npm:12.3.2"
   dependencies:
-    "@polkadot/util": 12.0.1
-    "@substrate/ss58-registry": ^1.39.0
-    tslib: ^2.5.0
-  checksum: 90a7237a64770e25db2f35cb2ec3bb0859816df9792afc67c3923d6f3fdc61acd92f54f093f571eb45b7f5ccafc22d152bade992d8f4053c7f6b454d2ac40929
+    "@polkadot/util": 12.3.2
+    "@substrate/ss58-registry": ^1.40.0
+    tslib: ^2.5.3
+  checksum: 54d5aa2a90b761a200bf0cf492f1c53cbbd555067f9486542997097640b0813e46675837e83225cee8ab4e816bcae12cdc046f07b5869930ab1e694b1e6e3cec
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/rpc-augment@npm:10.4.1"
+"@polkadot/rpc-augment@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/rpc-augment@npm:10.9.1"
   dependencies:
-    "@polkadot/rpc-core": 10.4.1
-    "@polkadot/types": 10.4.1
-    "@polkadot/types-codec": 10.4.1
-    "@polkadot/util": ^12.0.1
-    tslib: ^2.5.0
-  checksum: 19e95fe0ac371210fc5bc039a60263844267e8a790f4721925d6826d3c50b794ccd250a7dc32bb2a70b6563bbe552007bb599ea52a6ea137c9fe614d3b9957d2
+    "@polkadot/rpc-core": 10.9.1
+    "@polkadot/types": 10.9.1
+    "@polkadot/types-codec": 10.9.1
+    "@polkadot/util": ^12.3.1
+    tslib: ^2.5.3
+  checksum: 4f7b090be6d88ef6a56679a80da856bf007994e2142e16fbac6030132789b5a2411421650935ed4b18334afca399edfc0387135731836c6d9f8420acf510f11b
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/rpc-core@npm:10.4.1"
+"@polkadot/rpc-core@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/rpc-core@npm:10.9.1"
   dependencies:
-    "@polkadot/rpc-augment": 10.4.1
-    "@polkadot/rpc-provider": 10.4.1
-    "@polkadot/types": 10.4.1
-    "@polkadot/util": ^12.0.1
-    rxjs: ^7.8.0
-    tslib: ^2.5.0
-  checksum: c6422f6a669461386a86bb2645db38407a9912b1ea9f54cdc6f6fd212285c82b1e506e9c0bfaa0227a5562fec42551bdc71991d13f50c5b1f042602dade64f23
+    "@polkadot/rpc-augment": 10.9.1
+    "@polkadot/rpc-provider": 10.9.1
+    "@polkadot/types": 10.9.1
+    "@polkadot/util": ^12.3.1
+    rxjs: ^7.8.1
+    tslib: ^2.5.3
+  checksum: 538a207f5d321b4b18b0580da438598dd78e496dbc7069a776abcc39ede36903981ba2b9897eea73ecfe2f48a4d0cbd5b5cd738b3184f5c333709e6f4603f22a
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/rpc-provider@npm:10.4.1"
+"@polkadot/rpc-provider@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/rpc-provider@npm:10.9.1"
   dependencies:
-    "@polkadot/keyring": ^12.0.1
-    "@polkadot/types": 10.4.1
-    "@polkadot/types-support": 10.4.1
-    "@polkadot/util": ^12.0.1
-    "@polkadot/util-crypto": ^12.0.1
-    "@polkadot/x-fetch": ^12.0.1
-    "@polkadot/x-global": ^12.0.1
-    "@polkadot/x-ws": ^12.0.1
-    "@substrate/connect": 0.7.24
-    eventemitter3: ^5.0.0
+    "@polkadot/keyring": ^12.3.1
+    "@polkadot/types": 10.9.1
+    "@polkadot/types-support": 10.9.1
+    "@polkadot/util": ^12.3.1
+    "@polkadot/util-crypto": ^12.3.1
+    "@polkadot/x-fetch": ^12.3.1
+    "@polkadot/x-global": ^12.3.1
+    "@polkadot/x-ws": ^12.3.1
+    "@substrate/connect": 0.7.26
+    eventemitter3: ^5.0.1
     mock-socket: ^9.2.1
-    nock: ^13.3.0
-    tslib: ^2.5.0
+    nock: ^13.3.1
+    tslib: ^2.5.3
   dependenciesMeta:
     "@substrate/connect":
       optional: true
-  checksum: d2e0ddb3e04236496da5218a5811b03415fe04b4fe78a40800213a919eca823f951f91fc4c5bee75dbcdfc12911d7ad6cf39b307d3bef356d37128a1aaca278a
+  checksum: 4521ba64a1e69ed323910796a4598755e8101704aae3be33b6c363be4ebb9ea1a99ced17b8cd9fa3ab15abf5900e1055279f532f47b8472e8a143a299bfa046d
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/types-augment@npm:10.4.1"
+"@polkadot/types-augment@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/types-augment@npm:10.9.1"
   dependencies:
-    "@polkadot/types": 10.4.1
-    "@polkadot/types-codec": 10.4.1
-    "@polkadot/util": ^12.0.1
-    tslib: ^2.5.0
-  checksum: 9ddf94d5591fa4e9d9c8469fb89ba53ca8b6218a15e14e68f05aeabd16e9ef38ab1a30ae69c2fff715420547dc1c7a95e693472b578b03b19d6eb7b3984ad0a3
+    "@polkadot/types": 10.9.1
+    "@polkadot/types-codec": 10.9.1
+    "@polkadot/util": ^12.3.1
+    tslib: ^2.5.3
+  checksum: d643f83ab0a9498267037d95b878fa4e3b0087882195c3bd609038e8c934a092d9c82f7164ac97989305805aabe0d9186736c50a372498c81c22b3d7f4cfcccb
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/types-codec@npm:10.4.1"
+"@polkadot/types-codec@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/types-codec@npm:10.9.1"
   dependencies:
-    "@polkadot/util": ^12.0.1
-    "@polkadot/x-bigint": ^12.0.1
-    tslib: ^2.5.0
-  checksum: df0d96bd266d30a5672d5c8574ae8baf87c36b75972f18a9543159b850b989597804e6da071edd34fc9a2a598a5b909d61c263dae92ed917036efe4eddb88fe2
+    "@polkadot/util": ^12.3.1
+    "@polkadot/x-bigint": ^12.3.1
+    tslib: ^2.5.3
+  checksum: ac11b770fa4328f55daf6dd78fc8fc4d6906fb0d4b2bf92eaece58332c74f2b178d598a310a6dd068c72856acefddf5f7d23cac56991fa12f61d6853fb73d582
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/types-create@npm:10.4.1"
+"@polkadot/types-create@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/types-create@npm:10.9.1"
   dependencies:
-    "@polkadot/types-codec": 10.4.1
-    "@polkadot/util": ^12.0.1
-    tslib: ^2.5.0
-  checksum: c1a9240281c99d063eed5879a09cbda3330f7550daa1953dc06ca0244b59ba09e5c8e2b707211269215d0c85c8c2d0254df80597a094101f8f4384fabae3d2e5
+    "@polkadot/types-codec": 10.9.1
+    "@polkadot/util": ^12.3.1
+    tslib: ^2.5.3
+  checksum: 43f8fbd70a7891d6b49f1edb00b4a918c21924f2c1e44eb81ef7c9327e1fcc7eac65dbc2a9d0e3ba49079fdddda5498115e47f5fd99ec2a91f79c7f305bf553a
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/types-known@npm:10.4.1"
+"@polkadot/types-known@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/types-known@npm:10.9.1"
   dependencies:
-    "@polkadot/networks": ^12.0.1
-    "@polkadot/types": 10.4.1
-    "@polkadot/types-codec": 10.4.1
-    "@polkadot/types-create": 10.4.1
-    "@polkadot/util": ^12.0.1
-    tslib: ^2.5.0
-  checksum: 87b014d7d16c9156d8e0438f273778b027f0735262ba77e11201e200108c5f5eee2b1b41f2f3444a7249cf847ee083d058495ec6077369a59cc2e4ea121490ff
+    "@polkadot/networks": ^12.3.1
+    "@polkadot/types": 10.9.1
+    "@polkadot/types-codec": 10.9.1
+    "@polkadot/types-create": 10.9.1
+    "@polkadot/util": ^12.3.1
+    tslib: ^2.5.3
+  checksum: 8a3dd0dead1759112b9011c5ff47bf9fa0f5a00d0d5cba841d724494a9434a2f565fad8ab654ae8cc3949a10c28f3966034bfc23e493b7cc373d3532de508953
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/types-support@npm:10.4.1"
+"@polkadot/types-support@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/types-support@npm:10.9.1"
   dependencies:
-    "@polkadot/util": ^12.0.1
-    tslib: ^2.5.0
-  checksum: 2af8e000f495e6a55e6346b33f1b61c52361ad50507a2c4a98e6b1ca04be6dcc2aaf6757d175483bfca4eb5781032dbff650c26d8b87e2a8ee6d6754d670c9d2
+    "@polkadot/util": ^12.3.1
+    tslib: ^2.5.3
+  checksum: f5df33f215f529c33d4fd7ad7d6877a4567954488971c2986da416b6578ccb6d5c6eeadab4602abe0e3ce17373cdd6de0ce6f09529852b6e2fd6bc28b9183f9b
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:10.4.1":
-  version: 10.4.1
-  resolution: "@polkadot/types@npm:10.4.1"
+"@polkadot/types@npm:10.9.1":
+  version: 10.9.1
+  resolution: "@polkadot/types@npm:10.9.1"
   dependencies:
-    "@polkadot/keyring": ^12.0.1
-    "@polkadot/types-augment": 10.4.1
-    "@polkadot/types-codec": 10.4.1
-    "@polkadot/types-create": 10.4.1
-    "@polkadot/util": ^12.0.1
-    "@polkadot/util-crypto": ^12.0.1
-    rxjs: ^7.8.0
-    tslib: ^2.5.0
-  checksum: 16dbf436f4c8981fa554606c4edcd183c2b48f46f055932d9838d8efe01a15d66608f0f9e56dfab0fd6211a407cfde5ed6a1ad52b081aac46ca8f156e1515932
+    "@polkadot/keyring": ^12.3.1
+    "@polkadot/types-augment": 10.9.1
+    "@polkadot/types-codec": 10.9.1
+    "@polkadot/types-create": 10.9.1
+    "@polkadot/util": ^12.3.1
+    "@polkadot/util-crypto": ^12.3.1
+    rxjs: ^7.8.1
+    tslib: ^2.5.3
+  checksum: c9b0873b52f33c5d7913bc1e474c67d797411ac592c10af987dfecfee7480aeda02b9fc100ff506bc8af704a7fc239162a8ec7eec580e2e7a62ac7f7b95f3900
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:12.0.1, @polkadot/util-crypto@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/util-crypto@npm:12.0.1"
+"@polkadot/util-crypto@npm:12.3.2, @polkadot/util-crypto@npm:^12.3.1, @polkadot/util-crypto@npm:^12.3.2":
+  version: 12.3.2
+  resolution: "@polkadot/util-crypto@npm:12.3.2"
   dependencies:
-    "@noble/curves": 1.0.0
-    "@noble/hashes": 1.3.0
-    "@polkadot/networks": 12.0.1
-    "@polkadot/util": 12.0.1
-    "@polkadot/wasm-crypto": ^7.1.1
-    "@polkadot/wasm-util": ^7.1.1
-    "@polkadot/x-bigint": 12.0.1
-    "@polkadot/x-randomvalues": 12.0.1
+    "@noble/curves": 1.1.0
+    "@noble/hashes": 1.3.1
+    "@polkadot/networks": 12.3.2
+    "@polkadot/util": 12.3.2
+    "@polkadot/wasm-crypto": ^7.2.1
+    "@polkadot/wasm-util": ^7.2.1
+    "@polkadot/x-bigint": 12.3.2
+    "@polkadot/x-randomvalues": 12.3.2
     "@scure/base": 1.1.1
-    tslib: ^2.5.0
+    tslib: ^2.5.3
   peerDependencies:
-    "@polkadot/util": 12.0.1
-  checksum: ecab62f596c31e53800b91a0f7d09fd35085e61946d34438ceca9aa47a152b21299e6391bbc342efe33db1c9d0c35aa5a7dade8f77be73dde97bd29d9f52afff
+    "@polkadot/util": 12.3.2
+  checksum: 5c4053b4172ce138b4df5d61dc83905759fde6816ddf1d1aea7389bf4e9bba6d0a110e356eb9a3d76065393b787eb9797428966a1da36bb3b13567bdb67d5671
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:12.0.1, @polkadot/util@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/util@npm:12.0.1"
+"@polkadot/util@npm:12.3.2, @polkadot/util@npm:^12.3.1, @polkadot/util@npm:^12.3.2":
+  version: 12.3.2
+  resolution: "@polkadot/util@npm:12.3.2"
   dependencies:
-    "@polkadot/x-bigint": 12.0.1
-    "@polkadot/x-global": 12.0.1
-    "@polkadot/x-textdecoder": 12.0.1
-    "@polkadot/x-textencoder": 12.0.1
+    "@polkadot/x-bigint": 12.3.2
+    "@polkadot/x-global": 12.3.2
+    "@polkadot/x-textdecoder": 12.3.2
+    "@polkadot/x-textencoder": 12.3.2
     "@types/bn.js": ^5.1.1
     bn.js: ^5.2.1
-    tslib: ^2.5.0
-  checksum: b680726031c6f821db57d1fe8122d95a71bdedfdf2c9e1421e34728eefca0e70350914d48803e49d29a47eeab67d863e7e6285b5751368e77751d28ee80d734e
+    tslib: ^2.5.3
+  checksum: 53b5ac58bbae5d3aa867e0f1483fc0fd40e811919e573051225ab32e031ab81649be0f969ecb7c7a094c588f381d8ec1fa67160a65e3e2ef2180afe5677136cc
   languageName: node
   linkType: hard
 
@@ -2223,6 +2223,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/wasm-bridge@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/wasm-bridge@npm:7.2.1"
+  dependencies:
+    "@polkadot/wasm-util": 7.2.1
+    tslib: ^2.5.0
+  peerDependencies:
+    "@polkadot/util": "*"
+    "@polkadot/x-randomvalues": "*"
+  checksum: 6f4d255665f6c1552df9abcf8e99ee36b220c446c74e4da7ac21f3c578c3736695db41e816ef83226d98231c535df8daea6d2266c3090bdd8e7609fa87447de9
+  languageName: node
+  linkType: hard
+
 "@polkadot/wasm-crypto-asmjs@npm:7.1.1":
   version: 7.1.1
   resolution: "@polkadot/wasm-crypto-asmjs@npm:7.1.1"
@@ -2231,6 +2244,17 @@ __metadata:
   peerDependencies:
     "@polkadot/util": "*"
   checksum: f3bb12eb29495520c030ca9d59ef5bfcb425ae4ecf2e2a407379951688189533d75c444aaafaa4fb93b22bfe10c48141e1d4597581281adc8455903d17114013
+  languageName: node
+  linkType: hard
+
+"@polkadot/wasm-crypto-asmjs@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/wasm-crypto-asmjs@npm:7.2.1"
+  dependencies:
+    tslib: ^2.5.0
+  peerDependencies:
+    "@polkadot/util": "*"
+  checksum: 9d7f2ac6f73cc2ed390941a35426763c73e6f20374eb11ed60b880a6f716c2773cb1fe1cddb9416ab669c75b25b7d99be25c8c91886bb676d6faf9b4658f8fd7
   languageName: node
   linkType: hard
 
@@ -2250,6 +2274,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/wasm-crypto-init@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/wasm-crypto-init@npm:7.2.1"
+  dependencies:
+    "@polkadot/wasm-bridge": 7.2.1
+    "@polkadot/wasm-crypto-asmjs": 7.2.1
+    "@polkadot/wasm-crypto-wasm": 7.2.1
+    "@polkadot/wasm-util": 7.2.1
+    tslib: ^2.5.0
+  peerDependencies:
+    "@polkadot/util": "*"
+    "@polkadot/x-randomvalues": "*"
+  checksum: 97105a9e846e97d9d678526e5dd1b491cd71e705c759a8ace9e0e9a54aa045b2b512bdcdd524ea6684963b6cb0fc0a44043d2198bc680c893e1feaaf4d860e76
+  languageName: node
+  linkType: hard
+
 "@polkadot/wasm-crypto-wasm@npm:7.1.1":
   version: 7.1.1
   resolution: "@polkadot/wasm-crypto-wasm@npm:7.1.1"
@@ -2259,6 +2299,18 @@ __metadata:
   peerDependencies:
     "@polkadot/util": "*"
   checksum: d4f4e384f06293722e878bee16a20079147dfa1e835bfaf9e9ddaa0675d280116a3132bb4318fd6841abe526d7b61bbe47c31a99a0c7f4df1b5a98a9ab7419d2
+  languageName: node
+  linkType: hard
+
+"@polkadot/wasm-crypto-wasm@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/wasm-crypto-wasm@npm:7.2.1"
+  dependencies:
+    "@polkadot/wasm-util": 7.2.1
+    tslib: ^2.5.0
+  peerDependencies:
+    "@polkadot/util": "*"
+  checksum: f000fab2fc682a4d4d2029b483701a64091b9be0d75df82f3337a48d65ffdac8d76c828f46810cb5aae6b9ec77bdf3963ae8b8668106ea9e5c0c19f57637655d
   languageName: node
   linkType: hard
 
@@ -2279,7 +2331,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-util@npm:7.1.1, @polkadot/wasm-util@npm:^7.1.1":
+"@polkadot/wasm-crypto@npm:^7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/wasm-crypto@npm:7.2.1"
+  dependencies:
+    "@polkadot/wasm-bridge": 7.2.1
+    "@polkadot/wasm-crypto-asmjs": 7.2.1
+    "@polkadot/wasm-crypto-init": 7.2.1
+    "@polkadot/wasm-crypto-wasm": 7.2.1
+    "@polkadot/wasm-util": 7.2.1
+    tslib: ^2.5.0
+  peerDependencies:
+    "@polkadot/util": "*"
+    "@polkadot/x-randomvalues": "*"
+  checksum: f42f2bc34cf76d1438893f72a233080196c9a95dd3c53444f582150c7f56b75c80b8b8b9b4a3d9015438a6f7438c6e40def46b1fe7ce3a367bcd280f2bf29c98
+  languageName: node
+  linkType: hard
+
+"@polkadot/wasm-util@npm:7.1.1":
   version: 7.1.1
   resolution: "@polkadot/wasm-util@npm:7.1.1"
   dependencies:
@@ -2290,77 +2359,88 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:12.0.1, @polkadot/x-bigint@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/x-bigint@npm:12.0.1"
+"@polkadot/wasm-util@npm:7.2.1, @polkadot/wasm-util@npm:^7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/wasm-util@npm:7.2.1"
   dependencies:
-    "@polkadot/x-global": 12.0.1
-    tslib: ^2.5.0
-  checksum: 19c3f15c739b7868506e33e77c90a0a9900eaa3e9acd860dd446586b8e6652b69952793c39f592f7f22b3e58780493a9c97eb9aa8c2ae98cefd18706d22ccc6f
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-fetch@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/x-fetch@npm:12.0.1"
-  dependencies:
-    "@polkadot/x-global": 12.0.1
-    node-fetch: ^3.3.1
-    tslib: ^2.5.0
-  checksum: 4575df9e1c5625c0a94e6af5811f293bae27a9d44a214815e89d79f446db6188a3c76fbece026c975a58face0b7d90a188ef84e4361cb25920ceb67cffaface1
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-global@npm:12.0.1, @polkadot/x-global@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/x-global@npm:12.0.1"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 481c8305c41c72e9ca1afff9b74d4cff9639179d9796ffb9cd0d431c08c28f6007d2cbc3aef8260a838d72ec09198083ae4436235102f24987941f41a0b60d0a
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-randomvalues@npm:12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/x-randomvalues@npm:12.0.1"
-  dependencies:
-    "@polkadot/x-global": 12.0.1
     tslib: ^2.5.0
   peerDependencies:
-    "@polkadot/util": 12.0.1
+    "@polkadot/util": "*"
+  checksum: 8df30296664807c27b01d37a3e9f124fdc22aef61e633b1a538a7c533f485a2aa756c43e67aac8d0c8383273432783b78e5528c5bc1ffcf508e7faaa5009e618
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-bigint@npm:12.3.2, @polkadot/x-bigint@npm:^12.3.1":
+  version: 12.3.2
+  resolution: "@polkadot/x-bigint@npm:12.3.2"
+  dependencies:
+    "@polkadot/x-global": 12.3.2
+    tslib: ^2.5.3
+  checksum: 0c88e28f1072cd2e5bc0efa3b8ede13f1084c8d56bb78a91f031ee128e572a5f74faa99c22be64182950194647a2081899dcfaa7e7ab16bbb3f9b9761515eb85
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-fetch@npm:^12.3.1":
+  version: 12.3.2
+  resolution: "@polkadot/x-fetch@npm:12.3.2"
+  dependencies:
+    "@polkadot/x-global": 12.3.2
+    node-fetch: ^3.3.1
+    tslib: ^2.5.3
+  checksum: 063bae74b5c197c5b2c603cc761aa830fe96a196d8cc0d9bc428670d1d0fa44d053d96b463783a9d989ec1032bda6397cb4f8772e65fed9d5f1089d04d7b54dc
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-global@npm:12.3.2, @polkadot/x-global@npm:^12.3.1":
+  version: 12.3.2
+  resolution: "@polkadot/x-global@npm:12.3.2"
+  dependencies:
+    tslib: ^2.5.3
+  checksum: 85bd4a3e89bacdf8159fe505b875fad0ce8cfc5ba65377b14981166d973339a2fa3128582112af51dfecea4b68b0501a960056138110195b5bea69c3a8c88e11
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-randomvalues@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@polkadot/x-randomvalues@npm:12.3.2"
+  dependencies:
+    "@polkadot/x-global": 12.3.2
+    tslib: ^2.5.3
+  peerDependencies:
+    "@polkadot/util": 12.3.2
     "@polkadot/wasm-util": "*"
-  checksum: 4b678e141b6d596b0335bdd23a2fd92348514136100868048ce4ece5424509e9d8cf72e57a3337911775fa505be7b80bb2d9f4f1f5b797e787fc77947b10cbe7
+  checksum: 809e0429a0e6f285ad0e2bf0b7dbe1f8b05cc3aacb9f7d8593fd0702e2f23ef7e3aab861d1493528670712c03426b36aacecf43b6fc97cc4036ee1ae41fa04dc
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/x-textdecoder@npm:12.0.1"
+"@polkadot/x-textdecoder@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@polkadot/x-textdecoder@npm:12.3.2"
   dependencies:
-    "@polkadot/x-global": 12.0.1
-    tslib: ^2.5.0
-  checksum: 73104c280e488a694a70384bb2f5acc2ff9d25d1fba5d5802309d04ce0a2124d305ffacf39efdd6c75c27e1c2bba20ee8222f80aabaf7d7a1a3ea19d8cff56ed
+    "@polkadot/x-global": 12.3.2
+    tslib: ^2.5.3
+  checksum: d5b8810b325bad317e10f631f0d7c9c91e0db92ca37db7935e41569df8c926534aa4668a14b9b12d1d5263569239665bca8ad0089bf3b789a09dbf6f0303108f
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/x-textencoder@npm:12.0.1"
+"@polkadot/x-textencoder@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@polkadot/x-textencoder@npm:12.3.2"
   dependencies:
-    "@polkadot/x-global": 12.0.1
-    tslib: ^2.5.0
-  checksum: df4e6d7d3327ce79d241cf0a0757691066f7f62bc90fab089a45969835c3fd0055261646b8452c7dda1776d5c0852571af86dac25d82649fd1966b39ff8d01af
+    "@polkadot/x-global": 12.3.2
+    tslib: ^2.5.3
+  checksum: c383fab93904f6c47f87b1b111a002542c701844c82a62ead6bbbd19f23b58f87ebd47ec8578de7ed18b45668b43491cc60e44c343b9d59e80696e5c9357e962
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "@polkadot/x-ws@npm:12.0.1"
+"@polkadot/x-ws@npm:^12.3.1":
+  version: 12.3.2
+  resolution: "@polkadot/x-ws@npm:12.3.2"
   dependencies:
-    "@polkadot/x-global": 12.0.1
-    tslib: ^2.5.0
+    "@polkadot/x-global": 12.3.2
+    tslib: ^2.5.3
     ws: ^8.13.0
-  checksum: 6bfaf2978f97af88acff4afec1e2a95e1b15dc4d832c5688c50b04d8bf294dff2164de3a47cb3a9f0b6cf61f9280cfdb90e35dfb4dba20b57c23de0c63b0ba8e
+  checksum: 7bb18ada56bb7d441c1392ec459959ff7cfc27fd57953898cb19682ea2fd323b68946102e4fe1c5eb1eb89fa62eb2d8ea7be03382ef9a473cd8c74d039b875d1
   languageName: node
   linkType: hard
 
@@ -2458,21 +2538,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect@npm:0.7.24":
-  version: 0.7.24
-  resolution: "@substrate/connect@npm:0.7.24"
+"@substrate/connect@npm:0.7.26":
+  version: 0.7.26
+  resolution: "@substrate/connect@npm:0.7.26"
   dependencies:
     "@substrate/connect-extension-protocol": ^1.0.1
     eventemitter3: ^4.0.7
-    smoldot: 1.0.2
-  checksum: ffede7dd5cdc7512f5a6f97d4ff2655dc294c78d21856aa9d215e39b84c623ebfda3557d970652eba7c4ac4e02eb765cf7140b17345aface1f700af200e0bf2d
+    smoldot: 1.0.4
+  checksum: 3179d241f073318d5973deb61c9c8d9b89ae28909a594b6b9fbcdfffd030a70ba58e8428eaa9d72484810bad10c93de1ad9c440b878d0fcfaaf4559d2e6f4502
   languageName: node
   linkType: hard
 
-"@substrate/ss58-registry@npm:^1.39.0":
-  version: 1.39.0
-  resolution: "@substrate/ss58-registry@npm:1.39.0"
-  checksum: 1a16d1f637ea8c9a0cd2cabedb8731b81cafa1e979912a2183c2c670d680dc759136ad5f4183bef48359bd9f0a005f676e7ab78a4f076c19a2cf32974049a1f8
+"@substrate/ss58-registry@npm:^1.40.0":
+  version: 1.40.0
+  resolution: "@substrate/ss58-registry@npm:1.40.0"
+  checksum: 474cb16b350e95fa7ca1020b70c6885c5c3d739472f506d175f24e9fd5a6d337d3c7e7a7fa44962199ed03fffb5d3b44b8af79a9811cb55ec34b3b75bb8e7f97
   languageName: node
   linkType: hard
 
@@ -4308,10 +4388,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "eventemitter3@npm:5.0.0"
-  checksum: b974bafbab860e0a5bbb21add4c4e82f9d5691c583c03f2e4c5d44a2d6c4556d79223621bdcfc6c8e14366a4af9df6b5ea9d6caf65fbffc80b66f3e1dceacbc9
+"eventemitter3@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eventemitter3@npm:5.0.1"
+  checksum: 543d6c858ab699303c3c32e0f0f47fc64d360bf73c3daf0ac0b5079710e340d6fe9f15487f94e66c629f5f82cd1a8678d692f3dbb6f6fcd1190e1b97fcad36f8
   languageName: node
   linkType: hard
 
@@ -5715,7 +5795,7 @@ __metadata:
   resolution: "logion-backend-ts@workspace:."
   dependencies:
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/node-api": ^0.16.0
+    "@logion/node-api": ^0.17.0-2
     "@logion/node-exiftool": ^2.3.1-3
     "@logion/rest-api-core": ^0.4.2-1
     "@polkadot/wasm-crypto": ^7.1.1
@@ -6280,15 +6360,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nock@npm:^13.3.0":
-  version: 13.3.0
-  resolution: "nock@npm:13.3.0"
+"nock@npm:^13.3.1":
+  version: 13.3.1
+  resolution: "nock@npm:13.3.1"
   dependencies:
     debug: ^4.1.0
     json-stringify-safe: ^5.0.1
     lodash: ^4.17.21
     propagate: ^2.0.0
-  checksum: 118d04e95a17f493898a82b5dfecc03762776e1980d9c3b2077479747e60b77109c5f7c0df969d1a8f6039260abe5961733553a5841f0f627bb35238576a0009
+  checksum: 0f2a73e8432f6b5650656c53eef99f9e5bbde3df538dc2f07057edc4438cfc61a394c9d06dd82e60f6e86d42433f20f3c04364a1f088beee7bf03a24e3f0fdd0
   languageName: node
   linkType: hard
 
@@ -7474,12 +7554,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.8.0":
-  version: 7.8.0
-  resolution: "rxjs@npm:7.8.0"
+"rxjs@npm:^7.8.1":
+  version: 7.8.1
+  resolution: "rxjs@npm:7.8.1"
   dependencies:
     tslib: ^2.1.0
-  checksum: 61b4d4fd323c1043d8d6ceb91f24183b28bcf5def4f01ca111511d5c6b66755bc5578587fe714ef5d67cf4c9f2e26f4490d4e1d8cabf9bd5967687835e9866a2
+  checksum: de4b53db1063e618ec2eca0f7965d9137cabe98cf6be9272efe6c86b47c17b987383df8574861bcced18ebd590764125a901d5506082be84a8b8e364bf05f119
   languageName: node
   linkType: hard
 
@@ -7765,13 +7845,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smoldot@npm:1.0.2":
-  version: 1.0.2
-  resolution: "smoldot@npm:1.0.2"
+"smoldot@npm:1.0.4":
+  version: 1.0.4
+  resolution: "smoldot@npm:1.0.4"
   dependencies:
     pako: ^2.0.4
     ws: ^8.8.1
-  checksum: 2e069c49e520e72c63d16d94c51a074a6f90ae598a2299afbf5b90c3a0ba607e1640bf51d8e2a3b06dc7843e571c96b5838209a1d9c9d0dae66c8693fa0369c9
+  checksum: 81ecc38b98f7ac4dd093753e85956262608dca3c8a288c20a25fe1762a6afcdbe6f3622ea30a346df3f4145e0900ef0595e56e96e9e0de83c59f0649d1ab4786
   languageName: node
   linkType: hard
 
@@ -8298,6 +8378,13 @@ __metadata:
   version: 2.5.0
   resolution: "tslib@npm:2.5.0"
   checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.5.3":
+  version: 2.5.3
+  resolution: "tslib@npm:2.5.3"
+  checksum: 88902b309afaf83259131c1e13da1dceb0ad1682a213143a1346a649143924d78cf3760c448b84d796938fd76127183894f8d85cbb3bf9c4fddbfcc140c0003c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,19 +2210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-bridge@npm:7.1.1":
-  version: 7.1.1
-  resolution: "@polkadot/wasm-bridge@npm:7.1.1"
-  dependencies:
-    "@polkadot/wasm-util": 7.1.1
-    tslib: ^2.5.0
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: 7a394e9a41e9286ce41d233d54d69dc9585558c029b012f8d8a0528b3bb93bb480e18447576850026e4a3f22dc338b39796f5fa00720b2447b38ecaef8be5e02
-  languageName: node
-  linkType: hard
-
 "@polkadot/wasm-bridge@npm:7.2.1":
   version: 7.2.1
   resolution: "@polkadot/wasm-bridge@npm:7.2.1"
@@ -2236,17 +2223,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:7.1.1":
-  version: 7.1.1
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:7.1.1"
-  dependencies:
-    tslib: ^2.5.0
-  peerDependencies:
-    "@polkadot/util": "*"
-  checksum: f3bb12eb29495520c030ca9d59ef5bfcb425ae4ecf2e2a407379951688189533d75c444aaafaa4fb93b22bfe10c48141e1d4597581281adc8455903d17114013
-  languageName: node
-  linkType: hard
-
 "@polkadot/wasm-crypto-asmjs@npm:7.2.1":
   version: 7.2.1
   resolution: "@polkadot/wasm-crypto-asmjs@npm:7.2.1"
@@ -2255,22 +2231,6 @@ __metadata:
   peerDependencies:
     "@polkadot/util": "*"
   checksum: 9d7f2ac6f73cc2ed390941a35426763c73e6f20374eb11ed60b880a6f716c2773cb1fe1cddb9416ab669c75b25b7d99be25c8c91886bb676d6faf9b4658f8fd7
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto-init@npm:7.1.1":
-  version: 7.1.1
-  resolution: "@polkadot/wasm-crypto-init@npm:7.1.1"
-  dependencies:
-    "@polkadot/wasm-bridge": 7.1.1
-    "@polkadot/wasm-crypto-asmjs": 7.1.1
-    "@polkadot/wasm-crypto-wasm": 7.1.1
-    "@polkadot/wasm-util": 7.1.1
-    tslib: ^2.5.0
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: e0a375b4837c2a87e07df4ec8c99d0fc5c369c6bd1bcaf1e80f647921f7ae49d24c1638b41a81aa1b82064c0cfa033754eeb8cdc824f26731300a0bf2a912cfe
   languageName: node
   linkType: hard
 
@@ -2290,18 +2250,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-wasm@npm:7.1.1":
-  version: 7.1.1
-  resolution: "@polkadot/wasm-crypto-wasm@npm:7.1.1"
-  dependencies:
-    "@polkadot/wasm-util": 7.1.1
-    tslib: ^2.5.0
-  peerDependencies:
-    "@polkadot/util": "*"
-  checksum: d4f4e384f06293722e878bee16a20079147dfa1e835bfaf9e9ddaa0675d280116a3132bb4318fd6841abe526d7b61bbe47c31a99a0c7f4df1b5a98a9ab7419d2
-  languageName: node
-  linkType: hard
-
 "@polkadot/wasm-crypto-wasm@npm:7.2.1":
   version: 7.2.1
   resolution: "@polkadot/wasm-crypto-wasm@npm:7.2.1"
@@ -2314,24 +2262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "@polkadot/wasm-crypto@npm:7.1.1"
-  dependencies:
-    "@polkadot/wasm-bridge": 7.1.1
-    "@polkadot/wasm-crypto-asmjs": 7.1.1
-    "@polkadot/wasm-crypto-init": 7.1.1
-    "@polkadot/wasm-crypto-wasm": 7.1.1
-    "@polkadot/wasm-util": 7.1.1
-    tslib: ^2.5.0
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: 7dd4a1889bb5f6928a6459c44c7be882ecefdb14d214f6f9c47f5382e078e9061bcd1a2b5ea8a2c8ca9a4fe73314ef44e402d4878080aed0d49ab98c8500b2fb
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto@npm:^7.2.1":
+"@polkadot/wasm-crypto@npm:^7.1.1, @polkadot/wasm-crypto@npm:^7.2.1":
   version: 7.2.1
   resolution: "@polkadot/wasm-crypto@npm:7.2.1"
   dependencies:
@@ -2345,17 +2276,6 @@ __metadata:
     "@polkadot/util": "*"
     "@polkadot/x-randomvalues": "*"
   checksum: f42f2bc34cf76d1438893f72a233080196c9a95dd3c53444f582150c7f56b75c80b8b8b9b4a3d9015438a6f7438c6e40def46b1fe7ce3a367bcd280f2bf29c98
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-util@npm:7.1.1":
-  version: 7.1.1
-  resolution: "@polkadot/wasm-util@npm:7.1.1"
-  dependencies:
-    tslib: ^2.5.0
-  peerDependencies:
-    "@polkadot/util": "*"
-  checksum: e7da5e0a580e36b5e1ad19b39c90478fd52559d4052db33370e4c72278c32a93683a9b7be3bb21fd9c8e97743381ff0e74eca66a624020bf5c6cf66853bcae3f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* A new attribute `nameHash` (the hash of the name...) is added as a key to access a Metadata Item.
* The `name` of an item is now nullable.
* A migration is added to calculate the hash for the existing items, and to setup the new Primary Key.
* During Metadata item creation, the hash is calculated, stored and returned in all subsequent queries.
* The REST api docs is completed.
___
The Postgres type `bytea` is used, allowing a more efficient storage than `varchar(255)`. A similar technique could be used for loc file hashes, and collection item ids.

logion-network/logion-internal#937