### PR TITLE
Support Verified Issuer acknowledgment

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -720,10 +720,15 @@
                         "format": "date-time",
                         "description": "The date-time of review"
                     },
-                    "acknowledgedOn": {
+                    "acknowledgedByOwnerOn": {
                         "type": "string",
                         "format": "date-time",
                         "description": "The date-time of acknowledge (chain time)"
+                    },
+                    "acknowledgedByVerifiedIssuerOn": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date-time of acknowledge by verified issuer (chain time)"
                     }
                 },
                 "required": [
@@ -770,10 +775,15 @@
                         "format": "date-time",
                         "description": "The date-time of review"
                     },
-                    "acknowledgedOn": {
+                    "acknowledgedByOwnerOn": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "The date-time of acknowledge (chain time)"
+                        "description": "The date-time of acknowledge by owner (chain time)"
+                    },
+                    "acknowledgedByVerifiedIssuerOn": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date-time of acknowledge by verified issuer (chain time)"
                     }
                 },
                 "required": [

--- a/src/logion/controllers/adapters/locrequestadapter.ts
+++ b/src/logion/controllers/adapters/locrequestadapter.ts
@@ -226,6 +226,7 @@ export function toLifecycleView(item: ItemLifecycle) {
         rejectReason: item.rejectReason,
         reviewedOn: item.reviewedOn?.toISOString(),
         addedOn: item.addedOn?.toISOString(),
-        acknowledgedOn: item.acknowledgedOn?.toISOString(),
+        acknowledgedByOwnerOn: item.acknowledgedByOwnerOn?.toISOString(),
+        acknowledgedByVerifiedIssuerOn: item.acknowledgedByVerifiedIssuerOn?.toISOString(),
     }
 }

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -402,7 +402,12 @@ export interface components {
        * Format: date-time 
        * @description The date-time of acknowledge (chain time)
        */
-      acknowledgedOn?: string;
+      acknowledgedByOwnerOn?: string;
+      /**
+       * Format: date-time 
+       * @description The date-time of acknowledge by verified issuer (chain time)
+       */
+      acknowledgedByVerifiedIssuerOn?: string;
     };
     LocMetadataItemView: {
       /** @description The item's name */
@@ -430,9 +435,14 @@ export interface components {
       reviewedOn?: string;
       /**
        * Format: date-time 
-       * @description The date-time of acknowledge (chain time)
+       * @description The date-time of acknowledge by owner (chain time)
        */
-      acknowledgedOn?: string;
+      acknowledgedByOwnerOn?: string;
+      /**
+       * Format: date-time 
+       * @description The date-time of acknowledge by verified issuer (chain time)
+       */
+      acknowledgedByVerifiedIssuerOn?: string;
     };
     /**
      * LocRequestView 

--- a/src/logion/migration/1693307866605-AcknowledgedByVerifiedIssuer.ts
+++ b/src/logion/migration/1693307866605-AcknowledgedByVerifiedIssuer.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AcknowledgedByVerifiedIssuer1693307866605 implements MigrationInterface {
+    name = 'AcknowledgedByVerifiedIssuer1693307866605'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_request_file" RENAME COLUMN "acknowledged_on" TO "acknowledged_by_owner_on"`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" RENAME COLUMN "acknowledged_on" TO "acknowledged_by_owner_on"`);
+        await queryRunner.query(`ALTER TABLE "loc_request_file" ADD "acknowledged_by_verified_issuer_on" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" ADD "acknowledged_by_verified_issuer_on" TIMESTAMP`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" DROP COLUMN "acknowledged_by_verified_issuer_on"`);
+        await queryRunner.query(`ALTER TABLE "loc_request_file" DROP COLUMN "acknowledged_by_verified_issuer_on"`);
+        await queryRunner.query(`ALTER TABLE "loc_metadata_item" RENAME COLUMN "acknowledged_by_owner_on" TO "acknowledged_on"`);
+        await queryRunner.query(`ALTER TABLE "loc_request_file" RENAME COLUMN "acknowledged_by_owner_on" TO "acknowledged_on"`);
+    }
+
+}

--- a/src/logion/services/locsynchronization.service.ts
+++ b/src/logion/services/locsynchronization.service.ts
@@ -14,6 +14,7 @@ import { DirectoryService } from './directory.service.js';
 import { VerifiedIssuerSelectionService } from './verifiedissuerselection.service.js';
 import { TokensRecordService } from './tokensrecord.service.js';
 import { TokensRecordFactory } from '../model/tokensrecord.model.js';
+import { polkadotAccount } from '../model/supportedaccountid.model.js';
 
 const { logger } = Log;
 
@@ -315,12 +316,14 @@ export class LocSynchronizer {
     private async confirmAcknowledgedFile(timestamp: Moment, extrinsic: JsonExtrinsic) {
         const locId = extractUuid('loc_id', extrinsic.call.args);
         const hash = Hash.fromHex(Adapters.asHexString(extrinsic.call.args['hash']));
-        await this.mutateLoc(locId, async loc => loc.confirmFileAcknowledged(hash, timestamp));
+        const contributor = polkadotAccount(requireDefined(extrinsic.signer));
+        await this.mutateLoc(locId, async loc => loc.confirmFileAcknowledged(hash, contributor, timestamp));
     }
 
     private async confirmAcknowledgedMetadata(timestamp: Moment, extrinsic: JsonExtrinsic) {
         const locId = extractUuid('loc_id', extrinsic.call.args);
         const nameHash = Hash.fromHex(Adapters.asHexString(extrinsic.call.args['name']));
-        await this.mutateLoc(locId, async loc => loc.confirmMetadataItemAcknowledged(nameHash, timestamp));
+        const contributor = polkadotAccount(requireDefined(extrinsic.signer));
+        await this.mutateLoc(locId, async loc => loc.confirmMetadataItemAcknowledged(nameHash, contributor, timestamp));
     }
 }

--- a/test/unit/controllers/locrequest.controller.fetch.spec.ts
+++ b/test/unit/controllers/locrequest.controller.fetch.spec.ts
@@ -225,7 +225,9 @@ const testFile: FileDescription = {
     size: 123,
     fees: FILE_FEES,
     storageFeePaidBy: testData.requesterAddress?.address,
-    status: "DRAFT",
+    status: "ACKNOWLEDGED",
+    acknowledgedByOwnerOn: moment(),
+    acknowledgedByVerifiedIssuerOn: moment(),
 }
 
 const DATA_LINK_FEES = new Fees({ inclusionFee: 42n });
@@ -241,7 +243,9 @@ const testMetadataItem: MetadataItemDescription = {
     value: "test-data-value",
     submitter: SUBMITTER,
     fees: DATA_LINK_FEES,
-    status: "DRAFT",
+    status: "ACKNOWLEDGED",
+    acknowledgedByOwnerOn: moment(),
+    acknowledgedByVerifiedIssuerOn: moment(),
 }
 
 async function testGet(app: ReturnType<typeof setupApp>, expectedUserPrivateData: UserPrivateData) {
@@ -261,6 +265,9 @@ async function testGet(app: ReturnType<typeof setupApp>, expectedUserPrivateData
             expect(file.fees.inclusion).toBe(FILE_FEES.inclusionFee.toString())
             expect(file.fees.storage).toBe(FILE_FEES.storageFee?.toString())
             expect(file.storageFeePaidBy).toBe(testData.requesterAddress?.address)
+            expect(file.status).toBe(testFile.status)
+            expect(file.acknowledgedByOwnerOn).toBeDefined()
+            expect(file.acknowledgedByVerifiedIssuerOn).toBeDefined()
             const link = response.body.links[0]
             expect(link.nature).toBe(testLink.nature)
             expect(link.target).toBe(testLink.target)
@@ -273,6 +280,8 @@ async function testGet(app: ReturnType<typeof setupApp>, expectedUserPrivateData
             expect(metadataItem.submitter).toEqual(SUBMITTER)
             expect(metadataItem.fees.inclusion).toBe(DATA_LINK_FEES.inclusionFee.toString())
             expect(metadataItem.status).toBe(testMetadataItem.status)
+            expect(metadataItem.acknowledgedByOwnerOn).toBeDefined()
+            expect(metadataItem.acknowledgedByVerifiedIssuerOn).toBeDefined()
             checkPrivateData(response, expectedUserPrivateData);
         });
 }

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -21,6 +21,7 @@ import { TokensRecordFactory, TokensRecordRepository } from "../../../src/logion
 import { ALICE } from "../../helpers/addresses.js";
 import { Hash } from "../../../src/logion/lib/crypto/hashing.js";
 import { ItIsHash } from "../../helpers/Mock.js";
+import { SupportedAccountId } from "src/logion/model/supportedaccountid.model.js";
 
 describe("LocSynchronizer", () => {
 
@@ -350,17 +351,22 @@ function thenCollectionItemSaved() {
 }
 
 function givenLocRequestExpectsMetadataItemAcknowledged() {
-    locRequest.setup(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME_HASH, IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
 }
 
 function thenMetadataAcknowledged() {
-    locRequest.verify(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME_HASH, IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE), IS_BLOCK_TIME));
 }
 
 function givenLocRequestExpectsFileAcknowledged() {
-    locRequest.setup(instance => instance.confirmFileAcknowledged(ItIsHash(FILE_HASH), IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.confirmFileAcknowledged(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
 }
 
+function ItIsAccount(account: string) {
+    return It.Is<SupportedAccountId>(given => given.address === account && given.type === "Polkadot");
+}
+
+
 function thenFileAcknowledged() {
-    locRequest.verify(instance => instance.confirmFileAcknowledged(ItIsHash(FILE_HASH), IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.confirmFileAcknowledged(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7232,7 +7232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.2.4, protobufjs@npm:^7.0.0":
+"protobufjs@npm:7.2.4":
   version: 7.2.4
   resolution: "protobufjs@npm:7.2.4"
   dependencies:
@@ -7253,8 +7253,8 @@ __metadata:
   linkType: hard
 
 "protobufjs@npm:^6.10.2, protobufjs@npm:^6.11.2":
-  version: 6.11.3
-  resolution: "protobufjs@npm:6.11.3"
+  version: 6.11.4
+  resolution: "protobufjs@npm:6.11.4"
   dependencies:
     "@protobufjs/aspromise": ^1.1.2
     "@protobufjs/base64": ^1.1.2
@@ -7272,7 +7272,27 @@ __metadata:
   bin:
     pbjs: bin/pbjs
     pbts: bin/pbts
-  checksum: 4a6ce1964167e4c45c53fd8a312d7646415c777dd31b4ba346719947b88e61654912326101f927da387d6b6473ab52a7ea4f54d6f15d63b31130ce28e2e15070
+  checksum: b2fc6a01897b016c2a7e43a854ab4a3c57080f61be41e552235436e7a730711b8e89e47cb4ae52f0f065b5ab5d5989fc932f390337ce3a8ccf07203415700850
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.0.0":
+  version: 7.2.5
+  resolution: "protobufjs@npm:7.2.5"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: 3770a072114061faebbb17cfd135bc4e187b66bc6f40cd8bac624368b0270871ec0cfb43a02b9fb4f029c8335808a840f1afba3c2e7ede7063b98ae6b98a703f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* When a metadata or file was submitted by a Verified Issuer, it must be acknowledged by both the LOC owner and the Verified Issuer in order to be considered as fully acknowledged.
* When the item was submitted by either the owner or the requester, then only the LOC owner must acknowledge as before.
* `protobuf` was upgraded in order to fix a dependabot alert.

logion-network/logion-internal#969