### PR TITLE
Add REST resources for direct LOC opening

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -701,13 +701,6 @@
                             "$ref": "#/components/schemas/AddMetadataView"
                         }
                     },
-                    "files": {
-                        "type": "array",
-                        "description": "The metadata attached to this LOC",
-                        "items": {
-                            "$ref": "#/components/schemas/AddFileView"
-                        }
-                    },
                     "links": {
                         "type": "array",
                         "description": "The metadata attached to this LOC",
@@ -1228,6 +1221,10 @@
                     "restrictedDelivery": {
                         "type": "boolean",
                         "description": "true if the file can be downloaded by collection item owner. Applicable only for collection."
+                    },
+                    "direct": {
+                        "type": "string",
+                        "description": "true if the file is directly published (i.e. review by owner is bypassed)."
                     }
                 }
             },

--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -643,18 +643,9 @@
                     "address"
                 ]
             },
-            "CreateLocRequestView": {
+            "BaseLocView": {
                 "type": "object",
                 "properties": {
-                    "requesterAddress": {
-                        "description": "The address of the requester (this is only taken into account when created by the owner, which is needed when replacing a voided LOC)",
-                        "$ref": "#/components/schemas/SupportedAccountId"
-                    },
-                    "requesterIdentityLoc": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "The ID of the LOC identifying the requester"
-                    },
                     "ownerAddress": {
                         "type": "string",
                         "description": "The SS58 address of the legal officer that will own the LOC upon acceptance"
@@ -679,17 +670,9 @@
                         "type": "string",
                         "description": "If the user requesting an Identity LOC is representing a company, its legal entity name"
                     },
-                    "draft": {
-                        "type": "boolean",
-                        "description": "LOC will be created with initial status DRAFT if true, REQUESTED otherwise (false or undefined)"
-                    },
                     "template": {
                         "type": "string",
                         "description": "The LOC's template or undefined"
-                    },
-                    "sponsorshipId": {
-                        "type": "string",
-                        "description": "The ID of the sponsorship to use"
                     },
                     "valueFee": {
                         "type": "string",
@@ -698,6 +681,66 @@
                     "legalFee": {
                         "type": "string",
                         "description": "The legal fee associated with this LOC"
+                    }
+                },
+                "title": "BaseLocView",
+                "description": "Base LOC attributes"
+            },
+            "OpenLocView": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/BaseLocView"
+                    }
+                ],
+                "properties": {
+                    "metadata": {
+                        "type": "array",
+                        "description": "The metadata attached to this LOC",
+                        "items": {
+                            "$ref": "#/components/schemas/AddMetadataView"
+                        }
+                    },
+                    "files": {
+                        "type": "array",
+                        "description": "The metadata attached to this LOC",
+                        "items": {
+                            "$ref": "#/components/schemas/AddFileView"
+                        }
+                    },
+                    "links": {
+                        "type": "array",
+                        "description": "The metadata attached to this LOC",
+                        "items": {
+                            "$ref": "#/components/schemas/AddLinkView"
+                        }
+                    }
+                }
+            },
+            "CreateLocRequestView": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/BaseLocView"
+                    }
+                ],
+                "properties": {
+                    "requesterAddress": {
+                        "description": "The address of the requester (this is only taken into account when created by the owner, which is needed when replacing a voided LOC)",
+                        "$ref": "#/components/schemas/SupportedAccountId"
+                    },
+                    "requesterIdentityLoc": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The ID of the LOC identifying the requester"
+                    },
+                    "draft": {
+                        "type": "boolean",
+                        "description": "LOC will be created with initial status DRAFT if true, REQUESTED otherwise (false or undefined)"
+                    },
+                    "sponsorshipId": {
+                        "type": "string",
+                        "description": "The ID of the sponsorship to use"
                     }
                 },
                 "title": "CreateLocRequestView",

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -364,17 +364,10 @@ export interface components {
       address: string;
     };
     /**
-     * CreateLocRequestView 
-     * @description A LOC Request to create
+     * BaseLocView 
+     * @description Base LOC attributes
      */
