### PR TITLE
Fix: items addition/deletion forbidden for owner

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@astar-network/astar-api": "^0.2.8",
         "@astar-network/astar-sdk-core": "^0.2.8",
-        "@logion/node-api": "^0.28.2",
+        "@logion/node-api": "^0.28.3-2",
         "@logion/node-exiftool": "^2.3.1",
         "@logion/rest-api-core": "^0.4.6-1",
         "@polkadot/api-contract": "^10.10.1",

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -617,7 +617,7 @@ export class LocRequestController extends ApiController {
     @Async()
     async addFile(addFileView: AddFileView, requestId: string): Promise<void> {
         const request = requireDefined(await this.locRequestRepository.findById(requestId));
-        const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+        const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
         const hash = Hash.fromHex(requireDefined(addFileView.hash, () => badRequest("No hash found for upload file")));
         if(request.hasFile(hash)) {
             throw new Error("File already present");
@@ -717,7 +717,7 @@ export class LocRequestController extends ApiController {
     async deleteFile(_body: never, requestId: string, hash: string): Promise<void> {
         let file: FileDescription | undefined;
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
             file = request.removeFile(contributor, Hash.fromHex(hash));
         });
         if(file) {
@@ -744,7 +744,7 @@ export class LocRequestController extends ApiController {
             if (request.status !== 'OPEN') {
                 throw badRequest("LOC must be OPEN for requesting item review");
             }
-            await this.locAuthorizationService.ensureContributor(this.request, request);
+            await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
             request.requestFileReview(Hash.fromHex(hash));
         });
 
@@ -1042,7 +1042,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async addLink(addLinkView: AddLinkView, requestId: string): Promise<void> {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
             const linkParams = await this.toLink(addLinkView, contributor);
             const submissionType = accountEquals(contributor, request.getOwner()) ? "MANUAL_BY_OWNER" : "MANUAL_BY_USER";
             request.addLink(linkParams, submissionType);
@@ -1075,7 +1075,7 @@ export class LocRequestController extends ApiController {
     @Async()
     async deleteLink(_body: never, requestId: string, target: string): Promise<void> {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
             request.removeLink(contributor, target);
         });
     }
@@ -1099,7 +1099,7 @@ export class LocRequestController extends ApiController {
             if (request.status !== 'OPEN') {
                 throw badRequest("LOC must be OPEN for requesting item review");
             }
-            await this.locAuthorizationService.ensureContributor(this.request, request);
+            await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
             request.requestLinkReview(target);
         });
 
@@ -1264,7 +1264,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async addMetadata(addMetadataView: AddMetadataView, requestId: string): Promise<void> {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
             const submissionType = accountEquals(contributor, request.getOwner()) ? "MANUAL_BY_OWNER" : "MANUAL_BY_USER";
             request.addMetadataItem(this.toMetadata(addMetadataView, contributor), submissionType);
         });
@@ -1292,7 +1292,7 @@ export class LocRequestController extends ApiController {
     @Async()
     async deleteMetadata(_body: never, requestId: string, nameHash: string): Promise<void> {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
             request.removeMetadataItem(contributor, Hash.fromHex(nameHash));
         });
     }
@@ -1316,7 +1316,7 @@ export class LocRequestController extends ApiController {
             if (request.status !== 'OPEN') {
                 throw badRequest("LOC must be OPEN for requesting item review");
             }
-            await this.locAuthorizationService.ensureContributor(this.request, request);
+            await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
             request.requestMetadataItemReview(Hash.fromHex(nameHash));
         });
 

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -49,8 +49,6 @@ import { PostalAddress } from "../model/postaladdress.js";
 import { downloadAndClean, toBadRequest } from "../lib/http.js";
 import { LocRequestAdapter } from "./adapters/locrequestadapter.js";
 import { LocRequestService } from "../services/locrequest.service.js";
-import { VoteRepository } from "../model/vote.model.js";
-import { AuthenticatedUser } from "@logion/authenticator";
 import { LocAuthorizationService, Contribution } from "../services/locauthorization.service.js";
 import { accountEquals, polkadotAccount } from "../model/supportedaccountid.model.js";
 import { SponsorshipService } from "../services/sponsorship.service.js";
