### PR TITLE
Rename pub/ack methods/resources and add missing controller tests

### DIFF
--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -77,8 +77,8 @@ export function fillInSpec(spec: OpenAPIV3.Document): void {
     LocRequestController.deleteFile(spec);
     LocRequestController.requestFileReview(spec);
     LocRequestController.reviewFile(spec);
-    LocRequestController.confirmFile(spec);
-    LocRequestController.confirmFileAcknowledged(spec);
+    LocRequestController.prePublishOrAcknowledgeFile(spec);
+    LocRequestController.preAcknowledgeFile(spec);
     LocRequestController.openLoc(spec);
     LocRequestController.closeLoc(spec);
     LocRequestController.voidLoc(spec);
@@ -88,12 +88,12 @@ export function fillInSpec(spec: OpenAPIV3.Document): void {
     LocRequestController.reviewMetadata(spec);
     LocRequestController.requestLinkReview(spec);
     LocRequestController.reviewLink(spec);
-    LocRequestController.confirmLink(spec);
-    LocRequestController.confirmLinkAcknowledged(spec);
+    LocRequestController.prePublishOrAcknowledgeLink(spec);
+    LocRequestController.preAcknowledgeLink(spec);
     LocRequestController.addMetadata(spec);
     LocRequestController.deleteMetadata(spec);
-    LocRequestController.confirmMetadata(spec);
-    LocRequestController.confirmMetadataAcknowledged(spec);
+    LocRequestController.prePublishOrAcknowledgeMetadataItem(spec);
+    LocRequestController.preAcknowledgeMetadataItem(spec);
     LocRequestController.createSofRequest(spec);
     LocRequestController.submitLocRequest(spec);
     LocRequestController.cancelLocRequest(spec);
@@ -755,8 +755,8 @@ export class LocRequestController extends ApiController {
         this.response.sendStatus(204);
     }
 
-    static confirmFile(spec: OpenAPIV3.Document) {
-        const operationObject = spec.paths["/api/loc-request/{requestId}/files/{hashHex}/confirm"].put!;
+    static prePublishOrAcknowledgeFile(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/loc-request/{requestId}/files/{hashHex}/pre-publish-ack"].put!;
         operationObject.summary = "Confirms a file of the LOC";
         operationObject.description = "The authenticated user must be the owner of the LOC. Once a file is confirmed, it cannot be deleted anymore.";
         operationObject.responses = getDefaultResponsesNoContent();
@@ -766,15 +766,15 @@ export class LocRequestController extends ApiController {
         });
     }
 
-    @HttpPut('/:requestId/files/:hashHex/confirm')
+    @HttpPut('/:requestId/files/:hashHex/pre-publish-ack')
     @Async()
     @SendsResponse()
-    async confirmFile(_body: any, requestId: string, hashHex: string) {
+    async prePublishOrAcknowledgeFile(_body: any, requestId: string, hashHex: string) {
         const hash = Hash.fromHex(hashHex);
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
-            if(request.canConfirmFile(hash, contributor)) {
-                request.confirmFile(hash, contributor);
+            if(request.canPrePublishOrAcknowledgeFile(hash, contributor)) {
+                request.prePublishOrAcknowledgeFile(hash, contributor);
             } else {
                 throw unauthorized("Contributor cannot confirm");
             }
@@ -782,8 +782,8 @@ export class LocRequestController extends ApiController {
         this.response.sendStatus(204);
     }
 
-    static confirmFileAcknowledged(spec: OpenAPIV3.Document) {
-        const operationObject = spec.paths["/api/loc-request/{requestId}/files/{hashHex}/confirm-acknowledged"].put!;
+    static preAcknowledgeFile(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/loc-request/{requestId}/files/{hashHex}/pre-publish-ack"].put!;
         operationObject.summary = "Confirms a file as acknowledged";
         operationObject.description = "The authenticated user must be the owner or the submitter";
         operationObject.responses = getDefaultResponsesNoContent();
@@ -793,17 +793,17 @@ export class LocRequestController extends ApiController {
         });
     }
 
-    @HttpPut('/:requestId/files/:hashHex/confirm-acknowledged')
+    @HttpPut('/:requestId/files/:hashHex/pre-ack')
     @Async()
     @SendsResponse()
-    async confirmFileAcknowledged(_body: any, requestId: string, hashHex: string) {
+    async preAcknowledgeFile(_body: any, requestId: string, hashHex: string) {
         const hash = Hash.fromHex(hashHex);
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
-            if(!request.canConfirmFileAcknowledged(hash, contributor)) {
+            if(!request.canPreAcknowledgeFile(hash, contributor)) {
                 throw unauthorized("Only owner or Verified Issuer are allowed to acknowledge");
             } else {
-                request.confirmFileAcknowledged(hash, contributor);
+                request.preAcknowledgeFile(hash, contributor);
             }
         });
         this.response.sendStatus(204);
@@ -985,8 +985,8 @@ export class LocRequestController extends ApiController {
         this.response.sendStatus(204);
     }
 
-    static confirmLink(spec: OpenAPIV3.Document) {
-        const operationObject = spec.paths["/api/loc-request/{requestId}/links/{target}/confirm"].put!;
+    static prePublishOrAcknowledgeLink(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/loc-request/{requestId}/links/{target}/pre-publish-ack"].put!;
         operationObject.summary = "Confirms a link of the LOC";
         operationObject.description = "The authenticated user must be the owner of the LOC. Once a link is confirmed, it cannot be deleted anymore.";
         operationObject.responses = getDefaultResponsesNoContent();
@@ -996,14 +996,14 @@ export class LocRequestController extends ApiController {
         });
     }
 
-    @HttpPut('/:requestId/links/:target/confirm')
+    @HttpPut('/:requestId/links/:target/pre-publish-ack')
     @Async()
     @SendsResponse()
-    async confirmLink(_body: any, requestId: string, target: string) {
+    async prePublishOrAcknowledgeLink(_body: any, requestId: string, target: string) {
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
-            if (request.canConfirmLink(target, contributor)) {
-                request.confirmLink(target, contributor);
+            if (request.canPrePublishOrAcknowledgeLink(target, contributor)) {
+                request.prePublishOrAcknowledgeLink(target, contributor);
             } else {
                 throw unauthorized("Contributor cannot confirm");
             }
@@ -1011,8 +1011,8 @@ export class LocRequestController extends ApiController {
         this.response.sendStatus(204);
     }
 
-    static confirmLinkAcknowledged(spec: OpenAPIV3.Document) {
-        const operationObject = spec.paths["/api/loc-request/{requestId}/links/{target}/confirm-acknowledged"].put!;
+    static preAcknowledgeLink(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/loc-request/{requestId}/links/{target}/pre-ack"].put!;
         operationObject.summary = "Confirms a link as acknowledged";
         operationObject.description = "The authenticated user must be the owner of the LOC.";
         operationObject.responses = getDefaultResponsesNoContent();
@@ -1022,16 +1022,16 @@ export class LocRequestController extends ApiController {
         });
     }
 
-    @HttpPut('/:requestId/links/:target/confirm-acknowledged')
+    @HttpPut('/:requestId/links/:target/pre-ack')
     @Async()
     @SendsResponse()
-    async confirmLinkAcknowledged(_body: any, requestId: string, target: string) {
+    async preAcknowledgeLink(_body: any, requestId: string, target: string) {
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
-            if(!request.canConfirmLinkAcknowledged(target, contributor)) {
+            if(!request.canPreAcknowledgeLink(target, contributor)) {
                 throw unauthorized("Only owner or Verified Issuer are allowed to acknowledge");
             } else {
-                request.confirmLinkAcknowledged(target, contributor);
+                request.preAcknowledgeLink(target, contributor);
             }
         });
         this.response.sendStatus(204);
@@ -1145,8 +1145,8 @@ export class LocRequestController extends ApiController {
         this.response.sendStatus(204);
     }
 
-    static confirmMetadata(spec: OpenAPIV3.Document) {
-        const operationObject = spec.paths["/api/loc-request/{requestId}/metadata/{nameHash}/confirm"].put!;
+    static prePublishOrAcknowledgeMetadataItem(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/loc-request/{requestId}/metadata/{nameHash}/pre-publish-ack"].put!;
         operationObject.summary = "Confirms a metadata item of the LOC";
         operationObject.description = "The authenticated user must be the owner of the LOC. Once a metadata item is confirmed, it cannot be deleted anymore.";
         operationObject.responses = getDefaultResponsesNoContent();
@@ -1156,15 +1156,15 @@ export class LocRequestController extends ApiController {
         });
     }
 
-    @HttpPut('/:requestId/metadata/:nameHash/confirm')
+    @HttpPut('/:requestId/metadata/:nameHash/pre-publish-ack')
     @Async()
     @SendsResponse()
-    async confirmMetadata(_body: any, requestId: string, nameHash: string) {
+    async prePublishOrAcknowledgeMetadataItem(_body: any, requestId: string, nameHash: string) {
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
             const hash = Hash.fromHex(nameHash);
-            if(request.canConfirmMetadataItem(hash, contributor)) {
-                request.confirmMetadataItem(hash, contributor);
+            if(request.canPrePublishOrAcknowledgeMetadataItem(hash, contributor)) {
+                request.prePublishOrAcknowledgeMetadataItem(hash, contributor);
             } else {
                 throw unauthorized("Contributor cannot confirm");
             }
@@ -1172,8 +1172,8 @@ export class LocRequestController extends ApiController {
         this.response.sendStatus(204);
     }
 
-    static confirmMetadataAcknowledged(spec: OpenAPIV3.Document) {
-        const operationObject = spec.paths["/api/loc-request/{requestId}/metadata/{nameHashHex}/confirm-acknowledged"].put!;
+    static preAcknowledgeMetadataItem(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/loc-request/{requestId}/metadata/{nameHashHex}/pre-ack"].put!;
         operationObject.summary = "Confirms a metadata item as acknowledged";
         operationObject.description = "The authenticated user must be the owner of the LOC.";
         operationObject.responses = getDefaultResponsesNoContent();
@@ -1183,17 +1183,17 @@ export class LocRequestController extends ApiController {
         });
     }
 
-    @HttpPut('/:requestId/metadata/:nameHashHex/confirm-acknowledged')
+    @HttpPut('/:requestId/metadata/:nameHashHex/pre-ack')
     @Async()
     @SendsResponse()
-    async confirmMetadataAcknowledged(_body: any, requestId: string, nameHashHex: string) {
+    async preAcknowledgeMetadataItem(_body: any, requestId: string, nameHashHex: string) {
         const nameHash = Hash.fromHex(nameHashHex);
         await this.locRequestService.update(requestId, async request => {
             const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
-            if(!request.canConfirmMetadataItemAcknowledged(nameHash, contributor)) {
+            if(!request.canPreAcknowledgeMetadataItem(nameHash, contributor)) {
                 throw unauthorized("Only owner or Verified Issuer are allowed to acknowledge");
             } else {
-                request.confirmMetadataItemAcknowledged(nameHash, contributor);
+                request.preAcknowledgeMetadataItem(nameHash, contributor);
             }
         });
         this.response.sendStatus(204);

--- a/src/logion/services/locsynchronization.service.ts
+++ b/src/logion/services/locsynchronization.service.ts
@@ -320,20 +320,20 @@ export class LocSynchronizer {
         const locId = extractUuid('loc_id', extrinsic.call.args);
         const hash = Hash.fromHex(Adapters.asHexString(extrinsic.call.args['hash']));
         const contributor = polkadotAccount(requireDefined(extrinsic.signer));
-        await this.mutateLoc(locId, async loc => loc.confirmFileAcknowledged(hash, contributor, timestamp));
+        await this.mutateLoc(locId, async loc => loc.preAcknowledgeFile(hash, contributor, timestamp));
     }
 
     private async confirmAcknowledgedMetadata(timestamp: Moment, extrinsic: JsonExtrinsic) {
         const locId = extractUuid('loc_id', extrinsic.call.args);
         const nameHash = Hash.fromHex(Adapters.asHexString(extrinsic.call.args['name']));
         const contributor = polkadotAccount(requireDefined(extrinsic.signer));
-        await this.mutateLoc(locId, async loc => loc.confirmMetadataItemAcknowledged(nameHash, contributor, timestamp));
+        await this.mutateLoc(locId, async loc => loc.preAcknowledgeMetadataItem(nameHash, contributor, timestamp));
     }
 
     private async confirmAcknowledgedLink(timestamp: Moment, extrinsic: JsonExtrinsic) {
         const locId = extractUuid('loc_id', extrinsic.call.args);
         const target = extractUuid('target', extrinsic.call.args);
         const contributor = polkadotAccount(requireDefined(extrinsic.signer));
-        await this.mutateLoc(locId, async loc => loc.confirmLinkAcknowledged(target, contributor, timestamp));
+        await this.mutateLoc(locId, async loc => loc.preAcknowledgeLink(target, contributor, timestamp));
     }
 }

--- a/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
+++ b/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
@@ -16,7 +16,7 @@ import {
     testData,
     testDataWithType,
     userIdentities,
-    REQUESTER_ADDRESS, ETHEREUM_REQUESTER
+    REQUESTER_ADDRESS,
 } from "./locrequest.controller.shared.js";
 import { BOB } from "../../helpers/addresses.js";
 import { SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model";

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -455,9 +455,9 @@ describe("LocRequestAggregateRoot", () => {
         }, "MANUAL_BY_USER");
         request.requestMetadataItemReview(nameHash);
         request.acceptMetadataItem(nameHash);
-        request.confirmMetadataItem(nameHash, SUBMITTER);
+        request.prePublishOrAcknowledgeMetadataItem(nameHash, SUBMITTER);
 
-        request.confirmMetadataItemAcknowledged(nameHash, OWNER_ACCOUNT, moment());
+        request.preAcknowledgeMetadataItem(nameHash, OWNER_ACCOUNT, moment());
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByVerifiedIssuerOn).not.toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.status).toBe("ACKNOWLEDGED");
@@ -474,14 +474,14 @@ describe("LocRequestAggregateRoot", () => {
         }, "MANUAL_BY_USER");
         request.requestMetadataItemReview(nameHash);
         request.acceptMetadataItem(nameHash);
-        request.confirmMetadataItem(nameHash, SUBMITTER);
+        request.prePublishOrAcknowledgeMetadataItem(nameHash, SUBMITTER);
 
-        request.confirmMetadataItemAcknowledged(nameHash, OWNER_ACCOUNT, moment());
+        request.preAcknowledgeMetadataItem(nameHash, OWNER_ACCOUNT, moment());
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByVerifiedIssuerOn).not.toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.status).toBe("PUBLISHED");
 
-        request.confirmMetadataItemAcknowledged(nameHash, VERIFIED_ISSUER, moment());
+        request.preAcknowledgeMetadataItem(nameHash, VERIFIED_ISSUER, moment());
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByVerifiedIssuerOn).toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.status).toBe("ACKNOWLEDGED");
@@ -498,14 +498,14 @@ describe("LocRequestAggregateRoot", () => {
         }, "MANUAL_BY_USER");
         request.requestMetadataItemReview(nameHash);
         request.acceptMetadataItem(nameHash);
-        request.confirmMetadataItem(nameHash, SUBMITTER);
+        request.prePublishOrAcknowledgeMetadataItem(nameHash, SUBMITTER);
 
-        request.confirmMetadataItemAcknowledged(nameHash, VERIFIED_ISSUER, moment());
+        request.preAcknowledgeMetadataItem(nameHash, VERIFIED_ISSUER, moment());
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByVerifiedIssuerOn).toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByOwnerOn).not.toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.status).toBe("PUBLISHED");
 
-        request.confirmMetadataItemAcknowledged(nameHash, OWNER_ACCOUNT, moment());
+        request.preAcknowledgeMetadataItem(nameHash, OWNER_ACCOUNT, moment());
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByVerifiedIssuerOn).toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
         expect(request.getMetadataOrThrow(nameHash).lifecycle?.status).toBe("ACKNOWLEDGED");
@@ -521,9 +521,9 @@ describe("LocRequestAggregateRoot", () => {
         }, "MANUAL_BY_USER");
         request.requestLinkReview(target);
         request.acceptLink(target);
-        request.confirmLink(target, SUBMITTER);
+        request.prePublishOrAcknowledgeLink(target, SUBMITTER);
 
-        request.confirmLinkAcknowledged(target, OWNER_ACCOUNT, moment());
+        request.preAcknowledgeLink(target, OWNER_ACCOUNT, moment());
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByVerifiedIssuerOn).not.toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.status).toBe("ACKNOWLEDGED");
@@ -539,14 +539,14 @@ describe("LocRequestAggregateRoot", () => {
         }, "MANUAL_BY_USER");
         request.requestLinkReview(target);
         request.acceptLink(target);
-        request.confirmLink(target, SUBMITTER);
+        request.prePublishOrAcknowledgeLink(target, SUBMITTER);
 
-        request.confirmLinkAcknowledged(target, OWNER_ACCOUNT, moment());
+        request.preAcknowledgeLink(target, OWNER_ACCOUNT, moment());
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByVerifiedIssuerOn).not.toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.status).toBe("PUBLISHED");
 
-        request.confirmLinkAcknowledged(target, VERIFIED_ISSUER, moment());
+        request.preAcknowledgeLink(target, VERIFIED_ISSUER, moment());
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByVerifiedIssuerOn).toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.status).toBe("ACKNOWLEDGED");
@@ -562,14 +562,14 @@ describe("LocRequestAggregateRoot", () => {
         }, "MANUAL_BY_USER");
         request.requestLinkReview(target);
         request.acceptLink(target);
