### PR TITLE
Ensure all items ack/pub on-chain on close

### DIFF
--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -46,7 +46,7 @@ import { DirectoryService } from "../services/directory.service.js";
 import { CollectionRepository } from "../model/collection.model.js";
 import { getUploadedFile } from "./fileupload.js";
 import { PostalAddress } from "../model/postaladdress.js";
-import { downloadAndClean } from "../lib/http.js";
+import { downloadAndClean, toBadRequest } from "../lib/http.js";
 import { LocRequestAdapter } from "./adapters/locrequestadapter.js";
 import { LocRequestService } from "../services/locrequest.service.js";
 import { VoteRepository } from "../model/vote.model.js";
@@ -966,7 +966,11 @@ export class LocRequestController extends ApiController {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
         await this.locRequestService.update(requestId, async request => {
             authenticatedUser.require(user => user.is(request.ownerAddress));
-            request.preClose(body.autoAck || false);
+            try {
+                request.preClose(body.autoAck || false);
+            } catch(e) {
+                throw toBadRequest(e);
+            }
         });
         this.response.sendStatus(204);
     }

--- a/src/logion/lib/db/collections.ts
+++ b/src/logion/lib/db/collections.ts
@@ -16,3 +16,7 @@ export function order<T extends HasIndex>(items: T[] | undefined | null): Array<
     }
     return [ ...items ].sort((a, b) => a.index! - b.index!);
 }
+
+export function isTruthy<T>(value: T | undefined | null): boolean {
+    return value !== undefined && value !== null;
+}

--- a/src/logion/lib/http.ts
+++ b/src/logion/lib/http.ts
@@ -1,6 +1,7 @@
-import { Log } from "@logion/rest-api-core";
+import { Log, badRequest } from "@logion/rest-api-core";
 import { Response } from "express";
 import { rmSync } from "fs";
+import { isNativeError } from "util/types";
 
 const { logger } = Log;
 
@@ -17,4 +18,12 @@ export function downloadAndClean(args: {
             logger.error("Download failed: %s", error);
         }
     });
+}
+
+export function toBadRequest(e: unknown) {
+    if(isNativeError(e)) {
+        return badRequest(e.message);
+    } else {
+        return e;
+    }
 }

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -385,6 +385,120 @@ describe("LocRequestAggregateRoot", () => {
         thenRequestStatusIs('OPEN');
     });
 
+    it("fails auto-ack pre-close with metadata not published on-chain", () => {
+        givenRequestWithStatus('OPEN');
+        const name = "Name";
+        request.addMetadataItem({
+            name,
+            submitter: SUBMITTER,
+            value: "Value",
+        }, "DIRECT_BY_REQUESTER");
+        expect(() => request.preClose(true)).toThrowError("A metadata item was not yet published nor acknowledged");
+    });
+
+    it("fails auto-ack pre-close with metadata not acknowledged on-chain by VI", () => {
+        givenRequestWithStatus('OPEN');
+        const name = "Name";
+        request.addMetadataItem({
+            name,
+            submitter: VERIFIED_ISSUER,
+            value: "Value",
+        }, "DIRECT_BY_REQUESTER");
+        request.preAcknowledgeMetadataItem(Hash.of(name), VERIFIED_ISSUER);
+        expect(() => request.preClose(true)).toThrowError("A metadata item was not yet published nor acknowledged");
+    });
+
+    it("fails pre-close with metadata not acknowledged on-chain", () => {
+        givenRequestWithStatus('OPEN');
+        const name = "Name";
+        request.addMetadataItem({
+            name,
+            submitter: SUBMITTER,
+            value: "Value",
+        }, "DIRECT_BY_REQUESTER");
+        request.preAcknowledgeMetadataItem(Hash.of(name), ALICE_ACCOUNT);
+        expect(() => request.preClose(false)).toThrowError("A metadata item was not yet acknowledged");
+    });
+
+    it("fails auto-ack pre-close with file not published on-chain", () => {
+        givenRequestWithStatus('OPEN');
+        const hash = Hash.of("content");
+        request.addFile({
+            hash,
+            submitter: SUBMITTER,
+            name: "Name",
+            nature: "Nature",
+            restrictedDelivery: false,
+            size: 7,
+        }, "DIRECT_BY_REQUESTER");
+        expect(() => request.preClose(true)).toThrowError("A file was not yet published nor acknowledged");
+    });
+
+    it("fails auto-ack pre-close with file not acknowledged on-chain by VI", () => {
+        givenRequestWithStatus('OPEN');
+        const hash = Hash.of("content");
+        request.addFile({
+            hash,
+            submitter: VERIFIED_ISSUER,
+            name: "Name",
+            nature: "Nature",
+            restrictedDelivery: false,
+            size: 7,
+        }, "DIRECT_BY_REQUESTER");
+        request.preAcknowledgeFile(hash, VERIFIED_ISSUER);
+        expect(() => request.preClose(true)).toThrowError("A file was not yet published nor acknowledged");
+    });
+
+    it("fails pre-close with file not acknowledged on-chain", () => {
+        givenRequestWithStatus('OPEN');
+        const hash = Hash.of("content");
+        request.addFile({
+            hash,
+            submitter: SUBMITTER,
+            name: "Name",
+            nature: "Nature",
+            restrictedDelivery: false,
+            size: 7,
+        }, "DIRECT_BY_REQUESTER");
+        request.preAcknowledgeFile(hash, ALICE_ACCOUNT);
+        expect(() => request.preClose(false)).toThrowError("A file was not yet acknowledged");
+    });
+
+    it("fails auto-ack pre-close with link not published on-chain", () => {
+        givenRequestWithStatus('OPEN');
+        const target = new UUID().toString();
+        request.addLink({
+            target,
+            submitter: SUBMITTER,
+            nature: "Nature",
+        }, "DIRECT_BY_REQUESTER");
+        expect(() => request.preClose(true)).toThrowError("A link was not yet published nor acknowledged");
+    });
+
+    it("fails auto-ack pre-close with link not acknowledged on-chain by VI", () => {
+        givenRequestWithStatus('OPEN');
+        const target = new UUID().toString();
+        request.addLink({
+            target,
+            submitter: VERIFIED_ISSUER,
+            nature: "Nature",
+        }, "DIRECT_BY_REQUESTER");
+        request.preAcknowledgeLink(target, VERIFIED_ISSUER);
+        expect(() => request.preClose(true)).toThrowError("A link was not yet published nor acknowledged");
+    });
+
+    it("fails pre-close with link not acknowledged on-chain", () => {
+        givenRequestWithStatus('OPEN');
+        const target = new UUID().toString();
+        request.addLink({
+            target,
+            submitter: SUBMITTER,
+            nature: "Nature",
+        }, "DIRECT_BY_REQUESTER");
+        request.preAcknowledgeLink(target, ALICE_ACCOUNT);
+        expect(() => request.preClose(false)).toThrowError("A link was not yet acknowledged");
+    });
+
     it("closes", () => {
         givenRequestWithStatus('CLOSED');
         const closingDate = moment();


### PR DESCRIPTION
* Pre-close fails if all items are not published/acknowledged (depending on case) on-chain
* The check consists in testing if timestamps (set by sync) are defined
* With this, we at least prevent erroneous auto-ack close on chain in case of stale/erroneous data client-side or in backend DB

logion-network/logion-internal#1083