### PR TITLE
Remove now useless loc_id from protection accept resource.

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -54,17 +54,6 @@
                 "title": "ItemLifecycleView",
                 "description": "All item's lifecycle attributes"
             },
-            "AcceptProtectionRequestView": {
-                "type": "object",
-                "properties": {
-                    "locId": {
-                        "type": "string",
-                        "description": "ID of the Identity LOC to associate with the protection request"
-                    }
-                },
-                "title": "AcceptProtectionRequestView",
-                "description": "Parameters for Protection Request's acceptance"
-            },
             "ItemDeliveriesResponse": {
                 "type": "object",
                 "additionalProperties": {
@@ -312,10 +301,6 @@
                             "PENDING",
                             "REJECTED"
                         ]
-                    },
-                    "locId": {
-                        "type": "string",
-                        "description": "ID of the Identity LOC linked to an accepted protection request."
                     }
                 },
                 "title": "LegalOfficerDecisionView",

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -45,14 +45,6 @@ export interface components {
        */
       acknowledgedByVerifiedIssuerOn?: string;
     };
-    /**
-     * AcceptProtectionRequestView 
-     * @description Parameters for Protection Request's acceptance
-     */
-    AcceptProtectionRequestView: {
-      /** @description ID of the Identity LOC to associate with the protection request */
-      locId?: string;
-    };
     ItemDeliveriesResponse: {
       [key: string]: (components["schemas"]["CheckLatestItemDeliveryResponse"])[] | undefined;
     };