-    CreateLocRequestView: {
-      /** @description The address of the requester (this is only taken into account when created by the owner, which is needed when replacing a voided LOC) */
-      requesterAddress?: components["schemas"]["SupportedAccountId"];
-      /**
-       * Format: uuid 
-       * @description The ID of the LOC identifying the requester
-       */
-      requesterIdentityLoc?: string;
+    BaseLocView: {
       /** @description The SS58 address of the legal officer that will own the LOC upon acceptance */
       ownerAddress?: string;
       /** @description A description of the LOC */
@@ -387,17 +380,38 @@ export interface components {
       userPostalAddress?: components["schemas"]["PostalAddressView"];
       /** @description If the user requesting an Identity LOC is representing a company, its legal entity name */
       company?: string;
-      /** @description LOC will be created with initial status DRAFT if true, REQUESTED otherwise (false or undefined) */
-      draft?: boolean;
       /** @description The LOC's template or undefined */
       template?: string;
-      /** @description The ID of the sponsorship to use */
-      sponsorshipId?: string;
       /** @description The value fee associated with this collection LOC */
       valueFee?: string;
       /** @description The legal fee associated with this LOC */
       legalFee?: string;
     };
+    OpenLocView: {
+      /** @description The metadata attached to this LOC */
+      metadata?: (components["schemas"]["AddMetadataView"])[];
+      /** @description The metadata attached to this LOC */
+      files?: (components["schemas"]["AddFileView"])[];
+      /** @description The metadata attached to this LOC */
+      links?: (components["schemas"]["AddLinkView"])[];
+    } & components["schemas"]["BaseLocView"];
+    /**
+     * CreateLocRequestView 
+     * @description A LOC Request to create
+     */
+    CreateLocRequestView: {
+      /** @description The address of the requester (this is only taken into account when created by the owner, which is needed when replacing a voided LOC) */
+      requesterAddress?: components["schemas"]["SupportedAccountId"];
+      /**
+       * Format: uuid 
+       * @description The ID of the LOC identifying the requester
+       */
+      requesterIdentityLoc?: string;
+      /** @description LOC will be created with initial status DRAFT if true, REQUESTED otherwise (false or undefined) */
+      draft?: boolean;
+      /** @description The ID of the sponsorship to use */
+      sponsorshipId?: string;
+    } & components["schemas"]["BaseLocView"];
     /**
      * @description The request's status 
      * @enum {string}

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -391,8 +391,6 @@ export interface components {
       /** @description The metadata attached to this LOC */
       metadata?: (components["schemas"]["AddMetadataView"])[];
       /** @description The metadata attached to this LOC */
-      files?: (components["schemas"]["AddFileView"])[];
-      /** @description The metadata attached to this LOC */
       links?: (components["schemas"]["AddLinkView"])[];
     } & components["schemas"]["BaseLocView"];
     /**
@@ -672,6 +670,8 @@ export interface components {
       nature?: string;
       /** @description true if the file can be downloaded by collection item owner. Applicable only for collection. */
       restrictedDelivery?: boolean;
+      /** @description true if the file is directly published (i.e. review by owner is bypassed). */
+      direct?: string;
     };
     AddLinkView: {
       /** @description The link's target */

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -12,7 +12,11 @@ import {
     LocRequestAggregateRoot,
     FetchLocRequestsSpecification,
     LocRequestDecision,
-    FileDescription
+    FileDescription,
+    MetadataItemParams,
+    FileParams,
+    StoredFile,
+    LinkParams
 } from "../model/locrequest.model.js";
 import {
     getRequestBody,
@@ -61,12 +65,14 @@ export function fillInSpec(spec: OpenAPIV3.Document): void {
     setControllerTag(spec, /^\/api\/loc-request.*/, tagName);
 
     LocRequestController.createLocRequest(spec);
+    LocRequestController.createOpenLoc(spec);
     LocRequestController.fetchRequests(spec);
     LocRequestController.getLocRequest(spec);
     LocRequestController.getPublicLoc(spec);
     LocRequestController.rejectLocRequest(spec);
     LocRequestController.acceptLocRequest(spec);
     LocRequestController.addFile(spec);
+    LocRequestController.uploadFile(spec);
     LocRequestController.downloadFile(spec);
     LocRequestController.deleteFile(spec);
     LocRequestController.requestFileReview(spec);
@@ -109,6 +115,7 @@ type AddMetadataView = components["schemas"]["AddMetadataView"];
 type CreateSofRequestView = components["schemas"]["CreateSofRequestView"];
 type SupportedAccountId = components["schemas"]["SupportedAccountId"];
 type ReviewItemView = components["schemas"]["ReviewItemView"];
+type OpenLocView = components["schemas"]["OpenLocView"];
 
 @injectable()
 @Controller('/loc-request')
@@ -213,6 +220,66 @@ export class LocRequestController extends ApiController {
             this.notify("LegalOfficer", "loc-requested", request.getDescription(), userIdentity)
         }
         return this.locRequestAdapter.toView(request, authenticatedUser, { userIdentity, userPostalAddress, identityLocId });
+    }
+
+    static createOpenLoc(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/loc-request/open"].post!;
+        operationObject.summary = "Creates a new LOC";
+        operationObject.description = "The authenticated user must be either the requester";
+        operationObject.requestBody = getRequestBody({
+            description: "LOC creation data",
+            view: "OpenLocView",
+        });
+        operationObject.responses = getDefaultResponses("LocRequestView");
+    }
+
+    @HttpPost("/open")
+    @Async()
+    async createOpenLoc(openLocView: OpenLocView): Promise<LocRequestView> {
+        const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
+        const ownerAddress = await this.directoryService.requireLegalOfficerAddressOnNode(openLocView.ownerAddress);
+        const locType = requireDefined(openLocView.locType);
+        const requesterAddress = polkadotAccount(authenticatedUser.address);
+        const valueFee = openLocView.valueFee !== undefined ? BigInt(openLocView.valueFee) : undefined;
+        if (valueFee === undefined && locType === "Collection") {
+            throw badRequest("Value fee must be set for collection LOCs");
+        }
+        const legalFee = openLocView.legalFee !== undefined ? BigInt(openLocView.legalFee) : undefined;
+        const description: LocRequestDescription = {
+            requesterAddress,
+            ownerAddress,
+            description: requireDefined(openLocView.description),
+            locType,
+            createdOn: moment().toISOString(),
+            userIdentity: locType === "Identity" ? this.fromUserIdentityView(openLocView.userIdentity) : undefined,
+            userPostalAddress: locType === "Identity" ? this.fromUserPostalAddressView(openLocView.userPostalAddress) : undefined,
+            company: openLocView.company,
+            template: openLocView.template,
+            valueFee,
+            legalFee,
+        }
+        const validIdLoc = await this.existsValidIdentityLoc(description.requesterAddress, ownerAddress);
+        if (validIdLoc && locType === "Identity") {
+            throw badRequest("Only one Polkadot Identity LOC is allowed per Legal Officer.");
+        }
+        if (!validIdLoc && locType !== "Identity") {
+            throw badRequest("Unable to find a valid (closed) identity LOC.");
+        }
+        const metadata = openLocView.metadata?.map(item => this.toMetadata(item, requesterAddress));
+        const files = openLocView.files?.map(item => this.toFile(item, requesterAddress));
+        const links = openLocView.links ?
+            await Promise.all(openLocView.links.map(item => this.toLink(item, requesterAddress))) :
+            undefined;
+
+        const request = await this.locRequestFactory.newLoc({
+            id: uuid(),
+            description,
+            metadata,
+            files,
+            links,
+        })
+        await this.locRequestService.addNewRequest(request);
+        return this.locRequestAdapter.toView(request, authenticatedUser);
     }
 
     private async existsValidIdentityLoc(requesterAddress: SupportedAccountId | undefined, ownerAddress: string): Promise<boolean> {
@@ -517,31 +584,83 @@ export class LocRequestController extends ApiController {
     async addFile(addFileView: AddFileView, requestId: string): Promise<void> {
         const request = requireDefined(await this.locRequestRepository.findById(requestId));
         const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
-
         const hash = Hash.fromHex(requireDefined(addFileView.hash, () => badRequest("No hash found for upload file")));
         if(request.hasFile(hash)) {
             throw new Error("File already present");
         }
         const file = await getUploadedFile(this.request, hash);
         const cid = await this.fileStorageService.importFile(file.tempFilePath);
-
         try {
+            const storedFile: StoredFile = {
+                name: file.name,
+                size: file.size,
+                contentType: file.mimetype,
+                cid
+            }
+            const fileParams = this.toFile(addFileView, contributor, storedFile)
             await this.locRequestService.update(requestId, async request => {
-                const alreadyReviewed = accountEquals(contributor, request.getOwner());
-                request.addFile({
-                    name: file.name,
-                    contentType: file.mimetype,
-                    hash,
-                    cid,
-                    nature: addFileView.nature || "",
-                    submitter: contributor,
-                    restrictedDelivery: addFileView.restrictedDelivery || false,
-                    size: file.size,
-                }, alreadyReviewed);
+                const submissionType = accountEquals(contributor, request.getOwner()) ? "MANUAL_BY_OWNER" : "MANUAL_BY_USER";
+                request.addFile(fileParams, submissionType);
             });
         } catch(e) {
             await this.fileStorageService.deleteFile({ cid });
             throw e;
+        }
+    }
+
+    static uploadFile(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/loc-request/{requestId}/files/{hashHex}/upload"].put!;
+        operationObject.summary = "Adds the actual file content to an existing LocFile entry";
+        operationObject.description = "The authenticated user must be the submitter of the file";
+        operationObject.responses = getDefaultResponsesNoContent();
+        setPathParameters(operationObject, { 'requestId': "The ID of the LOC" });
+    }
+
+    @HttpPut('/:requestId/files/:hashHex/upload')
+    @Async()
+    @SendsResponse()
+    async uploadFile(_body: any, requestId: string, hashHex: string): Promise<void> {
+        const request = requireDefined(await this.locRequestRepository.findById(requestId));
+        const hash = Hash.fromHex(hashHex);
+        const file = request.getFile(hash);
+        const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+        if (!accountEquals(file.submitter, contributor)) {
+            throw forbidden("Authenticated user is not allowed to upload this file");
+        }
+        if(file.contentType) {
+            throw badRequest("File has already been uploaded");
+        }
+        const uploadedFile = await getUploadedFile(this.request, hash);
+        const cid = await this.fileStorageService.importFile(uploadedFile.tempFilePath);
+        try {
+            const storedFile: StoredFile = {
+                name: uploadedFile.name,
+                size: uploadedFile.size,
+                contentType: uploadedFile.mimetype,
+                cid
+            }
+            await this.locRequestService.update(requestId, async request => {
+                request.updateFileContent(hash, storedFile);
+            });
+        } catch(e) {
+            await this.fileStorageService.deleteFile({ cid });
+            throw e;
+        }
+        this.response.sendStatus(204);
+    }
+
+    toFile(addFileView: AddFileView, submitter: SupportedAccountId, storedFile?: StoredFile): FileParams {
+        const hash = Hash.fromHex(requireDefined(addFileView.hash, () => badRequest("No hash found for upload file")));
+        const file = storedFile ? storedFile : {
+            name: "not-yet-uploaded",
+            size: 0,
+        };
+        return {
+            hash,
+            nature: addFileView.nature || "",
+            submitter,
+            restrictedDelivery: addFileView.restrictedDelivery || false,
+            ...file,
         }
     }
 
@@ -804,17 +923,23 @@ export class LocRequestController extends ApiController {
     @Async()
     @SendsResponse()
     async addLink(addLinkView: AddLinkView, requestId: string): Promise<void> {
-        const targetRequest = requireDefined(await this.locRequestRepository.findById(addLinkView.target!));
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
-            const alreadyReviewed = accountEquals(contributor, request.getOwner());
-            request.addLink({
-                target: targetRequest.id!,
-                nature: addLinkView.nature || "",
-                submitter: contributor,
-            }, alreadyReviewed);
+            const linkParams = await this.toLink(addLinkView, contributor);
+            const submissionType = accountEquals(contributor, request.getOwner()) ? "MANUAL_BY_OWNER" : "MANUAL_BY_USER";
+            request.addLink(linkParams, submissionType);
         });
         this.response.sendStatus(204);
+    }
+
+    async toLink(addLinkView: AddLinkView, submitter: SupportedAccountId): Promise<LinkParams> {
+        // Note: this check (LOC exists in local backend) is stricter than the one done on-chain (LOC exists on chain)
+        const targetRequest = requireDefined(await this.locRequestRepository.findById(addLinkView.target!));
+        return {
+            target: targetRequest.id!,
+            nature: addLinkView.nature || "",
+            submitter,
+        }
     }
 
     static deleteLink(spec: OpenAPIV3.Document) {
@@ -962,14 +1087,18 @@ export class LocRequestController extends ApiController {
     @Async()
     @SendsResponse()
     async addMetadata(addMetadataView: AddMetadataView, requestId: string): Promise<void> {
-        const name = requireLength(addMetadataView, "name", 3, 255);
-        const value = requireLength(addMetadataView, "value", 1, 4096);
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
-            const alreadyReviewed = accountEquals(contributor, request.getOwner());
-            request.addMetadataItem({ name, value, submitter: contributor }, alreadyReviewed);
+            const submissionType = accountEquals(contributor, request.getOwner()) ? "MANUAL_BY_OWNER" : "MANUAL_BY_USER";
+            request.addMetadataItem(this.toMetadata(addMetadataView, contributor), submissionType);
         });
         this.response.sendStatus(204);
+    }
+
+    toMetadata(addMetadataView: AddMetadataView, submitter: SupportedAccountId): MetadataItemParams {
+        const name = requireLength(addMetadataView, "name", 3, 255);
+        const value = requireLength(addMetadataView, "value", 1, 4096);
+        return { name, value, submitter }
     }
 
     static deleteMetadata(spec: OpenAPIV3.Document) {

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -66,9 +66,16 @@ interface FileDescriptionMandatoryFields {
 }
 
 export interface FileParams extends FileDescriptionMandatoryFields {
-    readonly cid: string;
-    readonly contentType: string;
+    readonly cid?: string;
+    readonly contentType?: string;
     readonly nature: string;
+}
+
+export interface StoredFile {
+    readonly name: string;
+    readonly size: number;
+    readonly cid?: string;
+    readonly contentType?: string;
 }
 
 export interface FileDescription extends FileDescriptionMandatoryFields, ItemLifecycle {
@@ -119,6 +126,8 @@ export interface VoidInfo {
     readonly reason: string;
     readonly voidedOn: Moment | null;
 }
+
+export type SubmissionType = "MANUAL_BY_USER" | "MANUAL_BY_OWNER" | "DIRECT_BY_REQUESTER"; // "USER" can be Requester or VI.
 
 export class EmbeddableLifecycle {
 
@@ -218,11 +227,20 @@ export class EmbeddableLifecycle {
         }
     }
 
-    static from(alreadyReviewed: boolean) {
+    static fromSubmissionType(submissionType: SubmissionType) {
         const lifecycle = new EmbeddableLifecycle();
-        lifecycle.status = alreadyReviewed ? "REVIEW_ACCEPTED" : "DRAFT";
-        lifecycle.acknowledgedByOwner = alreadyReviewed;
-        lifecycle.acknowledgedByOwnerOn = alreadyReviewed ? moment().toDate() : undefined;
+        lifecycle.status =
+            submissionType === "DIRECT_BY_REQUESTER" ? "PUBLISHED" :
+                submissionType === "MANUAL_BY_OWNER" ? "REVIEW_ACCEPTED" : "DRAFT";
+        lifecycle.acknowledgedByOwner = submissionType === "MANUAL_BY_OWNER";
+        lifecycle.acknowledgedByOwnerOn = submissionType === "MANUAL_BY_OWNER" ? moment().toDate() : undefined;
+        lifecycle.acknowledgedByVerifiedIssuer = false;
+        return lifecycle;
+    }
+
+    static default() {
+        const lifecycle = new EmbeddableLifecycle();
+        lifecycle.acknowledgedByOwner = false;
         lifecycle.acknowledgedByVerifiedIssuer = false;
         return lifecycle;
     }
@@ -384,7 +402,7 @@ export class LocRequestAggregateRoot {
         }
     }
 
-    addFile(fileDescription: FileParams, alreadyReviewed: boolean) {
+    addFile(fileDescription: FileParams, submissionType: SubmissionType) {
         this.ensureEditable();
         if (this.hasFile(fileDescription.hash)) {
             throw new Error("A file with given hash was already added to this LOC");
@@ -397,13 +415,23 @@ export class LocRequestAggregateRoot {
         file.hash! = fileDescription.hash.toHex();
         file.cid = fileDescription.cid;
         file.contentType = fileDescription.contentType;
-        file.lifecycle = EmbeddableLifecycle.from(alreadyReviewed);
+        file.lifecycle = EmbeddableLifecycle.fromSubmissionType(submissionType);
         file.nature = fileDescription.nature;
         file.submitter = EmbeddableSupportedAccountId.from(fileDescription.submitter);
         file.size = fileDescription.size.toString();
+        file.restrictedDelivery = fileDescription.restrictedDelivery;
         file.delivered = [];
         file._toAdd = true;
         this.files!.push(file);
+    }
+
+    updateFileContent(hash: Hash, storedFile: StoredFile) {
+        this.mutateFile(hash, item => {
+            item.name = storedFile.name;
+            item.size = storedFile.size.toString();
+            item.contentType = storedFile.contentType;
+            item.cid = storedFile.cid;
+        });
     }
 
     private ensureEditable() {
@@ -589,7 +617,7 @@ export class LocRequestAggregateRoot {
         return (this.closedOn !== undefined && this.closedOn !== null) ? moment(this.closedOn) : null;
     }
 
-    addMetadataItem(itemDescription: MetadataItemParams, alreadyReviewed: boolean) {
+    addMetadataItem(itemDescription: MetadataItemParams, submissionType: SubmissionType) {
         this.ensureEditable();
         const nameHash = Hash.of(itemDescription.name);
         if (this.hasMetadataItem(nameHash)) {
@@ -602,7 +630,7 @@ export class LocRequestAggregateRoot {
         item.name = itemDescription.name;
         item.nameHash = nameHash;
         item.value = itemDescription.value;
-        item.lifecycle = EmbeddableLifecycle.from(alreadyReviewed);
+        item.lifecycle = EmbeddableLifecycle.fromSubmissionType(submissionType);
         item.submitter = EmbeddableSupportedAccountId.from(itemDescription.submitter);
         item._toAdd = true;
         this.metadata!.push(item);
@@ -743,7 +771,7 @@ export class LocRequestAggregateRoot {
         return this.toFileDescription(removedFile);
     }
 
-    addLink(itemDescription: LinkParams, alreadyReviewed: boolean) {
+    addLink(itemDescription: LinkParams, submissionType: SubmissionType) {
         this.ensureEditable();
         if (this.hasLink(itemDescription.target)) {
             throw new Error("A link with given target was already added to this LOC");
@@ -754,7 +782,7 @@ export class LocRequestAggregateRoot {
         item.index = this.links!.length;
         item.target = itemDescription.target;
         item.nature = itemDescription.nature
-        item.lifecycle = EmbeddableLifecycle.from(alreadyReviewed);
+        item.lifecycle = EmbeddableLifecycle.fromSubmissionType(submissionType);
         item.submitter = EmbeddableSupportedAccountId.from(itemDescription.submitter);
         item._toAdd = true;
         this.links!.push(item);
@@ -1211,7 +1239,7 @@ export class LocFile extends Child implements HasIndex, Submitted {
 
     set status(status: ItemStatus | undefined) {
         if (!this.lifecycle) {
-            this.lifecycle = EmbeddableLifecycle.from(false);
+            this.lifecycle = EmbeddableLifecycle.default();
         }
         this.lifecycle.status = status;
         this._toUpdate = true;
@@ -1291,7 +1319,7 @@ export class LocMetadataItem extends Child implements HasIndex, Submitted {
 
     set status(status: ItemStatus | undefined) {
         if (!this.lifecycle) {
-            this.lifecycle = EmbeddableLifecycle.from(false);
+            this.lifecycle = EmbeddableLifecycle.default();
         }
         this.lifecycle.status = status;
         this._toUpdate = true;
@@ -1342,7 +1370,7 @@ export class LocLink extends Child implements HasIndex, Submitted {
 
     set status(status: ItemStatus | undefined) {
         if (!this.lifecycle) {
-            this.lifecycle = EmbeddableLifecycle.from(false);
+            this.lifecycle = EmbeddableLifecycle.default();
         }
         this.lifecycle.status = status;
         this._toUpdate = true;
@@ -1551,6 +1579,12 @@ export interface NewLocRequestParameters {
     readonly description: LocRequestDescription;
 }
 
+export interface NewLocParameters extends NewLocRequestParameters {
+    readonly metadata?: MetadataItemParams[];
+    readonly files?: FileParams[];
+    readonly links?: LinkParams[];
+}
+
 export interface NewUserLocRequestParameters extends NewLocRequestParameters {
     readonly draft: boolean;
 }
@@ -1568,47 +1602,40 @@ export class LocRequestFactory {
     }
 
     async newLOLocRequest(params: NewLocRequestParameters): Promise<LocRequestAggregateRoot> {
-        return await this.newLocRequest({ ...params, draft: false }, false);
+        this.ensureCorrectRequester(params.description, true);
+        return await this.createLocRequest({ ...params, draft: false }, "MANUAL_BY_OWNER");
     }
 
     async newSofRequest(params: NewSofRequestParameters): Promise<LocRequestAggregateRoot> {
-        const request = await this.newLocRequest({
+        this.ensureCorrectRequester(params.description, false);
+        const request = await this.createLocRequest({
             ...params,
             draft: true,
             description: {
                 ...params.description,
                 template: "statement_of_facts"
             }
-        });
-        request.addLink(params, false);
+        }, "MANUAL_BY_USER");
+        request.addLink(params, "MANUAL_BY_USER");
         request.submit();
         return request;
     }
 
-    async newLocRequest(params: NewUserLocRequestParameters, isUserRequest: boolean = true): Promise<LocRequestAggregateRoot> {
-        const { description } = params;
-        this.ensureCorrectRequester(description)
-        this.ensureUserIdentityPresent(description, isUserRequest)
+    async newLoc(params: NewLocParameters): Promise<LocRequestAggregateRoot> {
+        this.ensureCorrectRequester(params.description, false);
+        const request = await this.createLocRequest({ ...params, draft: false }, "DIRECT_BY_REQUESTER")
+        params.metadata?.forEach(item => request.addMetadataItem(item, "DIRECT_BY_REQUESTER"))
+        params.files?.forEach(item => request.addFile(item, "DIRECT_BY_REQUESTER"))
+        params.links?.forEach(item => request.addLink(item, "DIRECT_BY_REQUESTER"))
+        return request;
+    }
 
-        const request = new LocRequestAggregateRoot();
-        request.id = params.id;
+    async newLocRequest(params: NewUserLocRequestParameters): Promise<LocRequestAggregateRoot> {
+        this.ensureCorrectRequester(params.description, false);
+        return this.createLocRequest(params, "MANUAL_BY_USER");
+    }
 
-        const nonDraftStatus = isUserRequest ? "REVIEW_PENDING" : "OPEN";
-        request.status = params.draft ? "DRAFT" : nonDraftStatus;
-
-        if (description.requesterAddress) {
-            request.requesterAddress = description.requesterAddress.address;
-            request.requesterAddressType = description.requesterAddress.type;
-        }
-        if (description.requesterIdentityLoc) {
-            const identityLoc = await this.repository.findById(description.requesterIdentityLoc);
-            request._requesterIdentityLoc = identityLoc ? identityLoc : undefined;
-            request.requesterIdentityLocId = description.requesterIdentityLoc;
-        }
-        request.ownerAddress = description.ownerAddress;
-        request.description = description.description;
-        request.locType = description.locType;
-        request.createdOn = description.createdOn;
+    private populateIdentity(request: LocRequestAggregateRoot, description: LocRequestDescription) {
         const userIdentity = description.userIdentity || {
             firstName: "",
             lastName: "",
@@ -1624,14 +1651,38 @@ export class LocRequestFactory {
             country: ""
         }
         const company = description.company;
+        const personalInfo: PersonalInfo = { userIdentity, userPostalAddress, company }
+        const seal = this.sealService.seal(personalInfo, LATEST_SEAL_VERSION);
+        request.updateSealedPersonalInfo(personalInfo, seal);
+    }
+
+    private async createLocRequest(params: NewUserLocRequestParameters, submissionType: SubmissionType): Promise<LocRequestAggregateRoot> {
+        const { description } = params;
+
+        const request = new LocRequestAggregateRoot();
+        request.id = params.id;
+
+        const nonDraftStatus = submissionType === "MANUAL_BY_USER" ?
+            "REVIEW_PENDING" :
+            "OPEN";
+        request.status = params.draft ? "DRAFT" : nonDraftStatus;
+
+        if (description.requesterAddress) {
+            request.requesterAddress = description.requesterAddress.address;
+            request.requesterAddressType = description.requesterAddress.type;
+        }
+        if (description.requesterIdentityLoc) {
+            const identityLoc = await this.repository.findById(description.requesterIdentityLoc);
+            request._requesterIdentityLoc = identityLoc ? identityLoc : undefined;
+            request.requesterIdentityLocId = description.requesterIdentityLoc;
+        }
+        request.ownerAddress = description.ownerAddress;
+        request.description = description.description;
+        request.locType = description.locType;
+        request.createdOn = description.createdOn;
         if (request.locType === 'Identity') {
-            const personalInfo: PersonalInfo = { userIdentity, userPostalAddress, company }
-            const seal = this.sealService.seal(personalInfo, LATEST_SEAL_VERSION);
-            request.updateSealedPersonalInfo(personalInfo, seal);
-        } else {
-            request.updateUserIdentity(userIdentity);
-            request.updateUserPostalAddress(userPostalAddress);
-            request.company = company;
+            this.ensureUserIdentityPresent(description)
+            this.populateIdentity(request, description);
         }
         request.files = [];
         request.metadata = [];
@@ -1646,7 +1697,10 @@ export class LocRequestFactory {
         return request;
     }
 
-    private ensureCorrectRequester(description: LocRequestDescription) {
+    private ensureCorrectRequester(description: LocRequestDescription, allowRequesterIdentityLoc: boolean) {
+        if (!description.requesterAddress && !allowRequesterIdentityLoc) {
+            throw new Error("UnexpectedRequester: Identity LOC cannot have a LOC as requester")
+        }
         switch (description.locType) {
             case 'Identity':
                 if (description.requesterIdentityLoc) {
@@ -1663,17 +1717,15 @@ export class LocRequestFactory {
         }
     }
 
-    private ensureUserIdentityPresent(description: LocRequestDescription, isUserRequest: boolean) {
-        if (description.locType === 'Identity' && (!description.requesterAddress || isUserRequest)) {
-            const userIdentity = description.userIdentity;
-            if (!userIdentity
-                || !userIdentity.firstName
-                || !userIdentity.lastName
-                || !userIdentity.email
-                || !userIdentity.phoneNumber
-            ) {
-                throw new Error("Logion Identity LOC request must contain first name, last name, email and phone number.")
-            }
+    private ensureUserIdentityPresent(description: LocRequestDescription) {
+        const userIdentity = description.userIdentity;
+        if (!userIdentity
+            || !userIdentity.firstName
+            || !userIdentity.lastName
+            || !userIdentity.email
+            || !userIdentity.phoneNumber
+        ) {
+            throw new Error("Logion Identity LOC request must contain first name, last name, email and phone number.")
         }
     }
 }

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -238,8 +238,9 @@ export class EmbeddableLifecycle {
         return lifecycle;
     }
 
-    static default() {
+    static default(status: ItemStatus  | undefined) {
         const lifecycle = new EmbeddableLifecycle();
+        lifecycle.status = status;
         lifecycle.acknowledgedByOwner = false;
         lifecycle.acknowledgedByVerifiedIssuer = false;
         return lifecycle;
@@ -1242,9 +1243,10 @@ export class LocFile extends Child implements HasIndex, Submitted {
 
     set status(status: ItemStatus | undefined) {
         if (!this.lifecycle) {
-            this.lifecycle = EmbeddableLifecycle.default();
+            this.lifecycle = EmbeddableLifecycle.default(status);
+        } else {
+            this.lifecycle.status = status;
         }
-        this.lifecycle.status = status;
         this._toUpdate = true;
     }
 }
@@ -1322,9 +1324,10 @@ export class LocMetadataItem extends Child implements HasIndex, Submitted {
 
     set status(status: ItemStatus | undefined) {
         if (!this.lifecycle) {
-            this.lifecycle = EmbeddableLifecycle.default();
+            this.lifecycle = EmbeddableLifecycle.default(status);
+        } else {
+            this.lifecycle.status = status;
         }
-        this.lifecycle.status = status;
         this._toUpdate = true;
     }
 }
@@ -1373,9 +1376,10 @@ export class LocLink extends Child implements HasIndex, Submitted {
 
     set status(status: ItemStatus | undefined) {
         if (!this.lifecycle) {
-            this.lifecycle = EmbeddableLifecycle.default();
+            this.lifecycle = EmbeddableLifecycle.default(status);
+        } else {
+            this.lifecycle.status = status;
         }
-        this.lifecycle.status = status;
         this._toUpdate = true;
     }
 }

--- a/src/logion/services/idenfy/idenfy.service.ts
+++ b/src/logion/services/idenfy/idenfy.service.ts
@@ -153,7 +153,7 @@ export class EnabledIdenfyService extends IdenfyService {
         await this.locRequestService.update(json.clientId, async request => {
             request.updateIdenfyVerification(json, raw.toString());
             for(const file of files) {
-                request.addFile(file, false);
+                request.addFile(file, "MANUAL_BY_USER");
             }   
         });
     }

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -377,7 +377,7 @@ function givenLoc(id: string, locType: LocType, status: "OPEN" | "DRAFT"): LocRe
         target: uuid(),
         nature: "link nature",
         submitter: SUBMITTER,
-    }, false)
+    }, "MANUAL_BY_USER")
     locRequest.files = []
     locRequest.addFile({
         name: "fileName",
@@ -388,13 +388,13 @@ function givenLoc(id: string, locType: LocType, status: "OPEN" | "DRAFT"): LocRe
         submitter: SUBMITTER,
         restrictedDelivery: false,
         size: 789,
-    }, false)
+    }, "MANUAL_BY_USER")
     locRequest.metadata = []
     locRequest.addMetadataItem({
         name: "itemName",
         value: "something valuable",
         submitter: SUBMITTER,
-    }, false)
+    }, "MANUAL_BY_USER")
     return locRequest;
 }
 

--- a/test/unit/controllers/collection.controller.spec.ts
+++ b/test/unit/controllers/collection.controller.spec.ts
@@ -573,7 +573,7 @@ function mockModel(
         collectionLoc.files = [];
     } else if (hasFile && fileType === "Collection") {
         const collectionFile = new LocFile();
-        collectionFile.lifecycle = EmbeddableLifecycle.from(true);
+        collectionFile.lifecycle = EmbeddableLifecycle.fromSubmissionType("MANUAL_BY_OWNER");
         collectionFile.hash = SOME_DATA_HASH.toHex();
         if(fileAlreadyUploaded) {
             collectionFile.cid = CID;

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -78,18 +78,12 @@ describe("LocRequestFactory", () => {
             { name: "data01", value: "value01", submitter: REQUESTER_ADDRESS },
             { name: "data02", value: "value02", submitter: REQUESTER_ADDRESS },
         ];
-        const files: FileParams[] = [
-            { name: "some-name-01", size: 0, hash: Hash.of("content01"), nature: "some-nature", restrictedDelivery: true, submitter: REQUESTER_ADDRESS },
-            { name: "some-name-02", size: 0, hash: Hash.of("content02"), nature: "some-nature", restrictedDelivery: false, submitter: REQUESTER_ADDRESS },
-            { name: "some-name-03", size: 0, hash: Hash.of("content03"), nature: "some-nature", restrictedDelivery: true, submitter: REQUESTER_ADDRESS },
-        ];
         const links: LinkParams[] = [
             { target: "3eb0334a-3524-4eb0-bf44-e44176b72d3e", nature: "some linked loc", submitter: REQUESTER_ADDRESS }
         ];
-        await whenCreatingLoc(metadata, files, links);
+        await whenCreatingLoc(metadata, links);
         thenRequestCreatedWithDescription(description, "OPEN");
         thenLocCreatedWithMetadata(metadata, "PUBLISHED");
-        thenLocCreatedWithFiles(files, "PUBLISHED");
         thenLocCreatedWithLinks(links, "PUBLISHED");
         thenStatusIs("OPEN");
     });
@@ -1469,14 +1463,13 @@ async function whenCreatingLocRequest(draft: boolean) {
     });
 }
 
-async function whenCreatingLoc(metadata: MetadataItemParams[], files: FileParams[], links: LinkParams[]) {
+async function whenCreatingLoc(metadata: MetadataItemParams[], links: LinkParams[]) {
     const sealService = new Mock<PersonalInfoSealService>();
     const factory = new LocRequestFactory(repository.object(), sealService.object());
     request = await factory.newLoc({
         id: requestId,
         description: locDescription,
         metadata,
-        files,
         links,
     });
 }

--- a/test/unit/services/idenfy/idenfy.service.spec.ts
+++ b/test/unit/services/idenfy/idenfy.service.spec.ts
@@ -77,7 +77,7 @@ describe("EnabledIdenfyService", () => {
                 && file.nature === EXPECTED_FILES[fileType].nature
                 && file.name === EXPECTED_FILES[fileType].name
                 && accountEquals(file.submitter, LOC_OWNER_ACCOUNT)
-            ), false));
+            ), "MANUAL_BY_USER"));
         }
         locRequestRepository.verify(instance => instance.save(locRequest.object()));
     });


### PR DESCRIPTION
* A REST resource is added for direct LOC opening - including **metadata** and **links** (but not files).
* The concept of `SubmissionType` (`MANUAL_BY_USER` | `MANUAL_BY_OWNER` | `DIRECT_BY_REQUESTER`) is introduced, to better capture the various ways of submitting loc (requests) and items.
* The REST resource for uploading **files** content is adapted: A new parameter is available, direct (boolean), to tell the file is directly published (i.e. submissionType is `DIRECT_BY_REQUESTER`)

logion-network/logion-internal#1000