-        request.confirmLink(target, SUBMITTER);
+        request.prePublishOrAcknowledgeLink(target, SUBMITTER);
 
-        request.confirmLinkAcknowledged(target, VERIFIED_ISSUER, moment());
+        request.preAcknowledgeLink(target, VERIFIED_ISSUER, moment());
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByVerifiedIssuerOn).toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByOwnerOn).not.toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.status).toBe("PUBLISHED");
 
-        request.confirmLinkAcknowledged(target, OWNER_ACCOUNT, moment());
+        request.preAcknowledgeLink(target, OWNER_ACCOUNT, moment());
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByVerifiedIssuerOn).toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
         expect(request.getLinkOrThrow(target).lifecycle?.status).toBe("ACKNOWLEDGED");
@@ -590,9 +590,9 @@ describe("LocRequestAggregateRoot", () => {
         }, "MANUAL_BY_USER");
         request.requestFileReview(hash);
         request.acceptFile(hash);
-        request.confirmFile(hash, SUBMITTER);
+        request.prePublishOrAcknowledgeFile(hash, SUBMITTER);
 
-        request.confirmFileAcknowledged(hash, OWNER_ACCOUNT, moment());
+        request.preAcknowledgeFile(hash, OWNER_ACCOUNT, moment());
 
         expect(request.getFileOrThrow(hash).lifecycle?.acknowledgedByVerifiedIssuerOn).not.toBeDefined();
         expect(request.getFileOrThrow(hash).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
@@ -614,14 +614,14 @@ describe("LocRequestAggregateRoot", () => {
         }, "MANUAL_BY_USER");
         request.requestFileReview(hash);
         request.acceptFile(hash);
-        request.confirmFile(hash, SUBMITTER);
+        request.prePublishOrAcknowledgeFile(hash, SUBMITTER);
 
-        request.confirmFileAcknowledged(hash, VERIFIED_ISSUER, moment());
+        request.preAcknowledgeFile(hash, VERIFIED_ISSUER, moment());
         expect(request.getFileOrThrow(hash).lifecycle?.acknowledgedByVerifiedIssuerOn).toBeDefined();
         expect(request.getFileOrThrow(hash).lifecycle?.acknowledgedByOwnerOn).not.toBeDefined();
         expect(request.getFileOrThrow(hash).lifecycle?.status).toBe("PUBLISHED");
 
-        request.confirmFileAcknowledged(hash, OWNER_ACCOUNT, moment());
+        request.preAcknowledgeFile(hash, OWNER_ACCOUNT, moment());
         expect(request.getFileOrThrow(hash).lifecycle?.acknowledgedByOwnerOn).toBeDefined();
         expect(request.getFileOrThrow(hash).lifecycle?.status).toBe("ACKNOWLEDGED");
     });
