### PR TITLE
fix: synchro of balances.transferAll.

### DIFF
--- a/test/resources/transfer/block-transferAll.json
+++ b/test/resources/transfer/block-transferAll.json
@@ -1,0 +1,98 @@
+{
+  "number": "8556893",
+  "extrinsics": [
+    {
+      "method": {
+        "pallet": "timestamp",
+        "method": "set"
+      },
+      "signer": null,
+      "args": {
+        "now": "1626699240000"
+      },
+      "tip": null,
+      "hash": "0x3f833763bf7bd16d11fb0aa4a5a83c766ce7096ff05390e75d9ee903a0325eb9",
+      "info": {},
+      "events": [
+        {
+          "method": {
+            "pallet": "system",
+            "method": "ExtrinsicSuccess"
+          },
+          "data": [
+            {
+              "weight": "161650000",
+              "class": "Mandatory",
+              "paysFee": "Yes"
+            }
+          ]
+        }
+      ],
+      "success": true,
+      "paysFee": false
+    },
+    {
+      "method": {
+        "pallet": "balances",
+        "method": "transferAll"
+      },
+      "signer": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      "args": {
+        "dest": {
+            "id": "5GFFWfShvZBJ25XyfcT8jXzR3nPsar76iusyYEBZAdFD3ySn"
+        },
+        "keep_alive": true
+      },
+      "tip": "0",
+      "hash": "0x1396964da957529b1b7f63fccb39315bd55efff97f19664e9c9d134f7c529933",
+      "partialFee": "2894701420000000",
+      "events": [
+        {
+          "method": {
+            "pallet": "system",
+            "method": "NewAccount"
+          },
+          "data": [
+            "5GFFWfShvZBJ25XyfcT8jXzR3nPsar76iusyYEBZAdFD3ySn"
+          ]
+        },
+        {
+          "method": {
+            "pallet": "balances",
+            "method": "Endowed"
+          },
+          "data": [
+            "5GFFWfShvZBJ25XyfcT8jXzR3nPsar76iusyYEBZAdFD3ySn",
+            "2894701420000000"
+          ]
+        },
+        {
+          "method": {
+            "pallet": "balances",
+            "method": "Transfer"
+          },
+          "data": [
+            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            "5GFFWfShvZBJ25XyfcT8jXzR3nPsar76iusyYEBZAdFD3ySn",
+            "2894701420000000"
+          ]
+        },
+        {
+          "method": {
+            "pallet": "system",
+            "method": "ExtrinsicSuccess"
+          },
+          "data": [
+            {
+              "weight": "225698000",
+              "class": "Normal",
+              "paysFee": "Yes"
+            }
+          ]
+        }
+      ],
+      "success": true,
+      "paysFee": true
+    }
+  ]
+}

--- a/test/resources/vault/block-approveCall.json
+++ b/test/resources/vault/block-approveCall.json
@@ -64,6 +64,17 @@
                 "paysFee": "Yes"
               }
             ]
+          },
+          {
+            "method": {
+              "pallet": "balances",
+              "method": "Transfer"
+            },
+            "data": [
+              "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+              "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY",
+              "200000000000000000"
+            ]
           }
         ],
         "success": true,
@@ -71,4 +82,3 @@
       }
     ]
   }
-  

--- a/test/unit/services/transaction.extractor.spec.ts
+++ b/test/unit/services/transaction.extractor.spec.ts
@@ -167,7 +167,7 @@ describe("TransactionExtractor", () => {
             blockNumber: 10534n,
             fee: 125000149n,
             tip: 0n,
-            transferValue: 540000000000000000n,
+            transferValue: 0n,
             from: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
             to: "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY",
             error: {
@@ -189,6 +189,20 @@ describe("TransactionExtractor", () => {
             transferValue: 200000000000000000n,
             from: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
             to: "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY",
+        });
+        await expectTransaction(params);
+    });
+
+    it('finds balances.transferKeepAll transactions', async () => {
+        const params = balancesParams({
+            fileName: "transfer/block-transferAll.json",
+            method: "transferAll",
+            blockNumber: 8556893n,
+            fee: 2894701420000000n,
+            tip: 0n,
+            transferValue: 2894701420000000n,
+            from: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            to: "5GFFWfShvZBJ25XyfcT8jXzR3nPsar76iusyYEBZAdFD3ySn",
         });
         await expectTransaction(params);
     });


### PR DESCRIPTION
For all operations `balances.transfer*()`, the amount is picked up from the event `pallet.Transfer` rather then from the call args. Reason for this is that arg `value` is not available for `transferAll()`.

It's not clear if such an event is sent when running in the context of a vault approval, a [technical debt](https://github.com/logion-network/logion-internal/issues/990) to address this.

logion-network/logion-internal#989