### PR TITLE
Store public item/record data

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -1197,6 +1197,89 @@
                 "title": "VoidLocView",
                 "description": "The parameters of LOC voiding"
             },
+            "CreateCollectionItemView": {
+                "type": "object",
+                "properties": {
+                    "itemId": {
+                        "type": "string",
+                        "description": "The id of the collection item",
+                        "example": "0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "The description of the item"
+                    },
+                    "files": {
+                        "type": "array",
+                        "description": "The files",
+                        "items": {
+                            "$ref": "#/components/schemas/CollectionItemFileView"
+                        }
+                    },
+                    "termsAndConditions": {
+                        "type": "array",
+                        "description": "The terms and conditions",
+                        "items": {
+                            "$ref": "#/components/schemas/TermsAndConditionsElementView"
+                        }
+                    },
+                    "token": {
+                        "$ref": "#/components/schemas/CollectionItemTokenView"
+                    }
+                }
+            },
+            "CollectionItemFileView": {
+                "type": "object",
+                "properties": {
+                    "hash": {
+                        "$ref": "#/components/schemas/HashView"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The file name"
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "description": "The content type"
+                    },
+                    "uploaded": {
+                        "type": "boolean",
+                        "description": "True if the file was already uploaded, false otherwise"
+                    }
+                }
+            },
+            "HashView": {
+                "type": "string",
+                "description": "A hash",
+                "example": "0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705"
+            },
+            "TermsAndConditionsElementView": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "The type of terms and conditions"
+                    },
+                    "details": {
+                        "type": "string",
+                        "description": "The details associated with given terms and conditions"
+                    }
+                }
+            },
+            "CollectionItemTokenView": {
+                "type": "object",
+                "description": "The item's token",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Token type"
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Token ID"
+                    }
+                }
+            },
             "CollectionItemView": {
                 "type": "object",
                 "properties": {
@@ -1210,6 +1293,10 @@
                         "description": "The id of the collection item",
                         "example": "0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705"
                     },
+                    "description": {
+                        "type": "string",
+                        "description": "The description of the item"
+                    },
                     "addedOn": {
                         "type": "string",
                         "format": "date-time",
@@ -1219,10 +1306,18 @@
                         "type": "array",
                         "description": "The files present in DB",
                         "items": {
-                            "type": "string",
-                            "description": "The hash of a file present in DB",
-                            "example": "0x6dec991b1b61b44550769ae3c4b7f54f7cd618391f32bab2bc4e3a96cbb2b198"
+                            "$ref": "#/components/schemas/CollectionItemFileView"
                         }
+                    },
+                    "termsAndConditions": {
+                        "type": "array",
+                        "description": "The terms and conditions",
+                        "items": {
+                            "$ref": "#/components/schemas/TermsAndConditionsElementView"
+                        }
+                    },
+                    "token": {
+                        "$ref": "#/components/schemas/CollectionItemTokenView"
                     }
                 }
             },
@@ -1557,6 +1652,47 @@
                     }
                 }
             },
+            "CreateTokensRecordView": {
+                "type": "object",
+                "properties": {
+                    "recordId": {
+                        "type": "string",
+                        "description": "The id of the tokens record",
+                        "example": "0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "The description of the item"
+                    },
+                    "files": {
+                        "type": "array",
+                        "description": "The files",
+                        "items": {
+                            "$ref": "#/components/schemas/TokensRecordFileView"
+                        }
+                    }
+                }
+            },
+            "TokensRecordFileView": {
+                "type": "object",
+                "properties": {
+                    "hash": {
+                        "$ref": "#/components/schemas/HashView"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The file name"
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "description": "The content type"
+                    },
+                    "uploaded": {
+                        "type": "boolean",
+                        "description": "True if the file was already uploaded, false otherwise"
+                    }
+                }
+            },
             "TokensRecordView": {
                 "type": "object",
                 "properties": {
@@ -1570,6 +1706,10 @@
                         "description": "The id of the collection item",
                         "example": "0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705"
                     },
+                    "description": {
+                        "type": "string",
+                        "description": "The description of the item"
+                    },
                     "addedOn": {
                         "type": "string",
                         "format": "date-time",
@@ -1579,9 +1719,7 @@
                         "type": "array",
                         "description": "The files present in DB",
                         "items": {
-                            "type": "string",
-                            "description": "The hash of a file present in DB",
-                            "example": "0x6dec991b1b61b44550769ae3c4b7f54f7cd618391f32bab2bc4e3a96cbb2b198"
+                            "$ref": "#/components/schemas/TokensRecordFileView"
                         }
                     }
                 }

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -683,6 +683,47 @@ export interface components {
       /** @description The voiding reason */
       reason?: string;
     };
