### PR TITLE
Expose workloads of many legal officers.

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -1850,12 +1850,28 @@
                     }
                 }
             },
+            "FetchWorkloadsView": {
+                "type": "object",
+                "properties": {
+                    "legalOfficerAddresses": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "description": "A legal officer address"
+                        }
+                    }
+                }
+            },
             "WorkloadView": {
                 "type": "object",
                 "properties": {
-                    "workload": {
-                        "type": "number",
-                        "description": "The number of pending tasks"
+                    "workloads": {
+                        "type": "object",
+                        "description": "The number of pending tasks per legal officer (the address is used as key)",
+                        "additionalProperties": {
+                            "type": "number",
+                            "description": "The number of pending tasks"
+                        }
                     }
                 }
             }

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -1007,9 +1007,14 @@ export interface components {
       /** @description Accepted items should be published automatically on opening */
       autoPublish?: boolean;
     };
+    FetchWorkloadsView: {
+      legalOfficerAddresses?: (string)[];
+    };
     WorkloadView: {
-      /** @description The number of pending tasks */
-      workload?: number;
+      /** @description The number of pending tasks per legal officer (the address is used as key) */
+      workloads?: {
+        [key: string]: number | undefined;
+      };
     };
   };
   responses: never;

--- a/src/logion/controllers/workload.controller.ts
+++ b/src/logion/controllers/workload.controller.ts
@@ -1,5 +1,5 @@
 import { injectable } from "inversify";
-import { Controller, ApiController, Async, HttpGet } from "dinoloop";
+import { Controller, ApiController, Async, HttpPut } from "dinoloop";
 import { components } from "./components.js";
 import { OpenAPIV3 } from "express-oas-generator";
 import {
@@ -18,9 +18,10 @@ export function fillInSpec(spec: OpenAPIV3.Document): void {
     });
     setControllerTag(spec, /^\/api\/workload.*/, tagName);
 
-    WorkloadController.getWorkload(spec);
+    WorkloadController.getWorkloads(spec);
 }
 
+type FetchWorkloadsView = components["schemas"]["FetchWorkloadsView"];
 type WorkloadView = components["schemas"]["WorkloadView"];
 
 @injectable()
@@ -34,19 +35,19 @@ export class WorkloadController extends ApiController {
         super();
     }
 
