### PR TITLE
Enable auto-publish

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -1826,6 +1826,15 @@
                 "required": [
                     "decision"
                 ]
+            },
+            "OpenView": {
+                "type": "object",
+                "properties": {
+                    "autoPublish": {
+                        "type": "boolean",
+                        "description": "Accepted items should be published automatically on opening"
+                    }
+                }
             }
         }
     }

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -999,6 +999,10 @@ export interface components {
       /** @description The rejection reason */
       rejectReason?: string;
     };
+    OpenView: {
+      /** @description Accepted items should be published automatically on opening */
+      autoPublish?: boolean;
+    };
   };
   responses: never;
   parameters: never;

--- a/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
+++ b/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
@@ -226,7 +226,7 @@ function mockModelForPreVoid(container: Container) {
 }
 
 function mockModelForOpen(container: Container, locType: LocType, userIdentity?: UserIdentity) {
-    const { request, repository } = buildMocksForUpdate(container);
+    const { request } = buildMocksForUpdate(container);
 
     const data = {
         ...testDataWithType(locType),
@@ -239,7 +239,7 @@ function mockModelForOpen(container: Container, locType: LocType, userIdentity?:
         .returns(false);
     request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params === undefined)))
         .returns(false);
-    request.setup(instance => instance.open()).returns();
+    request.setup(instance => instance.preOpen(It.IsAny())).returns();
 }
 
 const VOID_REASON = "Expired";

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -3,7 +3,7 @@ import { PolkadotService } from "@logion/rest-api-core";
 import moment, { Moment } from 'moment';
 import { It, Mock } from 'moq.ts';
 import { LocSynchronizer } from "../../../src/logion/services/locsynchronization.service.js";
-import { LocRequestAggregateRoot, LocRequestRepository } from '../../../src/logion/model/locrequest.model.js';
+import { EMPTY_ITEMS, LocRequestAggregateRoot, LocRequestRepository } from '../../../src/logion/model/locrequest.model.js';
 import { JsonExtrinsic } from '../../../src/logion/services/types/responses/Extrinsic.js';
 import {
     CollectionFactory,
@@ -54,7 +54,7 @@ describe("LocSynchronizer", () => {
             givenLocRequest();
             givenLocRequestExpectsLocCreationDate();
             await whenConsumingBlock();
-            thenLocCreateDateSet();
+            thenOpened();
             thenLocIsSaved();
         }
     });
@@ -259,7 +259,7 @@ let locRequest: Mock<LocRequestAggregateRoot>;
 let collectionItem: Mock<CollectionItemAggregateRoot>;
 
 function givenLocRequestExpectsLocCreationDate() {
-    locRequest.setup(instance => instance.setLocCreatedDate(IS_BLOCK_TIME))
+    locRequest.setup(instance => instance.open(IS_BLOCK_TIME, EMPTY_ITEMS))
         .returns(undefined);
 }
 
@@ -291,8 +291,8 @@ let verifiedIssuerSelectionService: Mock<VerifiedIssuerSelectionService>;
 let tokensRecordRepository: Mock<TokensRecordRepository>;
 let tokensRecordFactory: Mock<TokensRecordFactory>;
 
-function thenLocCreateDateSet() {
-    locRequest.verify(instance => instance.setLocCreatedDate(IS_BLOCK_TIME));
+function thenOpened() {
+    locRequest.verify(instance => instance.open(IS_BLOCK_TIME, EMPTY_ITEMS));
 }
 
 function thenLocIsSaved() {


### PR DESCRIPTION
* Pre-open and accept (for LOCs requested by non-Polkadot users) now expects an auto-publish flag in request body.
* "Added on" timestamps are now synchronized when items are passed on LOC creation.

logion-network/logion-internal#1035