@@ -147,7 +145,6 @@ export class LocRequestController extends ApiController {
         private directoryService: DirectoryService,
         private locRequestAdapter: LocRequestAdapter,
         private locRequestService: LocRequestService,
-        private voteRepository: VoteRepository,
         private locAuthorizationService: LocAuthorizationService,
         private sponsorshipService: SponsorshipService,
     ) {
@@ -426,7 +423,7 @@ export class LocRequestController extends ApiController {
                 contributor: authenticatedUser,
                 voter: false
             }
-        } else if (await this.isVoterOnLoc(request, authenticatedUser)) {
+        } else if (await this.locAuthorizationService.isVoterOnLoc(request, authenticatedUser)) {
             return {
                 contributor: authenticatedUser,
                 voter: true
@@ -434,14 +431,6 @@ export class LocRequestController extends ApiController {
         } else {
             throw forbidden("Authenticated user is not allowed to view the content of this LOC");
         }
-    }
-
-    // TODO Move to loc authorization service
-    private async isVoterOnLoc(request: LocRequestAggregateRoot, authenticatedUser: AuthenticatedUser): Promise<boolean> {
-        return (
-            await authenticatedUser.isLegalOfficer() &&
-            await this.voteRepository.findByLocId(request.id!) !== null
-        );
     }
 
     static getPublicLoc(spec: OpenAPIV3.Document) {

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -51,7 +51,7 @@ import { LocRequestAdapter } from "./adapters/locrequestadapter.js";
 import { LocRequestService } from "../services/locrequest.service.js";
 import { VoteRepository } from "../model/vote.model.js";
 import { AuthenticatedUser } from "@logion/authenticator";
-import { LocAuthorizationService } from "../services/locauthorization.service.js";
+import { LocAuthorizationService, Contribution } from "../services/locauthorization.service.js";
 import { accountEquals, polkadotAccount } from "../model/supportedaccountid.model.js";
 import { SponsorshipService } from "../services/sponsorship.service.js";
 import { Hash } from "../lib/crypto/hashing.js";
@@ -421,7 +421,7 @@ export class LocRequestController extends ApiController {
 
     private async ensureContributorOrVoter(request: LocRequestAggregateRoot): Promise<{ contributor: SupportedAccountId, voter: boolean} > {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
-        if (await this.locAuthorizationService.isContributor(request, authenticatedUser)) {
+        if (await this.locAuthorizationService.isContributor(Contribution.locContribution(this.request, request), authenticatedUser)) {
             return {
                 contributor: authenticatedUser,
                 voter: false
@@ -436,6 +436,7 @@ export class LocRequestController extends ApiController {
         }
     }
 
+    // TODO Move to loc authorization service
     private async isVoterOnLoc(request: LocRequestAggregateRoot, authenticatedUser: AuthenticatedUser): Promise<boolean> {
         return (
             await authenticatedUser.isLegalOfficer() &&
@@ -617,7 +618,7 @@ export class LocRequestController extends ApiController {
     @Async()
     async addFile(addFileView: AddFileView, requestId: string): Promise<void> {
         const request = requireDefined(await this.locRequestRepository.findById(requestId));
-        const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
+        const contributor = await this.locAuthorizationService.ensureContributor(Contribution.itemContribution(this.request, request));
         const hash = Hash.fromHex(requireDefined(addFileView.hash, () => badRequest("No hash found for upload file")));
         if(request.hasFile(hash)) {
             throw new Error("File already present");
@@ -717,7 +718,7 @@ export class LocRequestController extends ApiController {
     async deleteFile(_body: never, requestId: string, hash: string): Promise<void> {
         let file: FileDescription | undefined;
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.itemContribution(this.request, request));
             file = request.removeFile(contributor, Hash.fromHex(hash));
         });
         if(file) {
@@ -744,7 +745,7 @@ export class LocRequestController extends ApiController {
             if (request.status !== 'OPEN') {
                 throw badRequest("LOC must be OPEN for requesting item review");
             }
-            await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
+            await this.locAuthorizationService.ensureContributor(Contribution.itemContribution(this.request, request));
             request.requestFileReview(Hash.fromHex(hash));
         });
 
@@ -810,7 +811,7 @@ export class LocRequestController extends ApiController {
     async prePublishOrAcknowledgeFile(_body: never, requestId: string, hashHex: string) {
         const hash = Hash.fromHex(hashHex);
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if(request.canPrePublishOrAcknowledgeFile(hash, contributor)) {
                 request.prePublishOrAcknowledgeFile(hash, contributor);
             } else {
@@ -837,7 +838,7 @@ export class LocRequestController extends ApiController {
     async cancelPrePublishOrAcknowledgeFile(_body: never, requestId: string, hashHex: string) {
         const hash = Hash.fromHex(hashHex);
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if(request.canPrePublishOrAcknowledgeFile(hash, contributor)) {
                 request.cancelPrePublishOrAcknowledgeFile(hash, contributor);
             } else {
@@ -864,7 +865,7 @@ export class LocRequestController extends ApiController {
     async preAcknowledgeFile(_body: never, requestId: string, hashHex: string) {
         const hash = Hash.fromHex(hashHex);
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if(!request.canPreAcknowledgeFile(hash, contributor)) {
                 throw unauthorized("Only owner or Verified Issuer are allowed to acknowledge");
             } else {
@@ -891,7 +892,7 @@ export class LocRequestController extends ApiController {
     async cancelPreAcknowledgeFile(_body: never, requestId: string, hashHex: string) {
         const hash = Hash.fromHex(hashHex);
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if(!request.canPreAcknowledgeFile(hash, contributor)) {
                 throw unauthorized("Only owner or Verified Issuer are allowed to acknowledge");
             } else {
@@ -1042,7 +1043,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async addLink(addLinkView: AddLinkView, requestId: string): Promise<void> {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.itemContribution(this.request, request));
             const linkParams = await this.toLink(addLinkView, contributor);
             const submissionType = accountEquals(contributor, request.getOwner()) ? "MANUAL_BY_OWNER" : "MANUAL_BY_USER";
             request.addLink(linkParams, submissionType);
@@ -1075,7 +1076,7 @@ export class LocRequestController extends ApiController {
     @Async()
     async deleteLink(_body: never, requestId: string, target: string): Promise<void> {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.itemContribution(this.request, request));
             request.removeLink(contributor, target);
         });
     }
@@ -1099,7 +1100,7 @@ export class LocRequestController extends ApiController {
             if (request.status !== 'OPEN') {
                 throw badRequest("LOC must be OPEN for requesting item review");
             }
-            await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
+            await this.locAuthorizationService.ensureContributor(Contribution.itemContribution(this.request, request));
             request.requestLinkReview(target);
         });
 
@@ -1163,7 +1164,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async prePublishOrAcknowledgeLink(_body: never, requestId: string, target: string) {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if (request.canPrePublishOrAcknowledgeLink(target, contributor)) {
                 request.prePublishOrAcknowledgeLink(target, contributor);
             } else {
@@ -1189,7 +1190,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async cancelPrePublishOrAcknowledgeLink(_body: never, requestId: string, target: string) {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if (request.canPrePublishOrAcknowledgeLink(target, contributor)) {
                 request.cancelPrePublishOrAcknowledgeLink(target, contributor);
             } else {
@@ -1215,7 +1216,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async preAcknowledgeLink(_body: never, requestId: string, target: string) {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if(!request.canPreAcknowledgeLink(target, contributor)) {
                 throw unauthorized("Only owner or Verified Issuer are allowed to acknowledge");
             } else {
@@ -1241,7 +1242,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async cancelPreAcknowledgeLink(_body: never, requestId: string, target: string) {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if(!request.canPreAcknowledgeLink(target, contributor)) {
                 throw unauthorized("Only owner or Verified Issuer are allowed to acknowledge");
             } else {
@@ -1264,7 +1265,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async addMetadata(addMetadataView: AddMetadataView, requestId: string): Promise<void> {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.itemContribution(this.request, request));
             const submissionType = accountEquals(contributor, request.getOwner()) ? "MANUAL_BY_OWNER" : "MANUAL_BY_USER";
             request.addMetadataItem(this.toMetadata(addMetadataView, contributor), submissionType);
         });
@@ -1292,7 +1293,7 @@ export class LocRequestController extends ApiController {
     @Async()
     async deleteMetadata(_body: never, requestId: string, nameHash: string): Promise<void> {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.itemContribution(this.request, request));
             request.removeMetadataItem(contributor, Hash.fromHex(nameHash));
         });
     }
@@ -1316,7 +1317,7 @@ export class LocRequestController extends ApiController {
             if (request.status !== 'OPEN') {
                 throw badRequest("LOC must be OPEN for requesting item review");
             }
-            await this.locAuthorizationService.ensureContributor(this.request, request, false, false);
+            await this.locAuthorizationService.ensureContributor(Contribution.itemContribution(this.request, request));
             request.requestMetadataItemReview(Hash.fromHex(nameHash));
         });
 
@@ -1381,7 +1382,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async prePublishOrAcknowledgeMetadataItem(_body: never, requestId: string, nameHash: string) {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             const hash = Hash.fromHex(nameHash);
             if(request.canPrePublishOrAcknowledgeMetadataItem(hash, contributor)) {
                 request.prePublishOrAcknowledgeMetadataItem(hash, contributor);
@@ -1408,7 +1409,7 @@ export class LocRequestController extends ApiController {
     @SendsResponse()
     async cancelPrePublishOrAcknowledgeMetadataItem(_body: never, requestId: string, nameHash: string) {
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             const hash = Hash.fromHex(nameHash);
             if(request.canPrePublishOrAcknowledgeMetadataItem(hash, contributor)) {
                 request.cancelPrePublishOrAcknowledgeMetadataItem(hash, contributor);
@@ -1436,7 +1437,7 @@ export class LocRequestController extends ApiController {
     async preAcknowledgeMetadataItem(_body: never, requestId: string, nameHashHex: string) {
         const nameHash = Hash.fromHex(nameHashHex);
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if(!request.canPreAcknowledgeMetadataItem(nameHash, contributor)) {
                 throw unauthorized("Only owner or Verified Issuer are allowed to acknowledge");
             } else {
@@ -1463,7 +1464,7 @@ export class LocRequestController extends ApiController {
     async cancelPreAcknowledgeMetadataItem(_body: never, requestId: string, nameHashHex: string) {
         const nameHash = Hash.fromHex(nameHashHex);
         await this.locRequestService.update(requestId, async request => {
-            const contributor = await this.locAuthorizationService.ensureContributor(this.request, request);
+            const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, request));
             if(!request.canPreAcknowledgeMetadataItem(nameHash, contributor)) {
                 throw unauthorized("Only owner or Verified Issuer are allowed to acknowledge");
             } else {
@@ -1491,7 +1492,7 @@ export class LocRequestController extends ApiController {
             () => badRequest("Missing locId"));
         const loc = requireDefined(await this.locRequestRepository.findById(locId),
             () => badRequest("LOC not found"));
-        const contributor = await this.locAuthorizationService.ensureContributor(this.request, loc);
+        const contributor = await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, loc));
 
         let description = `Statement of Facts for LOC ${ new UUID(locId).toDecimalString() }`;
         let linkNature = `Original LOC`;

--- a/src/logion/controllers/records.controller.ts
+++ b/src/logion/controllers/records.controller.ts
@@ -39,7 +39,7 @@ import { OwnershipCheckService } from "../services/ownershipcheck.service.js";
 import { RestrictedDeliveryService } from "../services/restricteddelivery.service.js";
 import { downloadAndClean } from "../lib/http.js";
 import { GetTokensRecordFileParams, LogionNodeTokensRecordService, TokensRecordService } from "../services/tokensrecord.service.js";
-import { LocAuthorizationService } from "../services/locauthorization.service.js";
+import { LocAuthorizationService, Contribution } from "../services/locauthorization.service.js";
 import { CollectionRepository } from "../model/collection.model.js";
 
 type TokensRecordView = components["schemas"]["TokensRecordView"];
@@ -217,7 +217,7 @@ export class TokensRecordController extends ApiController {
         const collectionLoc = requireDefined(await this.locRequestRepository.findById(collectionLocId),
             () => badRequest(`Collection ${ collectionLocId } not found`));
 
-        await this.locAuthorizationService.ensureContributor(this.request, collectionLoc, true);
+        await this.locAuthorizationService.ensureContributor(Contribution.recordContribution(this.request, collectionLoc));
 
         const recordId = Hash.fromHex(recordIdHex);
         const publishedTokensRecord = await this.logionNodeTokensRecordService.getTokensRecord({
@@ -423,7 +423,7 @@ export class TokensRecordController extends ApiController {
     async getAllItemDeliveries(_body: never, collectionLocId: string, recordIdHex: string): Promise<ItemDeliveriesResponse> {
         const collectionLoc = requireDefined(await this.locRequestRepository.findById(collectionLocId),
             () => badRequest(`Collection ${ collectionLocId } not found`));
-        await this.locAuthorizationService.ensureContributor(this.request, collectionLoc);
+        await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, collectionLoc));
 
         const recordId = Hash.fromHex(recordIdHex);
         return this.getItemDeliveries({ collectionLocId, recordId });
@@ -447,7 +447,7 @@ export class TokensRecordController extends ApiController {
     async downloadFileSource(_body: never, collectionLocId: string, recordIdHex: string, hashHex: string): Promise<void> {
         const collectionLoc = requireDefined(await this.locRequestRepository.findById(collectionLocId),
             () => badRequest("Collection LOC not found"));
-        await this.locAuthorizationService.ensureContributor(this.request, collectionLoc);
+        await this.locAuthorizationService.ensureContributor(Contribution.locContribution(this.request, collectionLoc));
 
         const recordId = Hash.fromHex(recordIdHex);
         const hash = Hash.fromHex(hashHex);

--- a/test/unit/controllers/locrequest.controller.creation.spec.ts
+++ b/test/unit/controllers/locrequest.controller.creation.spec.ts
@@ -22,7 +22,7 @@ import {
     mockLogionIdentityLoc,
     testData,
     checkPrivateData,
-    REQUESTER_ADDRESS,
+    POLKADOT_REQUESTER,
     EXISTING_SPONSORSHIP_ID,
     ETHEREUM_REQUESTER
 } from "./locrequest.controller.shared.js";
@@ -71,7 +71,7 @@ describe('LocRequestController - Creation -', () => {
     });
 
     it('succeeds in creating a draft LOC', async () => {
-        const mock = mockAuthenticationForUserOrLegalOfficer(false, REQUESTER_ADDRESS.address);
+        const mock = mockAuthenticationForUserOrLegalOfficer(false, POLKADOT_REQUESTER.address);
         const app = setupApp(
             LocRequestController,
             container => mockModelForCreation(container, "Transaction", undefined, true),
@@ -162,7 +162,7 @@ describe('LocRequestController - Creation -', () => {
 });
 
 async function testLocRequestCreationWithEmbeddedUserIdentity(isLegalOfficer: boolean, locType: LocType, expectedStatus: number, expectedErrorMessage?: string, hasPolkadotIdentityLoc: boolean = false) {
-    const mock = mockAuthenticationForUserOrLegalOfficer(isLegalOfficer, isLegalOfficer ? undefined : REQUESTER_ADDRESS.address);
+    const mock = mockAuthenticationForUserOrLegalOfficer(isLegalOfficer, isLegalOfficer ? undefined : POLKADOT_REQUESTER.address);
     const app = setupApp(
         LocRequestController,
         container => mockModelForCreation(container, locType, undefined, hasPolkadotIdentityLoc),
@@ -197,7 +197,7 @@ async function testLocRequestCreationWithEmbeddedUserIdentity(isLegalOfficer: bo
 }
 
 async function testLocRequestCreationWithPolkadotIdentityLoc(isLegalOfficer: boolean, locType: LocType) {
-    const mock = mockAuthenticationForUserOrLegalOfficer(isLegalOfficer, isLegalOfficer ? ALICE : REQUESTER_ADDRESS.address);
+    const mock = mockAuthenticationForUserOrLegalOfficer(isLegalOfficer, isLegalOfficer ? ALICE : POLKADOT_REQUESTER.address);
     const notificationService = new Mock<NotificationService>();
     const app = setupApp(
         LocRequestController,

--- a/test/unit/controllers/locrequest.controller.items.spec.ts
+++ b/test/unit/controllers/locrequest.controller.items.spec.ts
@@ -26,7 +26,7 @@ import {
     setUpVote,
     mockRequester,
     mockOwner,
-    REQUESTER_ADDRESS,
+    POLKADOT_REQUESTER,
 } from "./locrequest.controller.shared.js";
 import { mockAuthenticationForUserOrLegalOfficer } from "@logion/rest-api-core/dist/TestApp.js";
 import {
@@ -42,8 +42,8 @@ describe('LocRequestController - Items -', () => {
     it('adds file to loc - requester', async () => {
         const locRequest = new Mock<LocRequestAggregateRoot>();
         mockOwner(locRequest, ALICE_ACCOUNT);
-        mockRequester(locRequest, REQUESTER_ADDRESS);
-        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, REQUESTER_ADDRESS.address);
+        mockRequester(locRequest, POLKADOT_REQUESTER);
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, POLKADOT_REQUESTER.address);
         const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, 'NOT_ISSUER'), authenticatedUserMock);
         await testAddFileSuccess(app, locRequest, "MANUAL_BY_USER");
     })
@@ -51,7 +51,7 @@ describe('LocRequestController - Items -', () => {
     it('fails to add file to loc - owner', async () => {
         const locRequest = new Mock<LocRequestAggregateRoot>();
         mockOwner(locRequest, ALICE_ACCOUNT);
-        mockRequester(locRequest, REQUESTER_ADDRESS);
+        mockRequester(locRequest, POLKADOT_REQUESTER);
         const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, 'NOT_ISSUER'));
         await testAddFileForbidden(app);
     })
@@ -66,8 +66,8 @@ describe('LocRequestController - Items -', () => {
     it('fails to add file to loc with wrong hash - requester', async () => {
         const locRequest = new Mock<LocRequestAggregateRoot>();
         mockOwner(locRequest, ALICE_ACCOUNT);
-        mockRequester(locRequest, REQUESTER_ADDRESS);
-        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, REQUESTER_ADDRESS.address);
+        mockRequester(locRequest, POLKADOT_REQUESTER);
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, POLKADOT_REQUESTER.address);
         const app = setupApp(LocRequestController, container => mockModelForAddFile(container, locRequest, 'NOT_ISSUER'), authenticatedUserMock);
         const buffer = Buffer.from(SOME_DATA);
         const wrongHash = Hash.of("wrong-hash").toHex();
@@ -139,7 +139,7 @@ describe('LocRequestController - Items -', () => {
 
     it('deletes a file - requester', async () => {
         const locRequest = new Mock<LocRequestAggregateRoot>();
-        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, REQUESTER_ADDRESS.address);
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, POLKADOT_REQUESTER.address);
         const app = setupApp(LocRequestController, container => mockModelForDeleteFile(container, locRequest, 'NOT_ISSUER'), authenticatedUserMock);
         await testDeleteFileSuccess(app, locRequest, 'NOT_ISSUER');
     });
@@ -173,7 +173,7 @@ describe('LocRequestController - Items -', () => {
 
     it('adds a metadata item - requester', async () => {
         const locRequest = mockRequestForMetadata();
-        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, REQUESTER_ADDRESS.address);
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, POLKADOT_REQUESTER.address);
         const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'NOT_ISSUER'), authenticatedUserMock);
         await testAddMetadataSuccess(app, locRequest, "MANUAL_BY_USER");
     });
@@ -188,7 +188,7 @@ describe('LocRequestController - Items -', () => {
         const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, ISSUER.address);
         const locRequest = mockRequestForMetadata();
         mockOwner(locRequest, ALICE_ACCOUNT);
-        mockRequester(locRequest, REQUESTER_ADDRESS);
+        mockRequester(locRequest, POLKADOT_REQUESTER);
         const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'SELECTED'), authenticatedUserMock)
         await testAddMetadataSuccess(app, locRequest, "MANUAL_BY_USER");
     });
@@ -209,7 +209,7 @@ describe('LocRequestController - Items -', () => {
 
     it('deletes a metadata item - requester', async () => {
         const locRequest = mockRequestForMetadata();
-        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, REQUESTER_ADDRESS.address);
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, POLKADOT_REQUESTER.address);
         const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'NOT_ISSUER'), authenticatedUserMock);
         await testDeleteMetadataSuccess(app, locRequest, false);
     });
@@ -243,7 +243,7 @@ describe('LocRequestController - Items -', () => {
 
     it('adds a link - requester', async () => {
         const locRequest = mockRequestForLink();
-        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, REQUESTER_ADDRESS.address);
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, POLKADOT_REQUESTER.address);
         const app = setupApp(LocRequestController, (container) => mockModelForAddLink(container, locRequest), authenticatedUserMock);
         await request(app)
             .post(`/api/loc-request/${ REQUEST_ID }/links`)
@@ -258,7 +258,7 @@ describe('LocRequestController - Items -', () => {
     it('fails to add a link - owner', async () => {
         const locRequest = mockRequestForLink();
         mockOwner(locRequest, ALICE_ACCOUNT);
-        mockRequester(locRequest, REQUESTER_ADDRESS);
+        mockRequester(locRequest, POLKADOT_REQUESTER);
         const app = setupApp(LocRequestController, (container) => mockModelForAddLink(container, locRequest));
         await request(app)
             .post(`/api/loc-request/${ REQUEST_ID }/links`)
@@ -272,13 +272,13 @@ describe('LocRequestController - Items -', () => {
 
     it('deletes a link - requester', async () => {
         const locRequest = mockRequestForLink();
-        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, REQUESTER_ADDRESS.address);
+        const authenticatedUserMock = mockAuthenticationForUserOrLegalOfficer(false, POLKADOT_REQUESTER.address);
         const app = setupApp(LocRequestController, (container) => mockModelForAnyItem(container, locRequest, 'NOT_ISSUER'), authenticatedUserMock);
         await request(app)
             .delete(`/api/loc-request/${ REQUEST_ID }/links/${ SOME_LINK_TARGET }`)
             .expect(200)
         locRequest.verify(instance => instance.removeLink(
-            It.Is<SupportedAccountId>(account => accountEquals(account, REQUESTER_ADDRESS)),
+            It.Is<SupportedAccountId>(account => accountEquals(account, POLKADOT_REQUESTER)),
             SOME_LINK_TARGET
         ))
     })
@@ -361,12 +361,12 @@ function mockModelForDownloadFile(container: Container, issuerMode: SetupIssuerM
 
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     mockOwner(request, ALICE_ACCOUNT);
-    mockRequester(request, REQUESTER_ADDRESS);
+    mockRequester(request, POLKADOT_REQUESTER);
 
     const hash = SOME_DATA_HASH;
     request.setup(instance => instance.getFile(ItIsHash(hash))).returns({
         ...SOME_FILE,
-        submitter: issuerMode !== "NOT_ISSUER" ? ISSUER : REQUESTER_ADDRESS,
+        submitter: issuerMode !== "NOT_ISSUER" ? ISSUER : POLKADOT_REQUESTER,
     });
 
     const filePath = "/tmp/download-" + REQUEST_ID + "-" + hash.toHex();
@@ -384,7 +384,7 @@ const SOME_FILE: FileDescription = {
     hash: SOME_DATA_HASH,
     oid: SOME_OID,
     nature: "file-nature",
-    submitter: REQUESTER_ADDRESS,
+    submitter: POLKADOT_REQUESTER,
     restrictedDelivery: false,
     size: 123,
     status: "DRAFT",
@@ -424,7 +424,7 @@ function mockModelForDeleteFile(container: Container, request: Mock<LocRequestAg
 
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     mockOwner(request, ALICE_ACCOUNT);
-    mockRequester(request, REQUESTER_ADDRESS);
+    mockRequester(request, POLKADOT_REQUESTER);
 
     if (issuerMode !== 'NOT_ISSUER') {
         request.setup(instance => instance.removeFile(
@@ -454,7 +454,7 @@ async function testDeleteFileSuccess(app: Express, locRequest: Mock<LocRequestAg
         ));
     } else {
         locRequest.verify(instance => instance.removeFile(
-            It.Is<SupportedAccountId>(account => accountEquals(account, REQUESTER_ADDRESS)),
+            It.Is<SupportedAccountId>(account => accountEquals(account, POLKADOT_REQUESTER)),
             ItIsHash(SOME_DATA_HASH)
         ));
     }
@@ -492,15 +492,15 @@ const SOME_DATA_VALUE = "data value with exotic char !é\"/&'"
 function mockRequestForMetadata(): Mock<LocRequestAggregateRoot> {
     const request = mockRequest("OPEN", testData);
     mockOwner(request, ALICE_ACCOUNT);
-    mockRequester(request, REQUESTER_ADDRESS);
+    mockRequester(request, POLKADOT_REQUESTER);
     request.setup(instance => instance.removeMetadataItem(ALICE_ACCOUNT, ItIsHash(SOME_DATA_NAME_HASH)))
         .returns()
-    request.setup(instance => instance.prePublishOrAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), ItIsAccount(REQUESTER_ADDRESS.address)))
+    request.setup(instance => instance.prePublishOrAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), ItIsAccount(POLKADOT_REQUESTER.address)))
         .returns()
     request.setup(instance => instance.addMetadataItem({
         name: SOME_DATA_NAME,
         value: SOME_DATA_VALUE,
-        submitter: REQUESTER_ADDRESS
+        submitter: POLKADOT_REQUESTER
     }, "MANUAL_BY_USER"))
         .returns()
     return request;
@@ -533,7 +533,7 @@ async function testDeleteMetadataSuccess(app: Express, locRequest: Mock<LocReque
     if(isVerifiedIssuer) {
         locRequest.verify(instance => instance.removeMetadataItem(It.Is<SupportedAccountId>(account => accountEquals(account, ISSUER)), ItIsHash(SOME_DATA_NAME_HASH)));
     } else {
-        locRequest.verify(instance => instance.removeMetadataItem(It.Is<SupportedAccountId>(account => accountEquals(account, REQUESTER_ADDRESS)), ItIsHash(SOME_DATA_NAME_HASH)));
+        locRequest.verify(instance => instance.removeMetadataItem(It.Is<SupportedAccountId>(account => accountEquals(account, POLKADOT_REQUESTER)), ItIsHash(SOME_DATA_NAME_HASH)));
     }
 }
 
@@ -554,14 +554,14 @@ function mockRequestForLink(): Mock<LocRequestAggregateRoot> {
     const request = mockRequest("OPEN", testData);
     request.setup(instance => instance.removeLink(ALICE_ACCOUNT, SOME_LINK_TARGET))
         .returns()
-    request.setup(instance => instance.prePublishOrAcknowledgeLink(SOME_LINK_TARGET, ItIsAccount(REQUESTER_ADDRESS.address)))
+    request.setup(instance => instance.prePublishOrAcknowledgeLink(SOME_LINK_TARGET, ItIsAccount(POLKADOT_REQUESTER.address)))
         .returns()
     request.setup(instance => instance.addLink(
-        { target: SOME_LINK_TARGET, nature: SOME_LINK_NATURE, submitter: REQUESTER_ADDRESS },
+        { target: SOME_LINK_TARGET, nature: SOME_LINK_NATURE, submitter: POLKADOT_REQUESTER },
         It.IsAny<boolean>()
         ))
         .returns()
-    mockRequester(request, REQUESTER_ADDRESS);
+    mockRequester(request, POLKADOT_REQUESTER);
     mockOwner(request, ALICE_ACCOUNT);
     return request;
 }

--- a/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
+++ b/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
@@ -16,7 +16,7 @@ import {
     testData,
     testDataWithType,
     userIdentities,
-    REQUESTER_ADDRESS,
+    POLKADOT_REQUESTER,
 } from "./locrequest.controller.shared.js";
 import { BOB } from "../../helpers/addresses.js";
 import { SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model";
@@ -168,7 +168,7 @@ describe("LocRequestController - Life Cycle - Authenticated user opens LOC", () 
     }
 
     it('opens an accepted request', async () => {
-        const app = setupApp(LocRequestController, container => mockModelForOpen(container, "Transaction"), authenticatePolkadotRequester(REQUESTER_ADDRESS.address))
+        const app = setupApp(LocRequestController, container => mockModelForOpen(container, "Transaction"), authenticatePolkadotRequester(POLKADOT_REQUESTER.address))
         await request(app)
             .post(`/api/loc-request/${ REQUEST_ID }/open`)
             .expect(204)
@@ -246,9 +246,9 @@ function mockModelForOpen(container: Container, locType: LocType, userIdentity?:
         userIdentity
     };
     setupRequest(request, REQUEST_ID, locType, "REVIEW_ACCEPTED", data);
-    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params.address === REQUESTER_ADDRESS.address)))
+    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params.address === POLKADOT_REQUESTER.address)))
         .returns(true);
-    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params.address !== REQUESTER_ADDRESS.address)))
+    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params.address !== POLKADOT_REQUESTER.address)))
         .returns(false);
     request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params === undefined)))
         .returns(false);

--- a/test/unit/controllers/locrequest.controller.shared.ts
+++ b/test/unit/controllers/locrequest.controller.shared.ts
@@ -38,7 +38,7 @@ import { SponsorshipService } from "../../../src/logion/services/sponsorship.ser
 import { validAccountId } from "@logion/rest-api-core/dist/TestUtil.js";
 
 export type IdentityLocation = "Logion" | "Polkadot" | 'EmbeddedInLoc';
-export const REQUESTER_ADDRESS = validAccountId("5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ");
+export const POLKADOT_REQUESTER = validAccountId("5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ");
 export const ETHEREUM_REQUESTER: SupportedAccountId = {
     type: "Ethereum",
     address: "0x590E9c11b1c2f20210b9b84dc2417B4A7955d4e6"
@@ -99,7 +99,7 @@ export const userIdentities: Record<IdentityLocation, UserPrivateData> = {
 
 export function testDataWithType(locType: LocType, draft?: boolean): Partial<LocRequestDescription & { draft: boolean }> {
     return {
-        requesterAddress: REQUESTER_ADDRESS,
+        requesterAddress: POLKADOT_REQUESTER,
         requesterIdentityLoc: locType === "Identity" ? undefined : userIdentities["Polkadot"].identityLocId,
         ownerAddress: ALICE,
         description: "I want to open a case",

--- a/test/unit/controllers/locrequest.controller.shared.ts
+++ b/test/unit/controllers/locrequest.controller.shared.ts
@@ -197,6 +197,7 @@ export function buildMocks(container: Container, existingMocks?: Partial<Mocks>)
     const locAuthorizationService = new LocAuthorizationService(
         container.get(AuthenticationService),
         polkadotService.object(),
+        voteRepository.object(),
     );
     container.bind(LocAuthorizationService).toConstantValue(locAuthorizationService);
 

--- a/test/unit/controllers/records.controller.spec.ts
+++ b/test/unit/controllers/records.controller.spec.ts
@@ -490,7 +490,7 @@ function mockModel(
     container.bind(TokensRecordService).toConstantValue(new NonTransactionalTokensRecordService(tokensRecordRepository.object()));
 
     const locAuthorityService = new Mock<LocAuthorizationService>();
-    locAuthorityService.setup(instance => instance.ensureContributor(It.IsAny(), It.IsAny())).returnsAsync(ALICE_ACCOUNT);
+    locAuthorityService.setup(instance => instance.ensureContributor(It.IsAny())).returnsAsync(ALICE_ACCOUNT);
     locAuthorityService.setup(instance => instance.isContributor(It.IsAny(), It.IsAny())).returnsAsync(true);
     container.bind(LocAuthorizationService).toConstantValue(locAuthorityService.object());
 }

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -30,7 +30,7 @@ import { UUID } from "@logion/node-api";
 import { IdenfyVerificationSession, IdenfyVerificationStatus } from "src/logion/services/idenfy/idenfy.types.js";
 import { SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
 import { Hash } from "../../../src/logion/lib/crypto/hashing.js";
-import { REQUESTER_ADDRESS } from "../controllers/locrequest.controller.shared.js";
+import { POLKADOT_REQUESTER } from "../controllers/locrequest.controller.shared.js";
 
 const SUBMITTER: SupportedAccountId = {
     type: "Polkadot",
@@ -91,11 +91,11 @@ describe("LocRequestFactory", () => {
         const description = createDescription('Transaction', requesterAddress, requesterIdentityLocId);
         givenLocDescription(description);
         const metadata: MetadataItemParams[] = [
-            { name: "data01", value: "value01", submitter: REQUESTER_ADDRESS },
-            { name: "data02", value: "value02", submitter: REQUESTER_ADDRESS },
+            { name: "data01", value: "value01", submitter: POLKADOT_REQUESTER },
+            { name: "data02", value: "value02", submitter: POLKADOT_REQUESTER },
         ];
         const links: LinkParams[] = [
-            { target: "3eb0334a-3524-4eb0-bf44-e44176b72d3e", nature: "some linked loc", submitter: REQUESTER_ADDRESS }
+            { target: "3eb0334a-3524-4eb0-bf44-e44176b72d3e", nature: "some linked loc", submitter: POLKADOT_REQUESTER }
         ];
         await whenCreatingLoc(metadata, links);
         thenRequestCreatedWithDescription(description, "OPEN");
@@ -985,7 +985,7 @@ describe("LocRequestAggregateRoot (links)", () => {
             {
                 target: "target-1",
                 nature: "nature-1",
-                submitter: REQUESTER_ADDRESS,
+                submitter: POLKADOT_REQUESTER,
             },
             {
                 target: "target-2",

--- a/test/unit/services/sponsorship.service.spec.ts
+++ b/test/unit/services/sponsorship.service.spec.ts
@@ -4,7 +4,7 @@ import { LocRequestRepository, FetchLocRequestsSpecification } from "../../../sr
 import { SponsorshipService } from "../../../src/logion/services/sponsorship.service.js";
 import { PolkadotService } from "@logion/rest-api-core";
 import { ALICE_ACCOUNT, CHARLY_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
-import { REQUESTER_ADDRESS } from "../controllers/locrequest.controller.shared.js";
+import { POLKADOT_REQUESTER } from "../controllers/locrequest.controller.shared.js";
 import { polkadotAccount, SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
 import { expectAsyncToThrow } from "../../helpers/asynchelper.js";
 
@@ -25,7 +25,7 @@ describe("SponsorshipService", () => {
 
     async function testError(sponsorshipId: UUID, expectedError: string, legalOfficer?: SupportedAccountId, requester?: SupportedAccountId) {
         return expectAsyncToThrow(
-            () => service.validateSponsorship(sponsorshipId, legalOfficer ? legalOfficer : ALICE_ACCOUNT, requester ? requester : REQUESTER_ADDRESS),
+            () => service.validateSponsorship(sponsorshipId, legalOfficer ? legalOfficer : ALICE_ACCOUNT, requester ? requester : POLKADOT_REQUESTER),
             expectedError
         )
     }
@@ -48,7 +48,7 @@ describe("SponsorshipService", () => {
 
     it("throws error for wrong Legal Officer", async () => {
         const wrongLegalOfficer = CHARLY_ACCOUNT;
-        await testError(validSponsorship, "This sponsorship is not applicable to your request", wrongLegalOfficer, REQUESTER_ADDRESS)
+        await testError(validSponsorship, "This sponsorship is not applicable to your request", wrongLegalOfficer, POLKADOT_REQUESTER)
     })
 
     it("throws error for wrong Sponsored Account", async () => {
@@ -57,7 +57,7 @@ describe("SponsorshipService", () => {
     })
 
     it("validates a valid sponsorship", async () => {
-        await service.validateSponsorship(validSponsorship, ALICE_ACCOUNT, REQUESTER_ADDRESS);
+        await service.validateSponsorship(validSponsorship, ALICE_ACCOUNT, POLKADOT_REQUESTER);
     })
 })
 
@@ -77,7 +77,7 @@ function mockSponsorship(locId: UUID | undefined): Sponsorship {
         locId,
         sponsor: BOB_ACCOUNT,
         legalOfficer: ALICE_ACCOUNT,
-        sponsoredAccount: REQUESTER_ADDRESS
+        sponsoredAccount: POLKADOT_REQUESTER
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,9 +2087,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.28.2":
-  version: 0.28.2
-  resolution: "@logion/node-api@npm:0.28.2"
+"@logion/node-api@npm:^0.28.3-2":
+  version: 0.28.3-2
+  resolution: "@logion/node-api@npm:0.28.3-2"
   dependencies:
     "@polkadot/api": ^10.10.1
     "@polkadot/util": ^12.5.1
@@ -2097,7 +2097,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 011ca2e22ded811677c839f7acd772fbce1e7780d5c8f6c3ea5e96822141420c82e3066ee5417db26e1a1addd2772228fb11237f2c6ee2080a29d277802a37f7
+  checksum: cf3ce8d654f67c2c26380bdf7edd41e27fcbd96841879731a82e5d7ca44bfafd7e6f87a85fbc3eb345584266c6bb7e46fe0652353fef13aab397f781d31951f6
   languageName: node
   linkType: hard
 
@@ -7713,7 +7713,7 @@ __metadata:
     "@astar-network/astar-api": ^0.2.8
     "@astar-network/astar-sdk-core": ^0.2.8
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/node-api": ^0.28.2
+    "@logion/node-api": ^0.28.3-2
     "@logion/node-exiftool": ^2.3.1
     "@logion/rest-api-core": ^0.4.6-1
     "@polkadot/api-contract": ^10.10.1


### PR DESCRIPTION
When a LOC is requested by someone having a Polkadot address, the LLO, owner of the LOC, may not add or remove items (i.e. files, metadata or links). He cannot request reviews of those items either.

logion-network/logion-internal#1169