+    CreateCollectionItemView: {
+      /**
+       * @description The id of the collection item 
+       * @example 0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705
+       */
+      itemId?: string;
+      /** @description The description of the item */
+      description?: string;
+      /** @description The files */
+      files?: (components["schemas"]["CollectionItemFileView"])[];
+      /** @description The terms and conditions */
+      termsAndConditions?: (components["schemas"]["TermsAndConditionsElementView"])[];
+      token?: components["schemas"]["CollectionItemTokenView"];
+    };
+    CollectionItemFileView: {
+      hash?: components["schemas"]["HashView"];
+      /** @description The file name */
+      name?: string;
+      /** @description The content type */
+      contentType?: string;
+      /** @description True if the file was already uploaded, false otherwise */
+      uploaded?: boolean;
+    };
+    /**
+     * @description A hash 
+     * @example 0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705
+     */
+    HashView: string;
+    TermsAndConditionsElementView: {
+      /** @description The type of terms and conditions */
+      type?: string;
+      /** @description The details associated with given terms and conditions */
+      details?: string;
+    };
+    /** @description The item's token */
+    CollectionItemTokenView: {
+      /** @description Token type */
+      type?: string;
+      /** @description Token ID */
+      id?: string;
+    };
     CollectionItemView: {
       /**
        * @description The id of the collection loc 
@@ -694,13 +735,18 @@ export interface components {
        * @example 0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705
        */
       itemId?: string;
+      /** @description The description of the item */
+      description?: string;
       /**
        * Format: date-time 
        * @description The creation timestamp
        */
       addedOn?: string;
       /** @description The files present in DB */
-      files?: (string)[];
+      files?: (components["schemas"]["CollectionItemFileView"])[];
+      /** @description The terms and conditions */
+      termsAndConditions?: (components["schemas"]["TermsAndConditionsElementView"])[];
+      token?: components["schemas"]["CollectionItemTokenView"];
     };
     CollectionItemsView: {
       /** @description The items of a given collection */
@@ -890,6 +936,26 @@ export interface components {
       /** @description Tells if the issuer was selected for a given LOC (undefined if not relevant) */
       selected?: boolean;
     };
+    CreateTokensRecordView: {
+      /**
+       * @description The id of the tokens record 
+       * @example 0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705
+       */
+      recordId?: string;
+      /** @description The description of the item */
+      description?: string;
+      /** @description The files */
+      files?: (components["schemas"]["TokensRecordFileView"])[];
+    };
+    TokensRecordFileView: {
+      hash?: components["schemas"]["HashView"];
+      /** @description The file name */
+      name?: string;
+      /** @description The content type */
+      contentType?: string;
+      /** @description True if the file was already uploaded, false otherwise */
+      uploaded?: boolean;
+    };
     TokensRecordView: {
       /**
        * @description The id of the collection loc 
@@ -901,13 +967,15 @@ export interface components {
        * @example 0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705
        */
       recordId?: string;
+      /** @description The description of the item */
+      description?: string;
       /**
        * Format: date-time 
        * @description The creation timestamp
        */
       addedOn?: string;
       /** @description The files present in DB */
-      files?: (string)[];
+      files?: (components["schemas"]["TokensRecordFileView"])[];
     };
     TokensRecordsView: {
       /** @description The items of a given collection */

--- a/src/logion/migration/1689170305381-AddItemPublicData.ts
+++ b/src/logion/migration/1689170305381-AddItemPublicData.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddItemPublicData1689170305381 implements MigrationInterface {
+    name = 'AddItemPublicData1689170305381'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "collection_item_tc_element" ("collection_loc_id" uuid NOT NULL, "item_id" character varying NOT NULL, "element_index" integer NOT NULL, "type" character varying(255) NOT NULL, "details" character varying(255) NOT NULL, CONSTRAINT "PK_collection_item_tc_element" PRIMARY KEY ("collection_loc_id", "item_id", "element_index"))`);
+        await queryRunner.query(`ALTER TABLE "loc_request" DROP COLUMN "status_bak"`);
+        await queryRunner.query(`ALTER TABLE "collection_item" ADD "description" character varying(4096)`);
+        await queryRunner.query(`ALTER TABLE "collection_item" ADD "token_type" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "collection_item" ADD "token_id" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "collection_item_file" ADD "name" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "collection_item_file" ADD "content_type" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "collection_item_file" ALTER COLUMN "cid" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "collection_item_tc_element" ADD CONSTRAINT "FK_collection_item_tc_element_collection_loc_id_item_id" FOREIGN KEY ("collection_loc_id", "item_id") REFERENCES "collection_item"("collection_loc_id","item_id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "collection_item_tc_element" DROP CONSTRAINT "FK_collection_item_tc_element_collection_loc_id_item_id"`);
+        await queryRunner.query(`ALTER TABLE "collection_item_file" ALTER COLUMN "cid" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "collection_item_file" DROP COLUMN "content_type"`);
+        await queryRunner.query(`ALTER TABLE "collection_item_file" DROP COLUMN "name"`);
+        await queryRunner.query(`ALTER TABLE "collection_item" DROP COLUMN "token_id"`);
+        await queryRunner.query(`ALTER TABLE "collection_item" DROP COLUMN "token_type"`);
+        await queryRunner.query(`ALTER TABLE "collection_item" DROP COLUMN "description"`);
+        await queryRunner.query(`ALTER TABLE "loc_request" ADD "status_bak" character varying(255)`);
+        await queryRunner.query(`DROP TABLE "collection_item_tc_element"`);
+    }
+
+}

--- a/src/logion/migration/1689239362222-AddRecordPublicData.ts
+++ b/src/logion/migration/1689239362222-AddRecordPublicData.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddRecordPublicData1689239362222 implements MigrationInterface {
+    name = 'AddRecordPublicData1689239362222'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tokens_record" ADD "description" character varying(4096)`);
+        await queryRunner.query(`ALTER TABLE "tokens_record_file" ADD "name" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "tokens_record_file" ADD "content_type" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "tokens_record_file" ALTER COLUMN "cid" DROP NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tokens_record_file" ALTER COLUMN "cid" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "tokens_record_file" DROP COLUMN "content_type"`);
+        await queryRunner.query(`ALTER TABLE "tokens_record_file" DROP COLUMN "name"`);
+        await queryRunner.query(`ALTER TABLE "tokens_record" DROP COLUMN "description"`);
+    }
+
+}

--- a/src/logion/model/collection.model.ts
+++ b/src/logion/model/collection.model.ts
@@ -8,22 +8,68 @@ import {
     JoinColumn,
     Index
 } from "typeorm";
+import { WhereExpressionBuilder } from "typeorm/query-builder/WhereExpressionBuilder.js";
 import moment, { Moment } from "moment";
 import { injectable } from "inversify";
 
-import { appDataSource } from "@logion/rest-api-core";
-import { Child, saveChildren } from "./child.js";
+import { appDataSource, requireDefined } from "@logion/rest-api-core";
+import { Child, saveChildren, saveIndexedChildren } from "./child.js";
+import { HasIndex } from "../lib/db/collections.js";
 
 export interface CollectionItemDescription {
     readonly collectionLocId: string
     readonly itemId: string
     readonly addedOn?: Moment
     readonly files?: CollectionItemFileDescription[]
+    readonly description?: string
+    readonly termsAndConditions?: TermsAndConditionsElementDescription[]
+    readonly token?: CollectionItemTokenDescription
 }
 
 export interface CollectionItemFileDescription {
+    readonly name?: string;
+    readonly contentType?: string;
     readonly hash: string;
-    readonly cid: string;
+    readonly cid?: string;
+}
+
+export interface TermsAndConditionsElementDescription {
+    readonly type?: string;
+    readonly details?: string;
+}
+
+export interface CollectionItemTokenDescription {
+    readonly type?: string;
+    readonly id?: string;
+}
+
+export class CollectionItemToken {
+
+    @Column("varchar", { length: 255, name: "token_type", nullable: true })
+    type?: string | null;
+
+    @Column("varchar", { length: 255, name: "token_id", nullable: true })
+    id?: string | null;
+
+    static from(token: CollectionItemTokenDescription | undefined): CollectionItemToken {
+        const embeddable = new CollectionItemToken();
+        if(token) {
+            embeddable.type = token.type;
+            embeddable.id = token.id;
+        }
+        return embeddable;
+    }
+
+    getDescription(): CollectionItemTokenDescription | undefined {
+        if(this.type && this.id) {
+            return {
+                type: this.type,
+                id: this.id,
+            };
+        } else {
+            return undefined;
+        }
+    }
 }
 
 @Entity("collection_item")
@@ -33,27 +79,26 @@ export class CollectionItemAggregateRoot {
         return {
             collectionLocId: this.collectionLocId!,
             itemId: this.itemId!,
-            addedOn: moment(this.addedOn),
-            files: this.files?.map(file => file.getDescription()) || []
+            addedOn: this.addedOn ? moment(this.addedOn) : undefined,
+            description: this.description,
+            token: this.token ? this.token.getDescription() : undefined,
+            files: this.files?.map(file => file.getDescription()) || [],
+            termsAndConditions: this.termsAndConditions?.map(element => element.getDescription()) || [],
         }
     }
 
-    addFile(fileDescription: CollectionItemFileDescription): CollectionItemFile {
-        const { hash, cid } = fileDescription
-        const file = new CollectionItemFile();
-        file.collectionLocId = this.collectionLocId;
-        file.itemId = this.itemId;
-        file.hash = hash;
-        file.cid = cid;
-        file.collectionItem = this;
-        file._toAdd = true;
-        this.files?.push(file);
-        return file
+    setFileCid(fileDescription: { hash: string, cid: string }) {
+        const { hash, cid } = fileDescription;
+        const file = this.file(hash);
+        if(!file) {
+            throw new Error(`No file with hash ${ hash }`);
+        }
+        file.setCid(cid);
     }
 
-    setAddedOn(addedOn: Moment) {
+    confirm(addedOn: Moment) {
         if(this.addedOn) {
-            throw new Error("Already set");
+            throw new Error("Already confirmed");
         }
         this.addedOn = addedOn.toDate();
     }
@@ -63,6 +108,12 @@ export class CollectionItemAggregateRoot {
 
     @PrimaryColumn({ name: "item_id" })
     itemId?: string;
+
+    @Column({ length: 4096, name: "description", nullable: true })
+    description?: string;
+
+    @Column(() => CollectionItemToken, { prefix: "" })
+    token?: CollectionItemToken;
 
     @OneToMany(() => CollectionItemFile, file => file.collectionItem, {
         eager: true,
@@ -85,17 +136,46 @@ export class CollectionItemAggregateRoot {
     getFile(hash: string): CollectionItemFile {
         return this.file(hash)!;
     }
+
+    @OneToMany(() => TermsAndConditionsElement, element => element.collectionItem, {
+        eager: true,
+        cascade: false,
+        persistence: false
+    })
+    termsAndConditions?: TermsAndConditionsElement[];
 }
 
 @Entity("collection_item_file")
 export class CollectionItemFile extends Child {
 
+    static from(description: CollectionItemFileDescription, root?: CollectionItemAggregateRoot): CollectionItemFile {
+        if(!description.name || !description.contentType) {
+            throw new Error("No name nor content type provided");
+        }
+        const file = new CollectionItemFile();
+        file.name = description.name;
+        file.contentType = description.contentType;
+        file.hash = description.hash;
+
+        if(root) {
+            file.collectionLocId = root.collectionLocId;
+            file.itemId = root.itemId;
+            file.collectionItem = root;
+            file._toAdd = true;
+        }
+
+        return file;
+    }
+
     getDescription(): CollectionItemFileDescription {
         return {
             hash: this.hash!,
-            cid: this.cid!,
+            name: this.name,
+            contentType: this.contentType,
+            cid: this.cid || undefined,
         }
     }
+
     @PrimaryColumn({ type: "uuid", name: "collection_loc_id" })
     collectionLocId?: string;
 
@@ -105,8 +185,22 @@ export class CollectionItemFile extends Child {
     @PrimaryColumn({ name: "hash" })
     hash?: string;
 
-    @Column({ length: 255 })
-    cid?: string;
+    @Column({ length: 255, name: "name", nullable: true })
+    name?: string;
+
+    @Column({ length: 255, name: "content_type", nullable: true })
+    contentType?: string;
+
+    setCid(cid: string) {
+        if(this.cid) {
+            throw new Error("File has already a CID");
+        }
+        this.cid = cid;
+        this._toUpdate = true;
+    }
+
+    @Column("varchar", { length: 255, nullable: true })
+    cid?: string | null;
 
     @ManyToOne(() => CollectionItemAggregateRoot, request => request.files)
     @JoinColumn([
@@ -143,6 +237,55 @@ export class CollectionItemFile extends Child {
         persistence: false
     })
     delivered?: CollectionItemFileDelivered[];
+}
+
+@Entity("collection_item_tc_element")
+export class TermsAndConditionsElement extends Child implements HasIndex {
+
+    static from(description: TermsAndConditionsElementDescription, index: number, root?: CollectionItemAggregateRoot): TermsAndConditionsElement {
+        const element = new TermsAndConditionsElement();
+        element.index = index;
+        element.type = description.type;
+        element.details = description.details;
+
+        if(root) {
+            element.collectionLocId = root.collectionLocId;
+            element.itemId = root.itemId;
+            element.collectionItem = root;
+            element._toAdd = true;
+        }
+
+        return element;
+    }
+
+    getDescription(): TermsAndConditionsElementDescription {
+        return {
+            type: this.type,
+            details: this.details,
+        }
+    }
+
+    @PrimaryColumn({ type: "uuid", name: "collection_loc_id" })
+    collectionLocId?: string;
+
+    @PrimaryColumn({ name: "item_id" })
+    itemId?: string;
+
+    @PrimaryColumn({ name: "element_index" })
+    index?: number;
+
+    @Column({ name: "type", length: 255 })
+    type?: string;
+
+    @Column({ name: "details", length: 255 })
+    details?: string;
+
+    @ManyToOne(() => CollectionItemAggregateRoot, request => request.termsAndConditions)
+    @JoinColumn([
+        { name: "collection_loc_id", referencedColumnName: "collectionLocId" },
+        { name: "item_id", referencedColumnName: "itemId" },
+    ])
+    collectionItem?: CollectionItemAggregateRoot;
 }
 
 @Entity("collection_item_file_delivered")
@@ -186,23 +329,35 @@ export class CollectionRepository {
         this.repository = appDataSource.getRepository(CollectionItemAggregateRoot);
         this.fileRepository = appDataSource.getRepository(CollectionItemFile);
         this.deliveredRepository = appDataSource.getRepository(CollectionItemFileDelivered);
+        this.termsRepository = appDataSource.getRepository(TermsAndConditionsElement);
     }
 
     readonly repository: Repository<CollectionItemAggregateRoot>;
     readonly fileRepository: Repository<CollectionItemFile>;
     readonly deliveredRepository: Repository<CollectionItemFileDelivered>;
+    readonly termsRepository: Repository<TermsAndConditionsElement>;
 
     public async save(root: CollectionItemAggregateRoot): Promise<void> {
         await this.repository.save(root);
         await this.saveFiles(root);
+        await this.saveTermsAndConditions(root);
     }
 
     private async saveFiles(root: CollectionItemAggregateRoot): Promise<void> {
         if(root.files) {
+            const whereExpression: <E extends WhereExpressionBuilder>(sql: E, file: CollectionItemFile) => E = (sql, _file) => sql
+                .where("collection_loc_id = :locId", { locId: root.collectionLocId })
+                .andWhere("item_id = :itemId", { itemId: root.itemId });
             await saveChildren({
                 children: root.files,
                 entityManager: this.repository.manager,
                 entityClass: CollectionItemFile,
+                whereExpression,
+                updateValuesExtractor: file => {
+                    const values = { ...file };
+                    delete values.delivered;
+                    return values;
+                }
             });
             for(const file of root.files) {
                 await this.saveDelivered(file);
@@ -218,17 +373,13 @@ export class CollectionRepository {
         });
     }
 
-    public async createIfNotExist(collectionLocId: string, itemId: string, creator: () => CollectionItemAggregateRoot): Promise<CollectionItemAggregateRoot> {
-        const existingCollectionItem = await this.repository.manager.findOneBy(CollectionItemAggregateRoot, {
-            collectionLocId,
-            itemId
-        });
-        if (existingCollectionItem) {
-            return existingCollectionItem;
-        } else {
-            const newCollectionItem = creator();
-            await this.repository.manager.insert(CollectionItemAggregateRoot, newCollectionItem);
-            return newCollectionItem;
+    private async saveTermsAndConditions(root: CollectionItemAggregateRoot): Promise<void> {
+        if(root.termsAndConditions) {
+            await saveIndexedChildren({
+                children: root.termsAndConditions,
+                entityManager: this.repository.manager,
+                entityClass: TermsAndConditionsElement,
+            });
         }
     }
 
@@ -276,18 +427,34 @@ export class CollectionRepository {
         }
         return deliveries;
     }
+
+    async delete(item: CollectionItemAggregateRoot): Promise<void> {
+        if(item.addedOn) {
+            throw new Error("Cannot delete already published item");
+        }
+        const criteria = {
+            collectionLocId: requireDefined(item.collectionLocId),
+            itemId: requireDefined(item.itemId),
+        };
+        await this.termsRepository.delete(criteria);
+        await this.deliveredRepository.delete(criteria); // There should be none
+        await this.fileRepository.delete(criteria);
+        await this.repository.delete(criteria);
+    }
 }
 
 @injectable()
 export class CollectionFactory {
 
     newItem(params: CollectionItemDescription): CollectionItemAggregateRoot {
-        const { collectionLocId, itemId, addedOn } = params;
+        const { collectionLocId, itemId } = params;
         const item = new CollectionItemAggregateRoot()
         item.collectionLocId = collectionLocId;
         item.itemId = itemId;
-        item.addedOn = addedOn?.toDate();
-        item.files = [];
+        item.description = params.description;
+        item.token = CollectionItemToken.from(params.token);
+        item.files = params.files?.map(file => CollectionItemFile.from(file, item)) || [];
+        item.termsAndConditions = params.termsAndConditions?.map((element, index) => TermsAndConditionsElement.from(element, index, item)) || [];
         return item;
     }
 }

--- a/src/logion/services/file.storage.service.ts
+++ b/src/logion/services/file.storage.service.ts
@@ -6,7 +6,7 @@ import { EncryptedFileWriter, EncryptedFileReader } from "../lib/crypto/Encrypte
 
 export interface FileId {
     oid?: number
-    cid?: string
+    cid?: string | null
 }
 
 @injectable()

--- a/src/logion/services/locsynchronization.service.ts
+++ b/src/logion/services/locsynchronization.service.ts
@@ -190,21 +190,10 @@ export class LocSynchronizer {
         const itemId = Adapters.asHexString(extrinsic.call.args['item_id']);
         const loc = await this.locRequestRepository.findById(collectionLocId);
         if (loc !== null) {
-            logger.info("Adding Collection Item %s to LOC %s", itemId, collectionLocId);
-            let created = false;
-            await this.collectionService.createIfNotExist(collectionLocId, itemId, () => {
-                created = true;
-                return this.collectionFactory.newItem({
-                    collectionLocId,
-                    itemId,
-                    addedOn: timestamp
-                });
+            logger.info("Confirming Collection Item %s to LOC %s", itemId, collectionLocId);
+            await this.collectionService.update(collectionLocId, itemId, async item => {
+                item.confirm(timestamp);
             });
-            if(!created) {
-                await this.collectionService.update(collectionLocId, itemId, async item => {
-                    item.setAddedOn(timestamp);
-                });
-            }
         }
     }
 
@@ -316,21 +305,10 @@ export class LocSynchronizer {
         const recordId = Adapters.asHexString(extrinsic.call.args['record_id']);
         const loc = await this.locRequestRepository.findById(collectionLocId);
         if (loc !== null) {
-            logger.info("Adding Tokens Record %s to LOC %s", recordId, collectionLocId);
-            let created = false;
-            await this.tokensRecordService.createIfNotExist(collectionLocId, recordId, () => {
-                created = true;
-                return this.tokensRecordFactory.newTokensRecord({
-                    collectionLocId,
-                    recordId,
-                    addedOn: timestamp
-                });
+            logger.info("Confirming Tokens Record %s to LOC %s", recordId, collectionLocId);
+            await this.tokensRecordService.update(collectionLocId, recordId, async record => {
+                record.confirm(timestamp);
             });
-            if(!created) {
-                await this.tokensRecordService.update(collectionLocId, recordId, async record => {
-                    record.setAddedOn(timestamp);
-                });
-            }
         }
     }
 

--- a/test/integration/migration/migration.spec.ts
+++ b/test/integration/migration/migration.spec.ts
@@ -7,7 +7,7 @@ const { connect, disconnect, queryRunner, allMigrations } = TestDb;
 
 describe('Migration', () => {
 
-    const NUM_OF_TABLES = 21;
+    const NUM_OF_TABLES = 22;
 
     beforeEach(async () => {
         await connect([ "src/logion/model/*.model.ts" ], [ "src/logion/migration/*.ts" ], false);

--- a/test/integration/model/collection_items.sql
+++ b/test/integration/model/collection_items.sql
@@ -26,6 +26,10 @@ VALUES ('296d3d8f-057f-445c-b4c8-59aa7d2d21de', '0xf35e4bcbc1b0ce85af90914e04350
 INSERT INTO collection_item(collection_loc_id, item_id, added_on)
 VALUES ('c38e5ab8-785f-4e26-91bd-f9cdef82f601', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', '2022-02-16T18:28:42.000000');
 
+-- File not uploaded yet
+INSERT INTO collection_item_file(collection_loc_id, item_id, hash)
+VALUES ('c38e5ab8-785f-4e26-91bd-f9cdef82f601', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee', '0x979ff1da4670561bf3f521a1a1d4aad097d617d2fa2c0e75d52efe90e7b7ce83');
+
 -- Not yet synced
 INSERT INTO collection_item(collection_loc_id, item_id)
 VALUES ('52d29fe9-983f-44d2-9e23-c8cb542981a3', '0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee');

--- a/test/unit/model/collection.model.spec.ts
+++ b/test/unit/model/collection.model.spec.ts
@@ -12,11 +12,9 @@ describe("CollectionFactory", () => {
         const collectionItemAggregateRoot = new CollectionFactory().newItem({
             collectionLocId,
             itemId,
-            addedOn,
         });
         expect(collectionItemAggregateRoot.collectionLocId).toEqual(collectionLocId)
         expect(collectionItemAggregateRoot.itemId).toEqual(itemId)
-        expect(collectionItemAggregateRoot.addedOn).toEqual(addedOn.toDate())
         expect(collectionItemAggregateRoot.hasFile("unknown")).toBeFalse();
     })
 })

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -228,10 +228,9 @@ function givenLocRequest() {
 
 function givenCollectionItem() {
     collectionItem = new Mock<CollectionItemAggregateRoot>();
-    collectionItem.setup(instance => instance.setAddedOn(It.IsAny())).returns();
+    collectionItem.setup(instance => instance.confirm(It.IsAny())).returns();
     collectionRepository.setup(instance => instance.findBy(locIdUuid, itemIdHex)).returns(Promise.resolve(collectionItem.object()));
     collectionRepository.setup(instance => instance.save(collectionItem.object())).returns(Promise.resolve());
-    collectionRepository.setup(instance => instance.createIfNotExist(locIdUuid, itemIdHex, It.IsAny())).returnsAsync(collectionItem.object());
 }
 
 function givenCollectionFactory() {


### PR DESCRIPTION
* Story https://github.com/logion-network/logion-internal/issues/948 requires that all public data related to items and records are submitted to the backend, otherwise hashing them on-chain would lead to a data loss
* Public data are submitted to backend before extrinsic submission in order to prevent concurrent updates (sync and client) and the potential data loss this represents (sync does not have the public data anymore, while client does).
* If extrinsic submission fails, submitted public data must be discarded.
* As a result, file upload is simplified: the collection items and tokens records always exist in the DB on upload (but have no CID as long as the file has not been uploaded).
* The mechanism has been implemented for collection items and tokens records.

logion-network/logion-internal#952