@@ -1333,17 +1333,17 @@ describe("LocRequestAggregateRoot (processes)", () => {
         thenRequestStatusIs("OPEN");
 
         // User publishes items
-        request.confirmFile(fileHash, SUBMITTER);
+        request.prePublishOrAcknowledgeFile(fileHash, SUBMITTER);
         request.setFileAddedOn(fileHash, moment()); // Sync
-        request.confirmFileAcknowledged(fileHash, SUBMITTER);
+        request.preAcknowledgeFile(fileHash, SUBMITTER);
 
-        request.confirmMetadataItem(itemNameHash, SUBMITTER);
+        request.prePublishOrAcknowledgeMetadataItem(itemNameHash, SUBMITTER);
         request.setMetadataItemAddedOn(itemNameHash, moment()); // Sync
-        request.confirmMetadataItemAcknowledged(itemNameHash, SUBMITTER);
+        request.preAcknowledgeMetadataItem(itemNameHash, SUBMITTER);
 
-        request.confirmLink(requesterLinkTarget, SUBMITTER);
+        request.prePublishOrAcknowledgeLink(requesterLinkTarget, SUBMITTER);
         request.setLinkAddedOn(requesterLinkTarget, moment()); // Sync
-        request.confirmLinkAcknowledged(requesterLinkTarget, SUBMITTER);
+        request.preAcknowledgeLink(requesterLinkTarget, SUBMITTER);
 
         // LLO adds other data
         request.addFile({
@@ -1356,7 +1356,7 @@ describe("LocRequestAggregateRoot (processes)", () => {
             restrictedDelivery: false,
             size: 123,
         }, "MANUAL_BY_OWNER");
-        request.confirmFile(hash2, OWNER_ACCOUNT);
+        request.prePublishOrAcknowledgeFile(hash2, OWNER_ACCOUNT);
         request.setFileAddedOn(hash2, moment()); // Sync
 
         const target = new UUID().toString();
@@ -1365,7 +1365,7 @@ describe("LocRequestAggregateRoot (processes)", () => {
             target: target,
             submitter: SUBMITTER,
         }, "MANUAL_BY_OWNER");
-        request.confirmLink(target, SUBMITTER);
+        request.prePublishOrAcknowledgeLink(target, SUBMITTER);
         request.setLinkAddedOn(target, moment()); // Sync
 
         const someOtherName = "Some other name";
@@ -1375,7 +1375,7 @@ describe("LocRequestAggregateRoot (processes)", () => {
             value: "Some other value",
             submitter: OWNER_ACCOUNT,
         }, "MANUAL_BY_OWNER");
-        request.confirmMetadataItem(someOtherNameHash, OWNER_ACCOUNT);
+        request.prePublishOrAcknowledgeMetadataItem(someOtherNameHash, OWNER_ACCOUNT);
         request.setMetadataItemAddedOn(someOtherNameHash, moment()); // Sync
 
         // LLO closes
@@ -1636,7 +1636,7 @@ function whenSettingMetadataItemAddedOn(nameHash: Hash, addedOn:Moment) {
 }
 
 function whenConfirmingMetadataItem(nameHash: Hash, contributor: SupportedAccountId) {
-    request.confirmMetadataItem(nameHash, contributor);
+    request.prePublishOrAcknowledgeMetadataItem(nameHash, contributor);
 }
 
 function thenMetadataItemStatusIs(nameHash: Hash, expectedStatus: ItemStatus) {
@@ -1657,7 +1657,7 @@ function whenSettingFileAddedOn(hash: Hash, addedOn:Moment) {
 }
 
 function whenConfirmingFile(hash: Hash, contributor: SupportedAccountId) {
-    request.confirmFile(hash, contributor);
+    request.prePublishOrAcknowledgeFile(hash, contributor);
 }
 
 function thenFileStatusIs(hash: Hash, status: ItemStatus) {
@@ -1678,7 +1678,7 @@ function whenSettingLinkAddedOn(target: string, addedOn:Moment) {
 }
 
 function whenConfirmingLink(target: string, contributor: SupportedAccountId) {
-    request.confirmLink(target, contributor);
+    request.prePublishOrAcknowledgeLink(target, contributor);
 }
 
 function thenLinkStatusIs(target: string, expectedStatus: ItemStatus) {

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -363,25 +363,25 @@ function thenCollectionItemSaved() {
 }
 
 function givenLocRequestExpectsMetadataItemAcknowledged() {
-    locRequest.setup(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.preAcknowledgeMetadataItem(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
 }
 
 function thenMetadataAcknowledged() {
-    locRequest.verify(instance => instance.confirmMetadataItemAcknowledged(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE), IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.preAcknowledgeMetadataItem(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE), IS_BLOCK_TIME));
 }
 
 function givenLocRequestExpectsFileAcknowledged() {
-    locRequest.setup(instance => instance.confirmFileAcknowledged(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.preAcknowledgeFile(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
 }
 
 function thenFileAcknowledged() {
-    locRequest.verify(instance => instance.confirmFileAcknowledged(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.preAcknowledgeFile(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME));
 }
 
 function givenLocRequestExpectsLinkAcknowledged() {
-    locRequest.setup(instance => instance.confirmLinkAcknowledged(IS_EXPECTED_TARGET, ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.preAcknowledgeLink(IS_EXPECTED_TARGET, ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
 }
 
 function thenLinkAcknowledged() {
-    locRequest.verify(instance => instance.confirmLinkAcknowledged(IS_EXPECTED_TARGET, ItIsAccount(ALICE), IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.preAcknowledgeLink(IS_EXPECTED_TARGET, ItIsAccount(ALICE), IS_BLOCK_TIME));
 }


### PR DESCRIPTION
* Adds controller tests for acknowledgment.
* Rename methods to clarify their "pre-chain submission" nature.

logion-network/logion-internal#907