### PR TITLE
Only recovery requests needed

### DIFF
--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -1915,6 +1915,22 @@ export class LocRequestRepository {
         const { deliveredFileHash } = query;
         return await this.deliveredRepository.findOneBy({ requestId, deliveredFileHash: deliveredFileHash.toHex() })
     }
+
+    async getValidPolkadotIdentityLoc(requesterAddress: SupportedAccountId | undefined, ownerAddress: string): Promise<LocRequestAggregateRoot | undefined> {
+        if (requesterAddress === undefined) {
+            return undefined;
+        }
+
+        const identityLoc = (await this.findBy({
+            expectedLocTypes: [ "Identity" ],
+            expectedIdentityLocType: requesterAddress.type,
+            expectedRequesterAddress: requesterAddress.address,
+            expectedOwnerAddress: ownerAddress,
+            expectedStatuses: [ "CLOSED" ]
+        })).find(loc => loc.getVoidInfo() === null);
+
+        return identityLoc;
+    }
 }
 
 export interface NewLocRequestParameters {

--- a/test/unit/controllers/locrequest.controller.shared.ts
+++ b/test/unit/controllers/locrequest.controller.shared.ts
@@ -365,6 +365,7 @@ export function mockPolkadotIdentityLoc(repository: Mock<LocRequestRepository>, 
     repository.setup(instance => instance.existsBy(specification)).returns(Promise.resolve(exists));
 
     repository.setup(instance => instance.findById(locId)).returnsAsync(identityLocs[0]);
+    repository.setup(instance => instance.getValidPolkadotIdentityLoc(It.IsAny(), It.IsAny())).returnsAsync(identityLocs[0]);
 }
 
 export const testData = testDataWithType("Transaction");

--- a/test/unit/controllers/protectionrequest.controller.spec.ts
+++ b/test/unit/controllers/protectionrequest.controller.spec.ts
@@ -22,7 +22,7 @@ import { notifiedLegalOfficer } from "../services/notification-test-data.js";
 import { UserIdentity } from '../../../src/logion/model/useridentity.js';
 import { PostalAddress } from '../../../src/logion/model/postaladdress.js';
 import { NonTransactionalProtectionRequestService, ProtectionRequestService } from '../../../src/logion/services/protectionrequest.service.js';
-import { LocRequestAggregateRoot, LocRequestDescription } from "../../../src/logion/model/locrequest.model.js";
+import { LocRequestAggregateRoot, LocRequestDescription, LocRequestRepository } from "../../../src/logion/model/locrequest.model.js";
 import { LocRequestAdapter } from "../../../src/logion/controllers/adapters/locrequestadapter.js";
 
 const DECISION_TIMESTAMP = "2021-06-10T16:25:23.668294";
@@ -131,6 +131,7 @@ function mockProtectionRequestModel(container: Container, isRecovery: boolean, a
 
     container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
+    container.bind(LocRequestRepository).toConstantValue(mockLocRequestRepository());
 }
 
 function mockLocRequestAdapter(): LocRequestAdapter {
@@ -142,6 +143,11 @@ function mockLocRequestAdapter(): LocRequestAdapter {
             identityLocId: REQUESTER_IDENTITY_LOC_ID
         }))
     return locRequestAdapter.object();
+}
+
+function mockLocRequestRepository(): LocRequestRepository {
+    const repository = new Mock<LocRequestRepository>();
+    return repository.object();
 }
 
 function mockIdentityLoc(): LocRequestAggregateRoot {
@@ -248,6 +254,7 @@ function mockModelForFetch(container: Container): void {
 
     container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
+    container.bind(LocRequestRepository).toConstantValue(mockLocRequestRepository());
 }
 
 function authenticatedLLONotProtectingUser() {
@@ -311,6 +318,7 @@ function mockModelForAccept(container: Container, verifies: boolean): void {
 
     container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
+    container.bind(LocRequestRepository).toConstantValue(mockLocRequestRepository());
 }
 
 const REQUEST_ID = "requestId";
@@ -477,6 +485,7 @@ function mockModelForReject(container: Container, verifies: boolean): void {
 
     container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
+    container.bind(LocRequestRepository).toConstantValue(mockLocRequestRepository());
 }
 
 function mockNotificationAndDirectoryService(container: Container) {
@@ -550,4 +559,5 @@ function mockModelForUser(container: Container, protectionRequest: Mock<Protecti
 
     container.bind(ProtectionRequestService).toConstantValue(new NonTransactionalProtectionRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
+    container.bind(LocRequestRepository).toConstantValue(mockLocRequestRepository());
 }


### PR DESCRIPTION
* Given the identity of a user has already been verified on the creation of its IDLOC, it is redundant to validate the protection request as well.
* Therefore, a user with 2 IDLOCs with 2 different LLOs is now able to directly activate its protection on chain without the preliminary review by the LLOs.
* However, the review is still required when requesting a recovery.
* Some clean-up and refactoring will be needed in order to simplify and clarify the model.

logion-network/logion-internal#1123