-    static getWorkload(spec: OpenAPIV3.Document) {
-        const operationObject = spec.paths["/api/workload/{legalOfficerAddress}"].get!;
-        operationObject.summary = "Provides the workload of a given legal officer";
+    static getWorkloads(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/workload"].put!;
+        operationObject.summary = "Provides the workloads of given legal officers";
         operationObject.description = "Requires authentication.";
         operationObject.responses = getDefaultResponses("WorkloadView");
     }
 
-    @HttpGet('/:legalOfficerAddress')
+    @HttpPut('')
     @Async()
-    async getWorkload(legalOfficerAddress: string): Promise<WorkloadView> {
+    async getWorkloads(body: FetchWorkloadsView): Promise<WorkloadView> {
         await this.authenticationService.authenticatedUser(this.request);
         return {
-            workload: await this.workloadService.workloadOf(legalOfficerAddress),
+            workloads: await this.workloadService.workloadOf(body.legalOfficerAddresses || []),
         }
     }
 }

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -1713,7 +1713,7 @@ export class LocLink extends Child implements HasIndex, Submitted {
 export interface FetchLocRequestsSpecification {
 
     readonly expectedRequesterAddress?: string;
-    readonly expectedOwnerAddress?: string;
+    readonly expectedOwnerAddress?: string | string[];
     readonly expectedStatuses?: LocRequestStatus[];
     readonly expectedLocTypes?: LocType[];
     readonly expectedIdentityLocType?: IdentityLocType;
@@ -1829,9 +1829,14 @@ export class LocRequestRepository {
                 { expectedRequesterAddress: specification.expectedRequesterAddress });
         }
 
-        if (specification.expectedOwnerAddress) {
-            builder.andWhere("request.owner_address = :expectedOwnerAddress",
-                { expectedOwnerAddress: specification.expectedOwnerAddress });
+        if (specification.expectedOwnerAddress !== undefined) {
+            if(typeof specification.expectedOwnerAddress === "string") {
+                builder.andWhere("request.owner_address = :expectedOwnerAddress",
+                    { expectedOwnerAddress: specification.expectedOwnerAddress });
+            } else {
+                builder.andWhere("request.owner_address IN (:...expectedOwnerAddress)",
+                    { expectedOwnerAddress: specification.expectedOwnerAddress });
+            }
         }
 
         if (specification.expectedStatuses && specification.expectedStatuses.length > 0) {

--- a/src/logion/model/protectionrequest.model.ts
+++ b/src/logion/model/protectionrequest.model.ts
@@ -152,7 +152,7 @@ export class FetchProtectionRequestsSpecification {
 
     constructor(builder: {
         expectedRequesterAddress?: string,
-        expectedLegalOfficerAddress?: string,
+        expectedLegalOfficerAddress?: string | string[],
         expectedStatuses?: ProtectionRequestStatus[],
         kind?: ProtectionRequestKind,
     }) {
@@ -163,7 +163,7 @@ export class FetchProtectionRequestsSpecification {
     }
 
     readonly expectedRequesterAddress: string | null;
-    readonly expectedLegalOfficerAddress: string | null;
+    readonly expectedLegalOfficerAddress: string | string[] | null;
     readonly kind: ProtectionRequestKind;
     readonly expectedStatuses: ProtectionRequestStatus[];
 }
@@ -196,7 +196,11 @@ export class ProtectionRequestRepository {
         }
 
         if(specification.expectedLegalOfficerAddress !== null) {
-            where("request.legal_officer_address = :expectedLegalOfficerAddress", {expectedLegalOfficerAddress: specification.expectedLegalOfficerAddress});
+            if(typeof specification.expectedLegalOfficerAddress === "string") {
+                where("request.legal_officer_address = :expectedLegalOfficerAddress", {expectedLegalOfficerAddress: specification.expectedLegalOfficerAddress});
+            } else {
+                where("request.legal_officer_address IN (:...expectedLegalOfficerAddress)", {expectedLegalOfficerAddress: specification.expectedLegalOfficerAddress});
+            }
             where = (a: string, b?: ObjectLiteral) => builder.andWhere(a, b);
         }
 

--- a/src/logion/model/vaulttransferrequest.model.ts
+++ b/src/logion/model/vaulttransferrequest.model.ts
@@ -136,7 +136,7 @@ export class FetchVaultTransferRequestsSpecification {
 
     constructor(builder: {
         expectedRequesterAddress?: string,
-        expectedLegalOfficerAddress?: string,
+        expectedLegalOfficerAddress?: string | string[],
         expectedStatuses?: VaultTransferRequestStatus[],
     }) {
         this.expectedRequesterAddress = builder.expectedRequesterAddress || null;
@@ -145,7 +145,7 @@ export class FetchVaultTransferRequestsSpecification {
     }
 
     readonly expectedRequesterAddress: string | null;
-    readonly expectedLegalOfficerAddress: string | null;
+    readonly expectedLegalOfficerAddress: string | string[] | null;
     readonly expectedStatuses: VaultTransferRequestStatus[];
 }
 
@@ -177,7 +177,11 @@ export class VaultTransferRequestRepository {
         }
 
         if(specification.expectedLegalOfficerAddress !== null) {
-            where("request.legal_officer_address = :expectedLegalOfficerAddress", {expectedLegalOfficerAddress: specification.expectedLegalOfficerAddress});
+            if(typeof specification.expectedLegalOfficerAddress === "string") {
+                where("request.legal_officer_address = :expectedLegalOfficerAddress", {expectedLegalOfficerAddress: specification.expectedLegalOfficerAddress});
+            } else {
+                where("request.legal_officer_address IN (:...expectedLegalOfficerAddress)", {expectedLegalOfficerAddress: specification.expectedLegalOfficerAddress});
+            }
             where = (a: string, b?: ObjectLiteral) => builder.andWhere(a, b);
         }
 

--- a/test/integration/model/locrequest.model.spec.ts
+++ b/test/integration/model/locrequest.model.spec.ts
@@ -239,6 +239,16 @@ describe('LocRequestRepository - read accesses', () => {
         expect(results).toEqual([ false, false, false ]);
     })
 
+    it("finds workload", async () => {
+        const query: FetchLocRequestsSpecification = {
+            expectedOwnerAddress: [ ALICE, BOB ],
+            expectedStatuses: [ "REVIEW_PENDING" ],
+        }
+        const requests = await repository.findBy(query);
+        checkDescription(requests, undefined, "loc-1", "loc-2", "loc-3", "loc-21", "loc-22", "loc-23");
+
+    })
+
     function checkDelivery(delivered: Record<string, LocFileDelivered[]>) {
         expect(delivered[hash.toHex()].length).toEqual(3);
         expect(delivered[hash.toHex()][0].owner).toEqual("5Eewz58eEPS81847EezkiFENE3kG8fxrx1BdRWyFJAudPC6m");

--- a/test/integration/model/protectionrequest.model.spec.ts
+++ b/test/integration/model/protectionrequest.model.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../src/logion/model/protectionrequest.model.js";
 import { ALICE, BOB } from "../../helpers/addresses.js";
 import { LocRequestAggregateRoot } from "../../../src/logion/model/locrequest.model.js";
+import { FetchVaultTransferRequestsSpecification } from "../../../src/logion/model/vaulttransferrequest.model";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 
@@ -93,6 +94,16 @@ describe('ProtectionRequestRepositoryTest', () => {
 
         const results = await repository.findBy(specification);
 
+        expect(results.length).toBe(1);
+        expectStatus(results, 'PENDING');
+    });
+
+    it("finds workload", async () => {
+        const specification = new FetchProtectionRequestsSpecification({
+            expectedLegalOfficerAddress: [ ALICE, BOB ],
+            expectedStatuses: [ "PENDING" ],
+        });
+        const results = await repository.findBy(specification);
         expect(results.length).toBe(1);
         expectStatus(results, 'PENDING');
     });

--- a/test/integration/model/vaulttransferrequest.model.spec.ts
+++ b/test/integration/model/vaulttransferrequest.model.spec.ts
@@ -5,7 +5,7 @@ import {
     VaultTransferRequestRepository,
     VaultTransferRequestStatus,
 } from "../../../src/logion/model/vaulttransferrequest.model.js";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, BOB } from "../../helpers/addresses.js";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 
@@ -55,6 +55,19 @@ describe('VaultTransferRequestRepository queries', () => {
         expect(results.length).toBe(1);
         expectStatus(results, 'PENDING');
     });
+
+    it("finds workload", async () => {
+        const specification = new FetchVaultTransferRequestsSpecification({
+            expectedLegalOfficerAddress: [ ALICE, BOB ],
+            expectedStatuses: [ 'PENDING' ],
+        });
+
+        const results = await repository.findBy(specification);
+
+        expect(results.length).toBe(1);
+        expectStatus(results, 'PENDING');
+    });
+
 });
 
 describe('VaultTransferRequestRepository updates', () => {

--- a/test/unit/controllers/workload.controller.spec.ts
+++ b/test/unit/controllers/workload.controller.spec.ts
@@ -1,8 +1,8 @@
 import { TestApp } from "@logion/rest-api-core";
 import { Container } from "inversify";
-import { Mock } from "moq.ts";
+import { Mock, It } from "moq.ts";
 import request from "supertest";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, BOB } from "../../helpers/addresses.js";
 import { WorkloadController } from "../../../src/logion/controllers/workload.controller.js";
 import { WorkloadService } from "../../../src/logion/services/workload.service.js";
 
@@ -13,18 +13,27 @@ describe("WorkloadController", () => {
     it("provides expected workload", async () => {
         const app = setupApp(WorkloadController, mockForFetch)
         await request(app)
-            .get(`/api/workload/${ ALICE }`)
-            .send()
+            .put(`/api/workload`)
+            .send({
+                legalOfficerAddresses: [ ALICE, BOB ]
+            })
             .expect(200)
             .expect('Content-Type', /application\/json/)
             .expect(response => {
-                expect(response.body.workload).toEqual(42);
-        });
+                expect(response.body.workloads.ALICE).toEqual(42);
+                expect(response.body.workloads.BOB).toEqual(24);
+            });
     });
 });
 
 function mockForFetch(container: Container) {
     const service = new Mock<WorkloadService>();
-    service.setup(instance => instance.workloadOf(ALICE)).returnsAsync(42);
+    service.setup(instance => instance.workloadOf(It.Is<string[]>(params =>
+        params.includes(ALICE) &&
+        params.includes(BOB)
+    ))).returnsAsync({
+        ALICE: 42,
+        BOB: 24,
+    });
     container.bind(WorkloadService).toConstantValue(service.object());
 }

--- a/test/unit/services/workload.service.spec.ts
+++ b/test/unit/services/workload.service.spec.ts
@@ -3,59 +3,72 @@ import { FetchLocRequestsSpecification, LocRequestAggregateRoot, LocRequestRepos
 import { FetchProtectionRequestsSpecification, ProtectionRequestAggregateRoot, ProtectionRequestRepository } from "../../../src/logion/model/protectionrequest.model.js";
 import { FetchVaultTransferRequestsSpecification, VaultTransferRequestAggregateRoot, VaultTransferRequestRepository } from "../../../src/logion/model/vaulttransferrequest.model.js";
 import { WorkloadService } from "../../../src/logion/services/workload.service.js";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, BOB } from "../../helpers/addresses.js";
+
+const legalOfficerAddresses = [ ALICE, BOB ];
 
 describe("WorkloadService", () => {
 
     it("provides expected workload", async () => {
-        const legalOfficerAddress = ALICE;
         const service = buildService({
-            legalOfficerAddress,
-            locRequests: 10,
-            vaultTransferRequests: 20,
-            protectionRequests: 12,
+            ALICE: {
+                locRequests: 10,
+                vaultTransferRequests: 20,
+                protectionRequests: 12,
+            },
+            BOB: {
+                locRequests: 22,
+                vaultTransferRequests: 1,
+                protectionRequests: 1,
+            },
         });
 
-        const workload = await service.workloadOf(legalOfficerAddress);
+        const workload = await service.workloadOf(legalOfficerAddresses);
 
-        expect(workload).toBe(42);
+        expect(workload[ALICE]).toBe(42);
+        expect(workload[BOB]).toBe(24);
     });
 
     it("provides 0 workload if nothing pending", async () => {
-        const legalOfficerAddress = ALICE;
         const service = buildService({
-            legalOfficerAddress,
-            locRequests: 0,
-            vaultTransferRequests: 0,
-            protectionRequests: 0,
+            ALICE: {
+                locRequests: 0,
+                vaultTransferRequests: 0,
+                protectionRequests: 0,
+            },
+            BOB: {
+                locRequests: 0,
+                vaultTransferRequests: 0,
+                protectionRequests: 0,
+            },
         });
 
-        const workload = await service.workloadOf(legalOfficerAddress);
+        const workload = await service.workloadOf(legalOfficerAddresses);
 
-        expect(workload).toBe(0);
+        expect(workload[ALICE]).toBe(0);
+        expect(workload[BOB]).toBe(0);
     });
 });
 
-function buildService(args: {
-    legalOfficerAddress: string,
+function buildService(args: Record<string, {
     locRequests: number,
     vaultTransferRequests: number,
     protectionRequests: number,
-}): WorkloadService {
+}>): WorkloadService {
     const locRequestRepository = new Mock<LocRequestRepository>();
     locRequestRepository.setup(instance => instance.findBy(
-        It.Is<FetchLocRequestsSpecification>(spec => spec.expectedOwnerAddress === args.legalOfficerAddress)
-    )).returnsAsync(pendingLocRequests(args.locRequests));
+        It.Is<FetchLocRequestsSpecification>(spec => spec.expectedOwnerAddress === legalOfficerAddresses)
+    )).returnsAsync(pendingLocRequests(ALICE, args.ALICE.locRequests).concat(pendingLocRequests(BOB, args.BOB.locRequests)));
 
     const vaultTransferRequestRepository = new Mock<VaultTransferRequestRepository>();
     vaultTransferRequestRepository.setup(instance => instance.findBy(
-        It.Is<FetchVaultTransferRequestsSpecification>(spec => spec.expectedLegalOfficerAddress === args.legalOfficerAddress)
-    )).returnsAsync(pendingVaultTransferRequests(args.vaultTransferRequests));
+        It.Is<FetchVaultTransferRequestsSpecification>(spec => spec.expectedLegalOfficerAddress === legalOfficerAddresses)
+    )).returnsAsync(pendingVaultTransferRequests(ALICE, args.ALICE.vaultTransferRequests).concat(pendingVaultTransferRequests(BOB, args.BOB.vaultTransferRequests)));
 
     const protectionRequestRepository = new Mock<ProtectionRequestRepository>();
     protectionRequestRepository.setup(instance => instance.findBy(
-        It.Is<FetchProtectionRequestsSpecification>(spec => spec.expectedLegalOfficerAddress === args.legalOfficerAddress)
-    )).returnsAsync(pendingProtectionRequests(args.protectionRequests));
+        It.Is<FetchProtectionRequestsSpecification>(spec => spec.expectedLegalOfficerAddress === legalOfficerAddresses)
+    )).returnsAsync(pendingProtectionRequests(ALICE, args.ALICE.protectionRequests).concat(pendingProtectionRequests(BOB, args.BOB.protectionRequests)));
 
     return new WorkloadService(
         locRequestRepository.object(),
@@ -64,14 +77,32 @@ function buildService(args: {
     );
 }
 
-function pendingLocRequests(length: number): LocRequestAggregateRoot[] {
-    return new Array(length);
+function pendingLocRequests(ownerAddress: string, length: number): LocRequestAggregateRoot[] {
+    const result = [];
+    for (let i = 0; i < length ; i++) {
+        const request = new Mock<LocRequestAggregateRoot>()
+        request.setup(instance => instance.ownerAddress).returns(ownerAddress);
+        result.push(request.object());
+    }
+    return result;
 }
 
-function pendingVaultTransferRequests(length: number): VaultTransferRequestAggregateRoot[] {
-    return new Array(length);
+function pendingVaultTransferRequests(ownerAddress: string, length: number): VaultTransferRequestAggregateRoot[] {
+    const result = [];
+    for (let i = 0; i < length ; i++) {
+        const request = new Mock<VaultTransferRequestAggregateRoot>()
+        request.setup(instance => instance.legalOfficerAddress).returns(ownerAddress);
+        result.push(request.object());
+    }
+    return result;
 }
 
-function pendingProtectionRequests(length: number): ProtectionRequestAggregateRoot[] {
-    return new Array(length);
+function pendingProtectionRequests(ownerAddress: string, length: number): ProtectionRequestAggregateRoot[] {
+    const result = [];
+    for (let i = 0; i < length ; i++) {
+        const request = new Mock<ProtectionRequestAggregateRoot>()
+        request.setup(instance => instance.legalOfficerAddress).returns(ownerAddress);
+        result.push(request.object());
+    }
+    return result;
 }


### PR DESCRIPTION
* Exposes the workload of a list of legal officers.
* Intended use is to have one call per backend, with all legal officers "hosted" on the backend given as parameter.

logion-network/logion-internal#1136