### PR TITLE
Broken requester publication

### DIFF
--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -690,7 +690,7 @@ export class LocRequestController extends ApiController {
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
             if(request.canConfirmFile(hash, contributor)) {
-                request.confirmFile(hash);
+                request.confirmFile(hash, contributor);
             } else {
                 throw unauthorized("Contributor cannot confirm");
             }
@@ -976,7 +976,7 @@ export class LocRequestController extends ApiController {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
             const hash = Hash.fromHex(nameHash);
             if(request.canConfirmMetadataItem(hash, contributor)) {
-                request.confirmMetadataItem(hash);
+                request.confirmMetadataItem(hash, contributor);
             } else {
                 throw unauthorized("Contributor cannot confirm");
             }

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -428,7 +428,10 @@ export class LocRequestAggregateRoot {
         this.mutateFile(hash, item => item.lifecycle!.reject(reason));
     }
 
-    confirmFile(hash: Hash) {
+    confirmFile(hash: Hash, contributor: SupportedAccountId) {
+        if(!this.canConfirmFile(hash, contributor)) {
+            throw new Error("Contributor cannot confirm");
+        }
         this.mutateFile(hash, item => item.lifecycle!.confirm(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toSupportedAccountId())));
     }
 
@@ -474,10 +477,11 @@ export class LocRequestAggregateRoot {
         if (submitter?.type !== "Polkadot" && accountEquals(owner, contributor)) {
             return true;
         }
+        const requester = this.getRequester();
         const expectVerifiedIssuer = !accountEquals(submitter, owner)
-            && !accountEquals(submitter, this.getRequester());
-        if(expectVerifiedIssuer) {
-            return accountEquals(contributor, this.getRequester());
+            && !accountEquals(submitter, requester);
+        if(expectVerifiedIssuer || accountEquals(submitter, requester)) {
+            return accountEquals(contributor, requester);
         } else {
             return accountEquals(contributor, owner);
         }
@@ -669,7 +673,10 @@ export class LocRequestAggregateRoot {
         this.mutateMetadataItem(nameHash, item => item.lifecycle!.reject(reason));
     }
 
-    confirmMetadataItem(nameHash: Hash) {
+    confirmMetadataItem(nameHash: Hash, contributor: SupportedAccountId) {
+        if(!this.canConfirmMetadataItem(nameHash, contributor)) {
+            throw new Error("Contributor cannot confirm");
+        }
         this.mutateMetadataItem(nameHash, item => item.lifecycle!.confirm(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toSupportedAccountId())));
     }
 

--- a/test/helpers/Mock.ts
+++ b/test/helpers/Mock.ts
@@ -1,6 +1,11 @@
 import { Hash } from "@logion/node-api";
 import { It } from "moq.ts";
+import { SupportedAccountId } from "../../src/logion/model/supportedaccountid.model.js";
 
 export function ItIsHash(expected: Hash) {
     return It.Is<Hash>(given => given.equalTo(expected));
+}
+
+export function ItIsAccount(account: string) {
+    return It.Is<SupportedAccountId>(given => given.address === account && given.type === "Polkadot");
 }

--- a/test/unit/controllers/locrequest.controller.items.spec.ts
+++ b/test/unit/controllers/locrequest.controller.items.spec.ts
@@ -32,7 +32,7 @@ import {
     SupportedAccountId,
     accountEquals
 } from "../../../src/logion/model/supportedaccountid.model.js";
-import { ItIsHash } from "../../helpers/Mock.js";
+import { ItIsAccount, ItIsHash } from "../../helpers/Mock.js";
 
 const { mockAuthenticationWithCondition, setupApp } = TestApp;
 
@@ -384,7 +384,7 @@ function mockModelForConfirmFile(container: Container) {
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getFile(ItIsHash(SOME_DATA_HASH))).returns({ submitter: { type: "Polkadot", address: ALICE } } as FileDescription);
     request.setup(instance => instance.canConfirmFile(ItIsHash(SOME_DATA_HASH), It.IsAny<SupportedAccountId>())).returns(true);
-    request.setup(instance => instance.confirmFile(ItIsHash(SOME_DATA_HASH))).returns();
+    request.setup(instance => instance.confirmFile(ItIsHash(SOME_DATA_HASH), ItIsAccount(ALICE))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }
 
@@ -398,7 +398,7 @@ function mockRequestForMetadata(): Mock<LocRequestAggregateRoot> {
     mockRequester(request, REQUESTER);
     request.setup(instance => instance.removeMetadataItem(ALICE_ACCOUNT, ItIsHash(SOME_DATA_NAME_HASH)))
         .returns()
-    request.setup(instance => instance.confirmMetadataItem(ItIsHash(SOME_DATA_NAME_HASH)))
+    request.setup(instance => instance.confirmMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), ItIsAccount(REQUESTER.address)))
         .returns()
     request.setup(instance => instance.addMetadataItem({
         name: SOME_DATA_NAME,
@@ -472,6 +472,6 @@ function mockModelForConfirmMetadata(container: Container) {
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns({ submitter: { type: "Polkadot", address: ALICE } } as MetadataItemDescription);
     request.setup(instance => instance.canConfirmMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), It.IsAny<SupportedAccountId>())).returns(true);
-    request.setup(instance => instance.confirmMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns();
+    request.setup(instance => instance.confirmMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), ItIsAccount(ALICE))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -20,7 +20,7 @@ import { NonTransactionalTokensRecordService } from "../../../src/logion/service
 import { TokensRecordFactory, TokensRecordRepository } from "../../../src/logion/model/tokensrecord.model.js";
 import { ALICE } from "../../helpers/addresses.js";
 import { Hash } from "../../../src/logion/lib/crypto/hashing.js";
-import { ItIsHash } from "../../helpers/Mock.js";
+import { ItIsAccount, ItIsHash } from "../../helpers/Mock.js";
 import { SupportedAccountId } from "src/logion/model/supportedaccountid.model.js";
 
 describe("LocSynchronizer", () => {
@@ -361,11 +361,6 @@ function thenMetadataAcknowledged() {
 function givenLocRequestExpectsFileAcknowledged() {
     locRequest.setup(instance => instance.confirmFileAcknowledged(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
 }
-
-function ItIsAccount(account: string) {
-    return It.Is<SupportedAccountId>(given => given.address === account && given.type === "Polkadot");
-}
-
 
 function thenFileAcknowledged() {
     locRequest.verify(instance => instance.confirmFileAcknowledged(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME));


### PR DESCRIPTION
* The publication confirmation by the requester when the requester submitted the item was broken.
* Probably unnoticed because it is actually fixed by sync.

logion-network/logion-internal#984