### PR TITLE
Adapt confirm/confirm-acknowledge authorization.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "typeorm": "node ./node_modules/typeorm/cli.js -d ./dist/db-tools/ormconfig.js"
     },
     "dependencies": {
-        "@logion/node-api": "^0.19.0",
+        "@logion/node-api": "^0.20.0-4",
         "@logion/node-exiftool": "^2.3.1-3",
         "@logion/rest-api-core": "^0.4.3",
         "@polkadot/wasm-crypto": "^7.1.1",

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -687,8 +687,7 @@ export class LocRequestController extends ApiController {
         const hash = Hash.fromHex(hashHex);
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
-            const file = request.getFile(hash);
-            if((file.submitter.type !== "Polkadot" && request.isOwner(contributor)) || accountEquals(file.submitter, contributor)) {
+            if(request.canConfirmFile(hash, contributor)) {
                 request.confirmFile(hash);
             } else {
                 throw unauthorized("Contributor cannot confirm");
@@ -974,8 +973,7 @@ export class LocRequestController extends ApiController {
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
             const hash = Hash.fromHex(nameHash);
-            const item = request.getMetadataItem(hash);
-            if((item.submitter.type !== "Polkadot" && request.isOwner(contributor)) || accountEquals(item.submitter, contributor)) {
+            if(request.canConfirmMetadataItem(hash, contributor)) {
                 request.confirmMetadataItem(hash);
             } else {
                 throw unauthorized("Contributor cannot confirm");

--- a/test/unit/controllers/locrequest.controller.items.spec.ts
+++ b/test/unit/controllers/locrequest.controller.items.spec.ts
@@ -383,6 +383,7 @@ function mockModelForConfirmFile(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getFile(ItIsHash(SOME_DATA_HASH))).returns({ submitter: { type: "Polkadot", address: ALICE } } as FileDescription);
+    request.setup(instance => instance.canConfirmFile(ItIsHash(SOME_DATA_HASH), It.IsAny<SupportedAccountId>())).returns(true);
     request.setup(instance => instance.confirmFile(ItIsHash(SOME_DATA_HASH))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }
@@ -470,6 +471,7 @@ function mockModelForConfirmMetadata(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns({ submitter: { type: "Polkadot", address: ALICE } } as MetadataItemDescription);
+    request.setup(instance => instance.canConfirmMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), It.IsAny<SupportedAccountId>())).returns(true);
     request.setup(instance => instance.confirmMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1811,9 +1811,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.19.0":
-  version: 0.19.0
-  resolution: "@logion/node-api@npm:0.19.0"
+"@logion/node-api@npm:^0.20.0-4":
+  version: 0.20.0-4
+  resolution: "@logion/node-api@npm:0.20.0-4"
   dependencies:
     "@polkadot/api": ^10.9.1
     "@polkadot/util": ^12.3.2
@@ -1821,7 +1821,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 7a91ed79bcc527f62e75f21de190cf2d0150463baf92b8ac40b741a332f6cadfd4be47544d58e332356a8576210f9989d8797c6b584192b6379dd6739dec3a8d
+  checksum: 9dcf0463e5826800679c949cd69b2a5947ad2e41acd62470ef068a8d50b893a38d781310ec7e6524a24ce7b3afb4002e30c2c6728a346c068ffc270a3f62758c
   languageName: node
   linkType: hard
 
@@ -5891,7 +5891,7 @@ __metadata:
   resolution: "logion-backend-ts@workspace:."
   dependencies:
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/node-api": ^0.19.0
+    "@logion/node-api": ^0.20.0-4
     "@logion/node-exiftool": ^2.3.1-3
     "@logion/rest-api-core": ^0.4.3
     "@polkadot/wasm-crypto": ^7.1.1


### PR DESCRIPTION
* Authorize confirm for requester, when submitter is verified issuer.
* Always authorize confirm-acknowledge for loc owner, even if submitter is verified issuer. In this case there is double acknowledgment.
* Inject latest `node-api`.

logion-network/logion-internal#975