@@ -177,8 +169,6 @@ export interface components {
        * @enum {string}
        */
       status?: "ACCEPTED" | "PENDING" | "REJECTED";
-      /** @description ID of the Identity LOC linked to an accepted protection request. */
-      locId?: string;
     };
     /**
      * PostalAddressView 

--- a/src/logion/migration/1706536716815-LinkProtectionToIdentity.ts
+++ b/src/logion/migration/1706536716815-LinkProtectionToIdentity.ts
@@ -13,11 +13,13 @@ export class LinkProtectionToIdentity1706536716815 implements MigrationInterface
         await queryRunner.query(`ALTER TABLE "protection_request" DROP COLUMN "last_name"`);
         await queryRunner.query(`ALTER TABLE "protection_request" DROP COLUMN "first_name"`);
         await queryRunner.query(`ALTER TABLE "protection_request" DROP COLUMN "email"`);
-        await queryRunner.query(`ALTER TABLE "protection_request" ADD "requester_identity_loc_id" uuid NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "protection_request" RENAME "loc_id" TO "requester_identity_loc_id"`);
+        await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "requester_identity_loc_id" SET NOT NULL`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "protection_request" DROP COLUMN "requester_identity_loc_id"`);
+        await queryRunner.query(`ALTER TABLE "protection_request" ALTER COLUMN "requester_identity_loc_id" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "protection_request" RENAME "requester_identity_loc_id" TO "loc_id"`);
         await queryRunner.query(`ALTER TABLE "protection_request" ADD "email" character varying(255)`);
         await queryRunner.query(`ALTER TABLE "protection_request" ADD "first_name" character varying(255)`);
         await queryRunner.query(`ALTER TABLE "protection_request" ADD "last_name" character varying(255)`);

--- a/src/logion/model/protectionrequest.model.ts
+++ b/src/logion/model/protectionrequest.model.ts
@@ -17,9 +17,8 @@ export class LegalOfficerDecision {
         this.rejectReason = reason;
     }
 
-    accept(decisionOn: Moment, locId: string): void {
+    accept(decisionOn: Moment): void {
         this.decisionOn = decisionOn.toISOString();
-        this.locId = locId;
     }
 
     clear() {
@@ -32,9 +31,6 @@ export class LegalOfficerDecision {
 
     @Column({ length: 255, name: "reject_reason", nullable: true })
     rejectReason?: string;
-
-    @Column({ type: "uuid", nullable: true, name: "loc_id" })
-    locId?: string;
 }
 
 @Entity("protection_request")
@@ -48,12 +44,12 @@ export class ProtectionRequestAggregateRoot {
         this.decision!.reject(reason, decisionOn);
     }
 
-    accept(decisionOn: Moment, locId: string): void {
+    accept(decisionOn: Moment): void {
         if(this.status !== 'PENDING') {
             throw badRequest("Request is not pending");
         }
         this.status = 'ACCEPTED';
-        this.decision!.accept(decisionOn, locId);
+        this.decision!.accept(decisionOn);
     }
 
     setActivated() {
@@ -144,11 +140,10 @@ export class ProtectionRequestAggregateRoot {
         if (!this.decision || this.decision.decisionOn === undefined) {
             return undefined
         }
-        const { decisionOn, locId, rejectReason} = this.decision
+        const { decisionOn, rejectReason } = this.decision
         return {
             decisionOn,
             rejectReason,
-            locId
         }
     }
 }
@@ -234,7 +229,6 @@ export interface ProtectionRequestDescription {
 export interface LegalOfficerDecisionDescription {
     readonly decisionOn: string;
     readonly rejectReason?: string;
-    readonly locId?: string;
 }
 
 export interface NewProtectionRequestParameters {

--- a/test/integration/model/protection_requests.sql
+++ b/test/integration/model/protection_requests.sql
@@ -1,8 +1,8 @@
 INSERT INTO protection_request (id, requester_address, legal_officer_address, other_legal_officer_address, requester_identity_loc_id, is_recovery, status)
 VALUES ('d9aea58aa7d24a768b74aff7b82380e1', '5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', 'b826df54-6d31-4dd0-99af-e89e81890143', FALSE, 'PENDING');
 
-INSERT INTO protection_request (id, requester_address, legal_officer_address, other_legal_officer_address, requester_identity_loc_id, is_recovery, status, decision_on, loc_id)
-VALUES ('7ef13bcd867d487a8fc28c58143e0c43', '5CSbpCKSTvZefZYddesUQ9w6NDye2PHbf12MwBZGBgzGeGoo', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', 'b826df54-6d31-4dd0-99af-e89e81890143', FALSE, 'ACCEPTED', '2021-10-29T11:47:00.000', '7ef13bcd867d487a8fc28c58143e0c43');
+INSERT INTO protection_request (id, requester_address, legal_officer_address, other_legal_officer_address, requester_identity_loc_id, is_recovery, status, decision_on)
+VALUES ('7ef13bcd867d487a8fc28c58143e0c43', '5CSbpCKSTvZefZYddesUQ9w6NDye2PHbf12MwBZGBgzGeGoo', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', 'b826df54-6d31-4dd0-99af-e89e81890143', FALSE, 'ACCEPTED', '2021-10-29T11:47:00.000');
 
 INSERT INTO protection_request (id, requester_address, legal_officer_address, other_legal_officer_address, requester_identity_loc_id, is_recovery, status, decision_on, reject_reason)
 VALUES ('6ef13bcd867d487a8fc28c58143e0c44', '5EvPZRKRatcHusoKB467pDHcFTe3rG1a4eEhVmLxfirn8Cum', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', 'b826df54-6d31-4dd0-99af-e89e81890143', FALSE, 'REJECTED', '2021-10-29T11:47:00.000', 'Because.');
@@ -10,5 +10,5 @@ VALUES ('6ef13bcd867d487a8fc28c58143e0c44', '5EvPZRKRatcHusoKB467pDHcFTe3rG1a4eE
 INSERT INTO protection_request (id, requester_address, legal_officer_address, other_legal_officer_address, requester_identity_loc_id, is_recovery, address_to_recover, status, decision_on, reject_reason)
 VALUES ('5926be94b2ba416a80fb069bd1e98845', '5EFHLCx7T6cHD75yjTcTV1KBSd9vbzXYVKweoReWbgVFSNhs', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', 'b826df54-6d31-4dd0-99af-e89e81890143', TRUE, '5EvPZRKRatcHusoKB467pDHcFTe3rG1a4eEhVmLxfirn8Cum', 'REJECTED', '2021-10-29T11:47:00.000', 'Because.');
 
-INSERT INTO protection_request (id, requester_address, legal_officer_address, other_legal_officer_address, requester_identity_loc_id, is_recovery, status, decision_on, loc_id)
-VALUES ('6ef13bcd867d487a8fc28c58143e0c45', '5GThAgk5q8fHoDymHuk7vPmbB9LsDK2BpK78GafB8kL2g8xp', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', 'b826df54-6d31-4dd0-99af-e89e81890143', FALSE, 'ACTIVATED', '2021-10-29T11:47:00.000', '6ef13bcd867d487a8fc28c58143e0c45');
+INSERT INTO protection_request (id, requester_address, legal_officer_address, other_legal_officer_address, requester_identity_loc_id, is_recovery, status, decision_on)
+VALUES ('6ef13bcd867d487a8fc28c58143e0c45', '5GThAgk5q8fHoDymHuk7vPmbB9LsDK2BpK78GafB8kL2g8xp', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty', 'b826df54-6d31-4dd0-99af-e89e81890143', FALSE, 'ACTIVATED', '2021-10-29T11:47:00.000');

--- a/test/unit/controllers/protectionrequest.controller.spec.ts
+++ b/test/unit/controllers/protectionrequest.controller.spec.ts
@@ -291,8 +291,8 @@ let notificationService: Mock<NotificationService>;
 
 function mockModelForAccept(container: Container, verifies: boolean): void {
     const protectionRequest = mockProtectionRequest();
-    protectionRequest.setup(instance => instance.accept(
-        It.IsAny(), It.Is<string>(locId => locId !== undefined && locId !== null))).returns(undefined);
+    protectionRequest.setup(instance => instance.accept(It.IsAny()))
+        .returns(undefined);
 
     mockDecision(protectionRequest, { decisionOn: DECISION_TIMESTAMP} )
 
@@ -446,8 +446,6 @@ function mockDecision(protectionRequest: Mock<ProtectionRequestAggregateRoot>, d
             .returns(decisionDescription.rejectReason)
         decision.setup(instance => instance.decisionOn)
             .returns(decisionDescription.decisionOn)
-        decision.setup(instance => instance.locId)
-            .returns(decisionDescription.locId)
     }
     protectionRequest.setup(instance => instance.decision)
         .returns(decision.object());

--- a/test/unit/model/protectionrequest.model.spec.ts
+++ b/test/unit/model/protectionrequest.model.spec.ts
@@ -57,13 +57,11 @@ describe('ProtectionRequestAggregateRootTest', () => {
     it('accepts', async () => {
         const request = await newProtectionRequestUsingFactory();
         const decisionOn = moment();
-        const locId = "locId";
 
-        request.accept(decisionOn, locId);
+        request.accept(decisionOn);
 
         expect(request.status).toBe('ACCEPTED');
         expect(request.decision!.decisionOn).toBe(decisionOn.toISOString());
-        expect(request.decision!.locId).toBe(locId);
     });
 
     it('rejects', async () => {
@@ -80,10 +78,9 @@ describe('ProtectionRequestAggregateRootTest', () => {
     it('fails on re-accept', async () => {
         const request = await newProtectionRequestUsingFactory();
         const decisionOn = moment();
-        const locId = "locId";
-        request.accept(decisionOn, locId);
+        request.accept(decisionOn);
 
-        expect(() => request.accept(decisionOn, locId)).toThrowError();
+        expect(() => request.accept(decisionOn)).toThrowError();
     });
 
     it('fails on re-reject', async () => {

--- a/test/unit/services/notification-test-data.ts
+++ b/test/unit/services/notification-test-data.ts
@@ -18,7 +18,6 @@ export const notifiedProtection: ProtectionRequestDescription & { decision: Lega
     decision: {
         decisionOn: "2021-06-10T16:25:23.668294",
         rejectReason: "Failed to provide some data",
-        locId: "103850a5-84f5-4ba9-bad8-f10fdbab3592",
     }
 }
 


### PR DESCRIPTION
Previously, the identity LOC ID was submitted by LLO, when `accept`ing the protection request.
So instead of dropping `loc_id` and creating `requester_identity_loc`, we now rename `loc_id` into `requester_identity_loc`.
Naming remains consistent with Transaction/Collection.

Also, as a prerequisite to protection creation, `requester_identity_loc` has no reason to be present in Decision only, and to stay nullable.

Companion of https://github.com/logion-network/logion-backend-ts/pull/289

logion-network/logion-internal#1126