### PR TITLE
Link Transaction/Collection LOCs to requester Identity LOC.

### DIFF
--- a/src/logion/controllers/adapters/locrequestadapter.ts
+++ b/src/logion/controllers/adapters/locrequestadapter.ts
@@ -133,21 +133,6 @@ export class LocRequestAdapter {
                 ...description
             };
         }
-        if (description.requesterAddress) {
-            const identityLoc = (await this.locRequestRepository.findBy({
-                expectedLocTypes: [ "Identity" ],
-                expectedIdentityLocType: "Polkadot",
-                expectedRequesterAddress: description.requesterAddress.address,
-                expectedOwnerAddress: description.ownerAddress,
-                expectedStatuses: [ "CLOSED" ]
-            })).find(loc => loc.getVoidInfo() === null);
-            if (identityLoc) {
-                return {
-                    identityLocId: identityLoc.id,
-                    ...identityLoc.getDescription()
-                }
-            }
-        }
         if (description.requesterIdentityLoc) {
             const identityLoc = await this.locRequestRepository.findById(description.requesterIdentityLoc)
             if (identityLoc) {

--- a/src/logion/controllers/adapters/locrequestadapter.ts
+++ b/src/logion/controllers/adapters/locrequestadapter.ts
@@ -127,13 +127,12 @@ export class LocRequestAdapter {
 
     async findUserPrivateData(request: LocRequestAggregateRoot): Promise<UserPrivateData> {
         const description = request.getDescription();
-        if (description.locType === 'Identity') {
+        if (description.requesterIdentityLoc === undefined) {
             return {
                 identityLocId: undefined,
                 ...description
             };
-        }
-        if (description.requesterIdentityLoc) {
+        } else {
             const identityLoc = await this.locRequestRepository.findById(description.requesterIdentityLoc)
             if (identityLoc) {
                 return {

--- a/src/logion/migration/1706107298453-LinkLocToIdentity.ts
+++ b/src/logion/migration/1706107298453-LinkLocToIdentity.ts
@@ -16,7 +16,8 @@ export class LinkLocToIdentity1706107298453 implements MigrationInterface {
                        AND identity_loc.owner_address = loc.owner_address
                        AND identity_loc.status = 'CLOSED'
                        AND identity_loc.void_reason IS NULL
-                       AND identity_loc.voided_on IS NULL)
+                       AND identity_loc.voided_on IS NULL
+                     LIMIT 1)
             WHERE loc_type in ('Transaction', 'Collection')
               AND requester_identity_loc IS NULL
               AND requester_address IS NOT NULL

--- a/src/logion/migration/1706107298453-LinkLocToIdentity.ts
+++ b/src/logion/migration/1706107298453-LinkLocToIdentity.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class LinkLocToIdentity1706107298453 implements MigrationInterface {
+
+    name = 'LinkLocToIdentity1706107298453';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE loc_request loc
+            SET requester_identity_loc =
+                    (SELECT identity_loc.id
+                     FROM loc_request identity_loc
+                     WHERE identity_loc.loc_type = 'Identity'
+                       AND identity_loc.requester_address = loc.requester_address
+                       AND identity_loc.requester_address_type = loc.requester_address_type
+                       AND identity_loc.owner_address = loc.owner_address
+                       AND identity_loc.status = 'CLOSED'
+                       AND identity_loc.void_reason IS NULL
+                       AND identity_loc.voided_on IS NULL)
+            WHERE loc_type in ('Transaction', 'Collection')
+              AND requester_identity_loc IS NULL
+              AND requester_address IS NOT NULL
+              AND requester_address_type IS NOT NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE loc_request loc
+            SET requester_identity_loc = NULL
+            WHERE loc_type in ('Transaction', 'Collection')
+              AND requester_address IS NOT NULL
+              AND requester_address_type IS NOT NULL
+        `);
+    }
+}

--- a/test/unit/controllers/locrequest.controller.shared.ts
+++ b/test/unit/controllers/locrequest.controller.shared.ts
@@ -100,6 +100,7 @@ export const userIdentities: Record<IdentityLocation, UserPrivateData> = {
 export function testDataWithType(locType: LocType, draft?: boolean): Partial<LocRequestDescription & { draft: boolean }> {
     return {
         requesterAddress: REQUESTER_ADDRESS,
+        requesterIdentityLoc: "eb1b554e-f8de-4ea2-bcff-64d0c1f1f237",
         ownerAddress: ALICE,
         description: "I want to open a case",
         locType,

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -61,18 +61,34 @@ describe("LocRequestFactory", () => {
         phoneNumber: "+789",
     };
 
-    it("creates Transaction LOC request", async () => {
+    function mockRequesterIdentityLoc(requesterAddress?: string): string {
+        const requesterIdentityLocId = uuid().toString();
+        const requesterIdentityLoc = new Mock<LocRequestAggregateRoot>();
+        requesterIdentityLoc.setup(instance => instance.id).returns(requesterIdentityLocId);
+        if (requesterAddress) {
+            requesterIdentityLoc.setup(instance => instance.requesterAddress).returns(requesterAddress);
+            requesterIdentityLoc.setup(instance => instance.requesterAddressType).returns("Polkadot");
+        }
+        repository.setup(instance => instance.findById(requesterIdentityLocId)).returns(Promise.resolve(requesterIdentityLoc.object()));
+        return requesterIdentityLocId;
+    }
+
+    it("creates Transaction LOC request with requester having POLKADOT identity", async () => {
         givenRequestId(uuid());
-        const description = createDescription('Transaction', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
+        const requesterAddress = "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW";
+        const requesterIdentityLocId = mockRequesterIdentityLoc(requesterAddress);
+        const description = createDescription('Transaction', requesterAddress, requesterIdentityLocId);
         givenLocDescription(description);
         await whenCreatingLocRequest(false);
         thenRequestCreatedWithDescription(description, "REVIEW_PENDING");
         thenStatusIs("REVIEW_PENDING");
     });
 
-    it("creates Transaction LOC", async () => {
+    it("creates Transaction LOC with requester having POLKADOT identity", async () => {
         givenRequestId(uuid());
-        const description = createDescription('Transaction', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
+        const requesterAddress = "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW";
+        const requesterIdentityLocId = mockRequesterIdentityLoc(requesterAddress);
+        const description = createDescription('Transaction', requesterAddress, requesterIdentityLocId);
         givenLocDescription(description);
         const metadata: MetadataItemParams[] = [
             { name: "data01", value: "value01", submitter: REQUESTER_ADDRESS },
@@ -88,29 +104,28 @@ describe("LocRequestFactory", () => {
         thenStatusIs("OPEN");
     });
 
-    it("creates an open Transaction LOC with requester address", async () => {
+    it("creates an open Transaction LOC with requester having a POLKADOT identity", async () => {
         givenRequestId(uuid());
-        const description = createDescription('Transaction', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
+        const requesterAddress = "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW";
+        const requesterIdentityLocId = mockRequesterIdentityLoc(requesterAddress);
+        const description = createDescription('Transaction', requesterAddress, requesterIdentityLocId);
         givenLocDescription(description);
         await whenLOCreatingOpenLoc();
         thenRequestCreatedWithDescription(description, "OPEN");
     });
 
-    it("creates an open Transaction LOC with requester id loc", async () => {
+    it("creates an open Transaction LOC with requester having LOGION identity", async () => {
         givenRequestId(uuid());
-        const requesterIdentityLocId = uuid().toString();
+        const requesterIdentityLocId = mockRequesterIdentityLoc();
         const description = createDescription('Transaction', undefined, requesterIdentityLocId);
-        const requesterIdentityLoc = new Mock<LocRequestAggregateRoot>();
-        requesterIdentityLoc.setup(instance => instance.id).returns(requesterIdentityLocId);
-        repository.setup(instance => instance.findById(requesterIdentityLocId)).returns(Promise.resolve(requesterIdentityLoc.object()));
         givenLocDescription(description);
         await whenLOCreatingOpenLoc();
         thenRequestCreatedWithDescription(description, "OPEN")
     });
 
-    it("fails to create an open Transaction LOC with 2 requesters", async () => {
+    it("fails to create an open Transaction LOC without identity LOC", async () => {
         givenRequestId(uuid());
-        const description = createDescription('Transaction', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW", uuid().toString());
+        const description = createDescription('Transaction', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
         givenLocDescription(description);
         await expectAsyncToThrow(whenLOCreatingOpenLoc);
     });
@@ -122,37 +137,38 @@ describe("LocRequestFactory", () => {
         await expectAsyncToThrow(whenLOCreatingOpenLoc);
     });
 
-    it("creates Collection LOC request", async () => {
+    it("creates Collection LOC request with requester having POLKADOT identity", async () => {
         givenRequestId(uuid());
-        const description = createDescription('Collection', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
+        const requesterAddress = "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW";
+        const requesterIdentityLocId = mockRequesterIdentityLoc(requesterAddress);
+        const description = createDescription('Collection', requesterAddress, requesterIdentityLocId);
         givenLocDescription(description);
         await whenCreatingLocRequest(false);
         thenRequestCreatedWithDescription(description, "REVIEW_PENDING");
     });
 
-    it("creates an open Collection LOC with requester address", async () => {
+    it("creates an open Collection LOC with requester having POLKADOT identity", async () => {
+        givenRequestId(uuid());
+        const requesterAddress = "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW";
+        const requesterIdentityLocId = mockRequesterIdentityLoc(requesterAddress);
+        const description = createDescription('Collection', requesterAddress, requesterIdentityLocId);
+        givenLocDescription(description);
+        await whenLOCreatingOpenLoc();
+        thenRequestCreatedWithDescription(description, "OPEN");
+    });
+
+    it("creates an open Collection LOC with requester having a LOGION identity", async () => {
+        givenRequestId(uuid());
+        const requesterIdentityLocId = mockRequesterIdentityLoc();
+        const description = createDescription('Collection', undefined, requesterIdentityLocId);
+        givenLocDescription(description);
+        await whenLOCreatingOpenLoc();
+        thenRequestCreatedWithDescription(description, "OPEN");
+    });
+
+    it("fails to create an open Collection LOC without identity LOC", async () => {
         givenRequestId(uuid());
         const description = createDescription('Collection', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
-        givenLocDescription(description);
-        await whenLOCreatingOpenLoc();
-        thenRequestCreatedWithDescription(description, "OPEN");
-    });
-
-    it("creates an open Collection LOC with requester id loc", async () => {
-        givenRequestId(uuid());
-        const requesterIdentityLocId = uuid().toString();
-        const description = createDescription('Collection', undefined, requesterIdentityLocId);
-        const requesterIdentityLoc = new Mock<LocRequestAggregateRoot>();
-        requesterIdentityLoc.setup(instance => instance.id).returns(requesterIdentityLocId);
-        repository.setup(instance => instance.findById(requesterIdentityLocId)).returns(Promise.resolve(requesterIdentityLoc.object()));
-        givenLocDescription(description);
-        await whenLOCreatingOpenLoc();
-        thenRequestCreatedWithDescription(description, "OPEN");
-    });
-
-    it("fails to create an open Collection LOC with 2 requesters", async () => {
-        givenRequestId(uuid());
-        const description = createDescription('Collection', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW", uuid().toString());
         givenLocDescription(description);
         await expectAsyncToThrow(whenLOCreatingOpenLoc);
     });
@@ -234,7 +250,9 @@ describe("LocRequestFactory", () => {
 
     it("creates SOF LOC request", async () => {
         givenRequestId(uuid());
-        const description = createDescription('Transaction', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
+        const requesterAddress = "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW";
+        const requesterIdentityLocId = mockRequesterIdentityLoc(requesterAddress);
+        const description = createDescription('Transaction', requesterAddress, requesterIdentityLocId);
         givenLocDescription(description);
         const target = "target-loc"
         const nature = "Original LOC"
@@ -250,7 +268,9 @@ describe("LocRequestFactory", () => {
 
     it("creates a draft request", async () => {
         givenRequestId(uuid());
-        const description = createDescription('Transaction', "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
+        const requesterAddress = "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW";
+        const requesterIdentityLocId = mockRequesterIdentityLoc();
+        const description = createDescription('Transaction', requesterAddress, requesterIdentityLocId);
         givenLocDescription(description);
         await whenCreatingLocRequest(true);
         thenStatusIs("DRAFT");


### PR DESCRIPTION
Persist the link between the requester of a Transaction/Collection LOC and his/her valid identity LOC.
* The field `requesterIdentityLoc` is re-used - was previously used for referencing Logion identity only.
* The identity LOC has to be valid (i.e. closed and non-voided) at the creation time.
* Previously the identity LOC was fetched using field `requesterAddress` (and `requesterAddressType`).
* Those 2 latter fields are still being populated, even if this introduces a denormalization.
* A migration will populate the fields for all Transaction/Collection Polkadot identity.
* The user identity being now based on this link, the identity of a requester of a LOC is now the one used at LOC creation time, even if the identity has been voided-and-replaced in between.

logion-network/logion-internal#1126