### PR TITLE
Manage SS58 Prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "dependencies": {
         "@astar-network/astar-api": "^0.2.8",
         "@astar-network/astar-sdk-core": "^0.2.8",
-        "@logion/node-api": "^0.28.4",
+        "@logion/node-api": "^0.29.0-3",
         "@logion/node-exiftool": "^2.3.1",
-        "@logion/rest-api-core": "^0.4.7",
+        "@logion/rest-api-core": "^0.4.8-5",
         "@polkadot/api-contract": "^10.12.4",
         "@polkadot/wasm-crypto": "^7.3.2",
         "alchemy-sdk": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "dependencies": {
         "@astar-network/astar-api": "^0.2.8",
         "@astar-network/astar-sdk-core": "^0.2.8",
-        "@logion/node-api": "^0.29.0-3",
+        "@logion/node-api": "^0.29.0-4",
         "@logion/node-exiftool": "^2.3.1",
-        "@logion/rest-api-core": "^0.4.8-6",
+        "@logion/rest-api-core": "^0.4.8-7",
         "@polkadot/api-contract": "^10.12.4",
         "@polkadot/wasm-crypto": "^7.3.2",
         "alchemy-sdk": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@astar-network/astar-api": "^0.2.8",
         "@astar-network/astar-sdk-core": "^0.2.8",
-        "@logion/node-api": "^0.29.0-4",
+        "@logion/node-api": "^0.29.0-5",
         "@logion/node-exiftool": "^2.3.1",
         "@logion/rest-api-core": "^0.4.8-7",
         "@polkadot/api-contract": "^10.12.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@astar-network/astar-sdk-core": "^0.2.8",
         "@logion/node-api": "^0.29.0-3",
         "@logion/node-exiftool": "^2.3.1",
-        "@logion/rest-api-core": "^0.4.8-5",
+        "@logion/rest-api-core": "^0.4.8-6",
         "@polkadot/api-contract": "^10.12.4",
         "@polkadot/wasm-crypto": "^7.3.2",
         "alchemy-sdk": "^3.2.0",

--- a/resources/mail/all-documented-vars.pug
+++ b/resources/mail/all-documented-vars.pug
@@ -35,7 +35,7 @@
 | #{otherLegalOfficer.postalAddress.country};
 |
 | === Protection ===
-| #{protection.requesterAddress};
+| #{protection.requesterAddress.address};
 | #{protection.otherLegalOfficerAddress};
 | #{protection.addressToRecover};
 | #{protection.createdOn};
@@ -47,7 +47,7 @@
 |
 | === LOC ===
 | #{loc.id};
-| #{loc.requesterAddress};
+| #{loc.requesterAddress.address};
 | #{loc.requesterIdentityLoc};
 | #{loc.ownerAddress};
 | #{loc.description};
@@ -71,7 +71,7 @@
 |
 | === Vault Transfer ===
 | #{vaultTransfer.id};
-| #{vaultTransfer.requesterAddress};
+| #{vaultTransfer.requesterAddress.address};
 | #{vaultTransfer.createdOn};
 | #{vaultTransfer.destination};
 | #{vaultTransfer.amount};

--- a/resources/mail/loc-requested.pug
+++ b/resources/mail/loc-requested.pug
@@ -19,10 +19,10 @@
 | #{walletUser.firstName} #{walletUser.lastName}
 |
 |
-if loc.requesterAddress
+if loc.requesterAddress.address
     | Identification key:
     | *******************
-    | #{loc.requesterAddress}
+    | #{loc.requesterAddress.address}
 else if loc.requesterIdentityLoc
     | Identification LOC:
     | *******************

--- a/resources/mail/protection-accepted.pug
+++ b/resources/mail/protection-accepted.pug
@@ -9,16 +9,16 @@
 |THE CONTENT OF THIS EMAIL IS IMPORTANT
 |***************************************
 |
-|YOU HAVE TO KEEP A COPY IN A SAFE PLACE AS IT CONTAINS MANDATORY INFORMATION 
+|YOU HAVE TO KEEP A COPY IN A SAFE PLACE AS IT CONTAINS MANDATORY INFORMATION
 |REQUESTED IN CASE OF A RECOVERY REQUEST:
-|- LOGION OFFICER DETAILS 
+|- LOGION OFFICER DETAILS
 |- AND PROTECTED ACCOUNT NUMBER
 |
 |________________________________________________________________________________
 |
-| One of your Legal Officers, #{legalOfficer.userIdentity.firstName} #{legalOfficer.userIdentity.lastName}, has accepted to protect your Polkadot account set as follows: 
+| One of your Legal Officers, #{legalOfficer.userIdentity.firstName} #{legalOfficer.userIdentity.lastName}, has accepted to protect your Polkadot account set as follows:
 |
-|#{protection.requesterAddress}.
+|#{protection.requesterAddress.address}.
 |
 |As a reminder, the Legal Officer in charge of your protection is the following one:
 |

--- a/resources/mail/protection-cancelled.pug
+++ b/resources/mail/protection-cancelled.pug
@@ -12,7 +12,7 @@
 |
 | Identification key:
 | ********************
-| #{protection.requesterAddress}
+| #{protection.requesterAddress.address}
 |
 | Email:
 | *******

--- a/resources/mail/protection-rejected.pug
+++ b/resources/mail/protection-rejected.pug
@@ -5,7 +5,7 @@
 |
 | Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
 |
-| One of your Legal Officers, #{legalOfficer.userIdentity.firstName} #{legalOfficer.userIdentity.lastName}, has refused to protect your Polkadot account set as follows: #{protection.requesterAddress}, for the following reason:
+| One of your Legal Officers, #{legalOfficer.userIdentity.firstName} #{legalOfficer.userIdentity.lastName}, has refused to protect your Polkadot account set as follows: #{protection.requesterAddress.address}, for the following reason:
 | #{protection.decision.rejectReason}
 |
 include /legal-officer-details.pug

--- a/resources/mail/protection-requested.pug
+++ b/resources/mail/protection-requested.pug
@@ -12,7 +12,7 @@
 |
 | Identification key:
 | ********************
-| #{protection.requesterAddress}
+| #{protection.requesterAddress.address}
 |
 | Email:
 | *******

--- a/resources/mail/protection-resubmitted.pug
+++ b/resources/mail/protection-resubmitted.pug
@@ -12,7 +12,7 @@
 |
 | Identification key:
 | ********************
-| #{protection.requesterAddress}
+| #{protection.requesterAddress.address}
 |
 | Email:
 | *******

--- a/resources/mail/protection-updated.pug
+++ b/resources/mail/protection-updated.pug
@@ -31,7 +31,7 @@
 |
 | Identification key:
 | ********************
-| #{protection.requesterAddress}
+| #{protection.requesterAddress.address}
 |
 | Email:
 | *******

--- a/resources/mail/recovery-accepted.pug
+++ b/resources/mail/recovery-accepted.pug
@@ -2,10 +2,10 @@
 | Dear #{walletUser.firstName} #{walletUser.lastName},
 |
 | You receive this message because you are requesting a recovery action from your Legal Officers through the logion blockchain network.
-| 
+|
 | Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
 |
-| One of your Legal Officers, #{legalOfficer.userIdentity.firstName} #{legalOfficer.userIdentity.lastName}, has accepted to let you recover all digital assets from your Polkadot account set as follows: #{protection.requesterAddress}.
+| One of your Legal Officers, #{legalOfficer.userIdentity.firstName} #{legalOfficer.userIdentity.lastName}, has accepted to let you recover all digital assets from your Polkadot account set as follows: #{protection.requesterAddress.address}.
 |
 | As a reminder, find below all details of the Legal Officer who accepted this request:
 |

--- a/resources/mail/recovery-cancelled.pug
+++ b/resources/mail/recovery-cancelled.pug
@@ -16,7 +16,7 @@
 |
 | New Identification key:
 | **************************
-| #{protection.requesterAddress}
+| #{protection.requesterAddress.address}
 |
 | Email:
 | *******

--- a/resources/mail/recovery-rejected.pug
+++ b/resources/mail/recovery-rejected.pug
@@ -4,7 +4,7 @@
 | You receive this message because you are requesting a recovery process from a Legal Officer through the logion blockchain network.
 | Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
 |
-| One of your Legal Officers, #{legalOfficer.userIdentity.firstName} #{legalOfficer.userIdentity.lastName}, has refused to let you recover assets from the Polkadot account you mentioned in your request (#{protection.requesterAddress}) for the following reason:
+| One of your Legal Officers, #{legalOfficer.userIdentity.firstName} #{legalOfficer.userIdentity.lastName}, has refused to let you recover assets from the Polkadot account you mentioned in your request (#{protection.requesterAddress.address}) for the following reason:
 | #{protection.decision.rejectReason}
 |
 | As a reminder, find below all details of the Legal Officer who refused this request:

--- a/resources/mail/recovery-requested.pug
+++ b/resources/mail/recovery-requested.pug
@@ -16,7 +16,7 @@
 |
 | New Identification key:
 | **************************
-| #{protection.requesterAddress}
+| #{protection.requesterAddress.address}
 |
 | Email:
 | *******

--- a/resources/mail/recovery-resubmitted.pug
+++ b/resources/mail/recovery-resubmitted.pug
@@ -16,7 +16,7 @@
 |
 | New Identification key:
 | **************************
-| #{protection.requesterAddress}
+| #{protection.requesterAddress.address}
 |
 | Email:
 | *******

--- a/resources/mail/review-requested.pug
+++ b/resources/mail/review-requested.pug
@@ -20,7 +20,7 @@
 |
 | Identification key:
 | *******************
-| #{loc.requesterAddress}
+| #{loc.requesterAddress.address}
 |
 | Email:
 | *******

--- a/resources/mail/sof-requested.pug
+++ b/resources/mail/sof-requested.pug
@@ -21,7 +21,7 @@
 |
 | Identification key:
 | *******************
-| #{loc.requesterAddress}
+| #{loc.requesterAddress.address}
 |
 |
 | Email:

--- a/resources/mail/vault-transfer-cancelled.pug
+++ b/resources/mail/vault-transfer-cancelled.pug
@@ -12,7 +12,7 @@
 |
 | Identification key:
 | ********************
-| #{vaultTransfer.requesterAddress}
+| #{vaultTransfer.requesterAddress.address}
 |
 | Email:
 | *******

--- a/resources/mail/vault-transfer-requested.pug
+++ b/resources/mail/vault-transfer-requested.pug
@@ -3,7 +3,7 @@
 |
 | Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
 |
-| The following user has requested your signature to validate a transfer of asset(s) from his/her vault. 
+| The following user has requested your signature to validate a transfer of asset(s) from his/her vault.
 | Please go to your logion application and start the review and approval process.
 | __________________________________________________________
 |
@@ -13,7 +13,7 @@
 |
 | Identification key:
 | ********************
-| #{vaultTransfer.requesterAddress}
+| #{vaultTransfer.requesterAddress.address}
 |
 | Email:
 | *******

--- a/src/logion/controllers/adapters/locrequestadapter.ts
+++ b/src/logion/controllers/adapters/locrequestadapter.ts
@@ -13,8 +13,7 @@ import { UserIdentity } from "../../model/useridentity.js";
 import { components } from "../components.js";
 import { VoteRepository, VoteAggregateRoot } from "../../model/vote.model.js";
 import { VerifiedIssuerAggregateRoot, VerifiedIssuerSelectionRepository } from "../../model/verifiedissuerselection.model.js";
-import { Fees } from "@logion/node-api";
-import { SupportedAccountId } from "../../model/supportedaccountid.model.js";
+import { Fees, ValidAccountId } from "@logion/node-api";
 
 export type UserPrivateData = {
     identityLocId: string | undefined,
@@ -40,7 +39,7 @@ export class LocRequestAdapter {
         private verifiedIssuerSelectionRepository: VerifiedIssuerSelectionRepository,
     ) {}
 
-    async toView(request: LocRequestAggregateRoot, viewer: SupportedAccountId, userPrivateDataArg?: UserPrivateData): Promise<LocRequestView> {
+    async toView(request: LocRequestAggregateRoot, viewer: ValidAccountId, userPrivateDataArg?: UserPrivateData): Promise<LocRequestView> {
         let userPrivateData: UserPrivateData;
         if(userPrivateDataArg) {
             userPrivateData = userPrivateDataArg;
@@ -75,7 +74,7 @@ export class LocRequestAdapter {
             id,
             requesterAddress: locDescription.requesterAddress,
             requesterIdentityLoc: locDescription.requesterIdentityLoc,
-            ownerAddress: locDescription.ownerAddress,
+            ownerAddress: locDescription.ownerAddress.address,
             description: locDescription.description,
             locType: locDescription.locType,
             identityLoc: userPrivateData.identityLocId,

--- a/src/logion/controllers/adapters/locrequestadapter.ts
+++ b/src/logion/controllers/adapters/locrequestadapter.ts
@@ -13,7 +13,7 @@ import { UserIdentity } from "../../model/useridentity.js";
 import { components } from "../components.js";
 import { VoteRepository, VoteAggregateRoot } from "../../model/vote.model.js";
 import { VerifiedIssuerAggregateRoot, VerifiedIssuerSelectionRepository } from "../../model/verifiedissuerselection.model.js";
-import { Fees, ValidAccountId } from "@logion/node-api";
+import { Fees, ValidAccountId, AccountId } from "@logion/node-api";
 
 export type UserPrivateData = {
     identityLocId: string | undefined,
@@ -28,6 +28,7 @@ type VerifiedIssuerIdentity = components["schemas"]["VerifiedIssuerIdentity"];
 type FeesView = components["schemas"]["FeesView"];
 type LocFeesView = components["schemas"]["LocFeesView"];
 type CollectionParamsView = components["schemas"]["CollectionParamsView"];
+type SupportedAccountId = components["schemas"]["SupportedAccountId"];
 
 @injectable()
 export class LocRequestAdapter {
@@ -72,7 +73,7 @@ export class LocRequestAdapter {
 
         const view: LocRequestView = {
             id,
-            requesterAddress: locDescription.requesterAddress,
+            requesterAddress: this.toSupportedAccountId(locDescription.requesterAddress),
             requesterIdentityLoc: locDescription.requesterIdentityLoc,
             ownerAddress: locDescription.ownerAddress.address,
             description: locDescription.description,
@@ -89,7 +90,7 @@ export class LocRequestAdapter {
                 name: file.name,
                 hash: file.hash.toHex(),
                 nature: file.nature,
-                submitter: file.submitter,
+                submitter: this.toSupportedAccountId(file.submitter),
                 restrictedDelivery: file.restrictedDelivery,
                 contentType: file.contentType,
                 size: file.size.toString(),
@@ -101,14 +102,14 @@ export class LocRequestAdapter {
                 name: item.name,
                 nameHash: item.nameHash.toHex(),
                 value: item.value,
-                submitter: item.submitter,
+                submitter: this.toSupportedAccountId(item.submitter),
                 fees: toFeesView(item.fees),
                 ...toLifecycleView(item),
             })),
             links: request.getLinks(viewer).map(link => ({
                 target: link.target,
                 nature: link.nature,
-                submitter: link.submitter,
+                submitter: this.toSupportedAccountId(link.submitter),
                 fees: toFeesView(link.fees),
                 ...toLifecycleView(link),
             })),
@@ -189,6 +190,16 @@ export class LocRequestAdapter {
             lastBlockSubmission: lastBlockSubmission?.toString(),
             maxSize,
             canUpload,
+        }
+    }
+
+    toSupportedAccountId(account: AccountId | undefined): SupportedAccountId | undefined {
+        if (account === undefined) {
+            return undefined;
+        }
+        return {
+            address: account.address,
+            type: account.type,
         }
     }
 }

--- a/src/logion/controllers/idenfy.controller.ts
+++ b/src/logion/controllers/idenfy.controller.ts
@@ -58,7 +58,7 @@ export class IdenfyController extends ApiController {
     async createVerificationSession(idenfyVerificationCreation: IdenfyVerificationCreationView, locId: string): Promise<IdenfyVerificationRedirectView> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
         const request = requireDefined(await this.locRequestRepository.findById(locId), () => badRequest("LOC not found"));
-        authenticatedUser.require(user => request.requesterAddress === user.address,
+        authenticatedUser.require(user => requireDefined(request.getRequester()).equals(user.toValidAccountId()),
             "Only LOC requester can start an identity verification session");
         return await this.idenfyService.createVerificationSession(request, idenfyVerificationCreation);
     }

--- a/src/logion/controllers/idenfy.controller.ts
+++ b/src/logion/controllers/idenfy.controller.ts
@@ -58,7 +58,7 @@ export class IdenfyController extends ApiController {
     async createVerificationSession(idenfyVerificationCreation: IdenfyVerificationCreationView, locId: string): Promise<IdenfyVerificationRedirectView> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
         const request = requireDefined(await this.locRequestRepository.findById(locId), () => badRequest("LOC not found"));
-        authenticatedUser.require(user => requireDefined(request.getRequester()).equals(user.toValidAccountId()),
+        authenticatedUser.require(user => requireDefined(request.getRequester()).equals(user.validAccountId),
             "Only LOC requester can start an identity verification session");
         return await this.idenfyService.createVerificationSession(request, idenfyVerificationCreation);
     }

--- a/src/logion/controllers/protectionrequest.controller.ts
+++ b/src/logion/controllers/protectionrequest.controller.ts
@@ -355,9 +355,10 @@ export class ProtectionRequestController extends ApiController {
     @SendsResponse()
     async update(updateProtectionRequestView: UpdateProtectionRequestView, id: string): Promise<void> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
+        const otherLegalOfficerAddress = ValidAccountId.polkadot(requireDefined(updateProtectionRequestView.otherLegalOfficerAddress));
         const request = await this.protectionRequestService.update(id, async request => {
             authenticatedUser.require(user => user.is(request.getRequester()));
-            request.updateOtherLegalOfficer(requireDefined(updateProtectionRequestView.otherLegalOfficerAddress));
+            request.updateOtherLegalOfficer(otherLegalOfficerAddress);
         });
         this.notify("LegalOfficer", 'protection-updated', request.getDescription());
         this.response.sendStatus(204);

--- a/src/logion/controllers/protectionrequest.controller.ts
+++ b/src/logion/controllers/protectionrequest.controller.ts
@@ -119,7 +119,7 @@ export class ProtectionRequestController extends ApiController {
         const requesterIdentityLoc = requireDefined(body.requesterIdentityLoc);
         const request = await this.protectionRequestFactory.newProtectionRequest({
             id: uuid(),
-            requesterAddress: requester.toValidAccountId(),
+            requesterAddress: requester.validAccountId,
             requesterIdentityLoc,
             legalOfficerAddress,
             otherLegalOfficerAddress: ValidAccountId.polkadot(body.otherLegalOfficerAddress),

--- a/src/logion/controllers/protectionrequest.controller.ts
+++ b/src/logion/controllers/protectionrequest.controller.ts
@@ -30,6 +30,7 @@ import { ProtectionRequestService } from '../services/protectionrequest.service.
 import { LocalsObject } from 'pug';
 import { LocRequestAdapter, UserPrivateData } from "./adapters/locrequestadapter.js";
 import { LocRequestRepository } from '../model/locrequest.model.js';
+import { ValidAccountId } from "@logion/node-api";
 
 type CreateProtectionRequestView = components["schemas"]["CreateProtectionRequestView"];
 type ProtectionRequestView = components["schemas"]["ProtectionRequestView"];
@@ -63,13 +64,13 @@ interface ProtectionRequestPublicFields {
 
     id?: string;
 
-    addressToRecover?: string | null;
+    getAddressToRecover(): ValidAccountId | null;
 
     createdOn?: string;
 
     isRecovery?: boolean;
 
-    requesterAddress?: string;
+    getRequester(): ValidAccountId;
 
     requesterIdentityLocId?: string;
 
@@ -77,9 +78,9 @@ interface ProtectionRequestPublicFields {
 
     decision?: { decisionOn?: string, rejectReason?: string };
 
-    legalOfficerAddress?: string;
+    getLegalOfficer(): ValidAccountId;
 
-    otherLegalOfficerAddress?: string;
+    getOtherLegalOfficer(): ValidAccountId;
 }
 
 @injectable()
@@ -118,13 +119,13 @@ export class ProtectionRequestController extends ApiController {
         const requesterIdentityLoc = requireDefined(body.requesterIdentityLoc);
         const request = await this.protectionRequestFactory.newProtectionRequest({
             id: uuid(),
-            requesterAddress: requester.address,
+            requesterAddress: requester.toValidAccountId(),
             requesterIdentityLoc,
             legalOfficerAddress,
-            otherLegalOfficerAddress: body.otherLegalOfficerAddress,
+            otherLegalOfficerAddress: ValidAccountId.polkadot(body.otherLegalOfficerAddress),
             createdOn: moment().toISOString(),
             isRecovery: body.isRecovery,
-            addressToRecover: body.addressToRecover || null,
+            addressToRecover: body.addressToRecover ? ValidAccountId.polkadot(body.addressToRecover) : null,
         });
         await this.protectionRequestService.add(request);
         const templateId: Template = request.isRecovery ? "recovery-requested" : "protection-requested"
@@ -148,10 +149,12 @@ export class ProtectionRequestController extends ApiController {
     @HttpPut('')
     async fetchProtectionRequests(body: FetchProtectionRequestsSpecificationView): Promise<FetchProtectionRequestsResponseView> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
-        authenticatedUser.require(user => user.isOneOf([ body.legalOfficerAddress, body.requesterAddress ]));
+        const requester = body.requesterAddress ? ValidAccountId.polkadot(body.requesterAddress) : undefined;
+        const legalOfficer = body.legalOfficerAddress ? ValidAccountId.polkadot(body.legalOfficerAddress) : undefined;
+        authenticatedUser.require(user => user.isOneOf([ legalOfficer, requester ]));
         const specification = new FetchProtectionRequestsSpecification({
-            expectedRequesterAddress: body.requesterAddress,
-            expectedLegalOfficerAddress: body.legalOfficerAddress,
+            expectedRequesterAddress: requester,
+            expectedLegalOfficerAddress: legalOfficer ? [ legalOfficer ] : undefined,
             expectedStatuses: body.statuses,
             kind: body.kind,
         });
@@ -169,10 +172,10 @@ export class ProtectionRequestController extends ApiController {
         const { userIdentity, userPostalAddress } = userPrivateData;
         return {
             id: request.id!,
-            requesterAddress: request.requesterAddress || "",
+            requesterAddress: request.getRequester().address,
             requesterIdentityLoc: request.requesterIdentityLocId,
-            legalOfficerAddress: request.legalOfficerAddress || "",
-            otherLegalOfficerAddress: request.otherLegalOfficerAddress || "",
+            legalOfficerAddress: request.getLegalOfficer().address,
+            otherLegalOfficerAddress: request.getOtherLegalOfficer().address,
             userIdentity,
             userPostalAddress,
             decision: {
@@ -181,7 +184,7 @@ export class ProtectionRequestController extends ApiController {
             },
             createdOn: request.createdOn!,
             isRecovery: request.isRecovery || false,
-            addressToRecover: request.addressToRecover || undefined,
+            addressToRecover: request.getAddressToRecover()?.address,
             status: request.status!,
         };
     }
@@ -203,7 +206,7 @@ export class ProtectionRequestController extends ApiController {
     async rejectProtectionRequest(body: RejectProtectionRequestView, id: string): Promise<ProtectionRequestView> {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
         const request = await this.protectionRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.is(request.legalOfficerAddress))
+            authenticatedUser.require(user => user.is(request.getLegalOfficer()))
             request.reject(body.rejectReason!, moment());
         });
         const templateId: Template = request.isRecovery ? "recovery-rejected" : "protection-rejected";
@@ -229,7 +232,7 @@ export class ProtectionRequestController extends ApiController {
     async acceptProtectionRequest(_body: never, id: string): Promise<ProtectionRequestView> {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
         const request = await this.protectionRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.is(request.legalOfficerAddress))
+            authenticatedUser.require(user => user.is(request.getLegalOfficer()))
             request.accept(moment());
         });
         const templateId: Template = request.isRecovery ? "recovery-accepted" : "protection-accepted";
@@ -252,7 +255,7 @@ export class ProtectionRequestController extends ApiController {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
 
         const recovery = await this.protectionRequestRepository.findById(id);
-        authenticatedUser.require(user => user.is(recovery?.legalOfficerAddress));
+        authenticatedUser.require(user => user.is(recovery?.getLegalOfficer()));
         if(recovery === null
             || !recovery.isRecovery
             || recovery.status !== 'PENDING'
@@ -262,10 +265,10 @@ export class ProtectionRequestController extends ApiController {
 
         const addressToRecover = recovery.getDescription().addressToRecover!;
         const recoveryUserPrivateData = await this.locRequestAdapter.getUserPrivateData(recovery.requesterIdentityLocId!)
-        const identityLoc = await this.locRequestRepository.getValidPolkadotIdentityLoc({
-            address: addressToRecover,
-            type: "Polkadot"
-        }, requireDefined(recovery?.legalOfficerAddress));
+        const identityLoc = await this.locRequestRepository.getValidPolkadotIdentityLoc(
+            addressToRecover,
+            recovery.getLegalOfficer()
+        );
         let accountToRecoverUserPrivateData: UserPrivateData | undefined;
         if(identityLoc) {
             const description = identityLoc.getDescription();
@@ -276,16 +279,18 @@ export class ProtectionRequestController extends ApiController {
             };
         }
         return {
-            addressToRecover,
+            addressToRecover: addressToRecover.address,
             recoveryAccount: this.adapt(recovery, recoveryUserPrivateData),
             accountToRecover: accountToRecoverUserPrivateData ? this.adapt({
+                getAddressToRecover: () => null,
                 id: "dummy",
-                legalOfficerAddress: recovery?.legalOfficerAddress,
-                requesterAddress: addressToRecover,
+                getLegalOfficer: () => recovery.getLegalOfficer(),
+                getOtherLegalOfficer: () => recovery.getOtherLegalOfficer(),
+                getRequester: () => addressToRecover,
                 requesterIdentityLocId: accountToRecoverUserPrivateData.identityLocId,
                 status: 'ACCEPTED',
                 decision: {
-                    
+
                 }
             }, accountToRecoverUserPrivateData) : undefined,
         };
@@ -305,7 +310,7 @@ export class ProtectionRequestController extends ApiController {
     async resubmit(_body: never, id: string): Promise<void> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
         const request = await this.protectionRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.is(request.requesterAddress));
+            authenticatedUser.require(user => user.is(request.getRequester()));
             request.resubmit();
         });
         this.notify("LegalOfficer", request.isRecovery ? 'recovery-resubmitted' : 'protection-resubmitted', request.getDescription());
@@ -326,7 +331,7 @@ export class ProtectionRequestController extends ApiController {
     async cancel(_body: never, id: string): Promise<void> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
         const request = await this.protectionRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.is(request.requesterAddress));
+            authenticatedUser.require(user => user.is(request.getRequester()));
             request.cancel();
         });
         this.notify("LegalOfficer", request.isRecovery ? 'recovery-cancelled' : 'protection-cancelled', request.getDescription());
@@ -351,7 +356,7 @@ export class ProtectionRequestController extends ApiController {
     async update(updateProtectionRequestView: UpdateProtectionRequestView, id: string): Promise<void> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
         const request = await this.protectionRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.is(request.requesterAddress));
+            authenticatedUser.require(user => user.is(request.getRequester()));
             request.updateOtherLegalOfficer(requireDefined(updateProtectionRequestView.otherLegalOfficerAddress));
         });
         this.notify("LegalOfficer", 'protection-updated', request.getDescription());

--- a/src/logion/controllers/vaulttransferrequest.controller.ts
+++ b/src/logion/controllers/vaulttransferrequest.controller.ts
@@ -124,13 +124,13 @@ export class VaultTransferRequestController extends ApiController {
 
     private async userAuthorizedAndProtected(origin: ValidAccountId, legalOfficerAddress: ValidAccountId): Promise<UserData> {
         const user = await this.authenticationService.authenticatedUser(this.request);
-        const data = await this.getProtectionAndRecoveryData(user.toValidAccountId(), origin, legalOfficerAddress);
+        const data = await this.getProtectionAndRecoveryData(user.validAccountId, origin, legalOfficerAddress);
 
         user.require(user =>
-            user.toValidAccountId().equals(origin) ||
+            user.validAccountId.equals(origin) ||
             data.activeRecovery !== undefined && origin === data.activeRecovery.addressToRecover);
 
-        return this.getUserDataFromProtection(user.toValidAccountId(), origin, legalOfficerAddress, data.activeRecovery, data.activeProtection);
+        return this.getUserDataFromProtection(user.validAccountId, origin, legalOfficerAddress, data.activeRecovery, data.activeProtection);
     }
 
     private async getProtectionAndRecoveryData(requester: ValidAccountId, origin: ValidAccountId, legalOfficerAddress: ValidAccountId): Promise<{
@@ -139,7 +139,7 @@ export class VaultTransferRequestController extends ApiController {
     }> {
         const activeRecovery = await this.findActiveRecovery(requester, legalOfficerAddress);
         const api = await this.polkadotService.readyApi();
-        const activeProtection = await api.queries.getRecoveryConfig(origin.address);
+        const activeProtection = await api.queries.getRecoveryConfig(origin);
 
         if(!activeRecovery && !activeProtection) {
             throw badRequest("Requester is not protected");
@@ -347,7 +347,7 @@ export class VaultTransferRequestController extends ApiController {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
 
         const request = await this.vaultTransferRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.toValidAccountId().equals(request.getDescription().requesterAddress));
+            authenticatedUser.require(user => user.validAccountId.equals(request.getDescription().requesterAddress));
             request.cancel(moment());
         });
 
@@ -366,7 +366,7 @@ export class VaultTransferRequestController extends ApiController {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
 
         const request = await this.vaultTransferRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.toValidAccountId().equals(request.getDescription().requesterAddress));
+            authenticatedUser.require(user => user.validAccountId.equals(request.getDescription().requesterAddress));
             request.resubmit();
         });
 

--- a/src/logion/controllers/vaulttransferrequest.controller.ts
+++ b/src/logion/controllers/vaulttransferrequest.controller.ts
@@ -31,7 +31,7 @@ import { VaultTransferRequestService } from '../services/vaulttransferrequest.se
 import { LocalsObject } from 'pug';
 import { UserPrivateData } from "./adapters/locrequestadapter.js";
 import { LocRequestAggregateRoot, LocRequestRepository } from '../model/locrequest.model.js';
-import { TypesRecoveryConfig } from '@logion/node-api';
+import { TypesRecoveryConfig, ValidAccountId } from '@logion/node-api';
 
 type CreateVaultTransferRequestView = components["schemas"]["CreateVaultTransferRequestView"];
 type VaultTransferRequestView = components["schemas"]["VaultTransferRequestView"];
@@ -56,7 +56,7 @@ export function fillInSpec(spec: OpenAPIV3.Document): void {
 }
 
 interface UserData {
-    requesterAddress: string;
+    requesterAddress: ValidAccountId;
     userPrivateData: UserPrivateData;
     activeRecovery?: ProtectionRequestDescription;
     activeProtection?: TypesRecoveryConfig;
@@ -94,7 +94,8 @@ export class VaultTransferRequestController extends ApiController {
     @Async()
     @HttpPost('')
     async createVaultTransferRequest(body: CreateVaultTransferRequestView): Promise<VaultTransferRequestView> {
-        const origin = requireDefined(body.origin, () => badRequest("Missing origin"))
+        const origin = ValidAccountId.polkadot(requireDefined(body.origin, () => badRequest("Missing origin")));
+        const destination = ValidAccountId.polkadot(requireDefined(body.destination, () => badRequest("Missing destination")));
         const legalOfficerAddress = await this.directoryService.requireLegalOfficerAddressOnNode(body.legalOfficerAddress);
         const protectionRequestDescription = await this.userAuthorizedAndProtected(origin, legalOfficerAddress);
 
@@ -105,7 +106,7 @@ export class VaultTransferRequestController extends ApiController {
             createdOn: moment().toISOString(),
             amount: BigInt(body.amount!),
             origin,
-            destination: body.destination!,
+            destination,
             timepoint: {
                 blockNumber: BigInt(body.block!),
                 extrinsicIndex: body.index!
@@ -121,24 +122,24 @@ export class VaultTransferRequestController extends ApiController {
         return this.adapt(request, protectionRequestDescription.userPrivateData);
     }
 
-    private async userAuthorizedAndProtected(origin: string, legalOfficerAddress: string): Promise<UserData> {
+    private async userAuthorizedAndProtected(origin: ValidAccountId, legalOfficerAddress: ValidAccountId): Promise<UserData> {
         const user = await this.authenticationService.authenticatedUser(this.request);
-        const data = await this.getProtectionAndRecoveryData(user.address, origin, legalOfficerAddress);
+        const data = await this.getProtectionAndRecoveryData(user.toValidAccountId(), origin, legalOfficerAddress);
 
         user.require(user =>
-            user.address === origin ||
+            user.toValidAccountId().equals(origin) ||
             data.activeRecovery !== undefined && origin === data.activeRecovery.addressToRecover);
 
-        return this.getUserDataFromProtection(user.address, origin, legalOfficerAddress, data.activeRecovery, data.activeProtection);
+        return this.getUserDataFromProtection(user.toValidAccountId(), origin, legalOfficerAddress, data.activeRecovery, data.activeProtection);
     }
 
-    private async getProtectionAndRecoveryData(requester: string, origin: string, legalOfficerAddress: string): Promise<{
+    private async getProtectionAndRecoveryData(requester: ValidAccountId, origin: ValidAccountId, legalOfficerAddress: ValidAccountId): Promise<{
         activeRecovery?: ProtectionRequestDescription,
         activeProtection?: TypesRecoveryConfig,
     }> {
         const activeRecovery = await this.findActiveRecovery(requester, legalOfficerAddress);
         const api = await this.polkadotService.readyApi();
-        const activeProtection = await api.queries.getRecoveryConfig(origin);
+        const activeProtection = await api.queries.getRecoveryConfig(origin.address);
 
         if(!activeRecovery && !activeProtection) {
             throw badRequest("Requester is not protected");
@@ -147,15 +148,15 @@ export class VaultTransferRequestController extends ApiController {
         return { activeProtection, activeRecovery };
     }
 
-    private async getUserData(requester: string, origin: string, legalOfficerAddress: string): Promise<UserData> {
+    private async getUserData(requester: ValidAccountId, origin: ValidAccountId, legalOfficerAddress: ValidAccountId): Promise<UserData> {
         const data = await this.getProtectionAndRecoveryData(requester, origin, legalOfficerAddress);
         return this.getUserDataFromProtection(requester, origin, legalOfficerAddress, data.activeRecovery, data.activeProtection);
     }
 
     private async getUserDataFromProtection(
-        requester: string,
-        origin: string,
-        legalOfficerAddress: string,
+        requester: ValidAccountId,
+        origin: ValidAccountId,
+        legalOfficerAddress: ValidAccountId,
         activeRecovery?: ProtectionRequestDescription,
         activeProtection?: TypesRecoveryConfig,
     ): Promise<UserData> {
@@ -167,10 +168,7 @@ export class VaultTransferRequestController extends ApiController {
         if(activeRecovery) {
             identityLoc = requireDefined(await this.locRequestRepository.findById(activeRecovery.requesterIdentityLocId));
         } else {
-            identityLoc = requireDefined(await this.locRequestRepository.getValidPolkadotIdentityLoc({
-                address: origin,
-                type: "Polkadot",
-            }, legalOfficerAddress));
+            identityLoc = requireDefined(await this.locRequestRepository.getValidPolkadotIdentityLoc(origin, legalOfficerAddress));
         }
 
         const description = identityLoc.getDescription();
@@ -186,10 +184,10 @@ export class VaultTransferRequestController extends ApiController {
         };
     }
 
-    private async findActiveRecovery(requesterAddress: string, legalOfficerAddress: string): Promise<ProtectionRequestDescription | undefined> {
+    private async findActiveRecovery(requesterAddress: ValidAccountId, legalOfficerAddress: ValidAccountId): Promise<ProtectionRequestDescription | undefined> {
         const protectionRequests = await this.protectionRequestRepository.findBy({
             expectedRequesterAddress: requesterAddress,
-            expectedLegalOfficerAddress: legalOfficerAddress,
+            expectedLegalOfficerAddress: [ legalOfficerAddress ],
             expectedStatuses: [ 'ACTIVATED' ],
             kind: 'RECOVERY'
         });
@@ -236,10 +234,12 @@ export class VaultTransferRequestController extends ApiController {
     @HttpPut('')
     async fetchVaultTransferRequests(body: FetchVaultTransferRequestsSpecificationView): Promise<FetchVaultTransferRequestsResponseView> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
-        authenticatedUser.require(user => user.isOneOf([ body.legalOfficerAddress, body.requesterAddress ]));
+        const requester = body.requesterAddress ? ValidAccountId.polkadot(body.requesterAddress) : undefined;
+        const legalOfficer = body.legalOfficerAddress ? ValidAccountId.polkadot(body.legalOfficerAddress) : undefined;
+        authenticatedUser.require(user => user.isOneOf([ requester, legalOfficer ]));
         const specification = new FetchVaultTransferRequestsSpecification({
-            expectedRequesterAddress: body.requesterAddress,
-            expectedLegalOfficerAddress: body.legalOfficerAddress,
+            expectedRequesterAddress: requester,
+            expectedLegalOfficerAddress: legalOfficer ? [ legalOfficer ] : undefined,
             expectedStatuses: body.statuses,
         });
 
@@ -247,7 +247,7 @@ export class VaultTransferRequestController extends ApiController {
         const protectionDescriptions: Record<string, UserData> = {};
         for(let i = 0; i < vaultTransferRequests.length; ++i) {
             const request = vaultTransferRequests[i].getDescription();
-            protectionDescriptions[request.requesterAddress!] ||= await this.getUserData(
+            protectionDescriptions[request.requesterAddress.address] ||= await this.getUserData(
                 request.requesterAddress,
                 request.origin,
                 request.legalOfficerAddress
@@ -255,7 +255,7 @@ export class VaultTransferRequestController extends ApiController {
         }
 
         const requests = vaultTransferRequests.map(request => {
-            const protectionDescription = protectionDescriptions[request.requesterAddress!];
+            const protectionDescription = protectionDescriptions[request.getRequester().address];
             return this.adapt(request, protectionDescription.userPrivateData);
         });
         return { requests };
@@ -267,8 +267,8 @@ export class VaultTransferRequestController extends ApiController {
             id: description.id,
             createdOn: description.createdOn,
             amount: description.amount.toString(),
-            origin: description.origin,
-            destination: description.destination,
+            origin: description.origin.address,
+            destination: description.destination.address,
             block: description.timepoint.blockNumber.toString(),
             index: description.timepoint.extrinsicIndex,
             decision: {
@@ -298,7 +298,7 @@ export class VaultTransferRequestController extends ApiController {
     async rejectVaultTransferRequest(body: RejectVaultTransferRequestView, id: string): Promise<VaultTransferRequestView> {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
         const request = await this.vaultTransferRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.is(request.legalOfficerAddress))
+            authenticatedUser.require(user => user.is(request.getLegalOfficer()))
             request.reject(body.rejectReason!, moment());
         });
 
@@ -328,7 +328,7 @@ export class VaultTransferRequestController extends ApiController {
     async acceptVaultTransferRequest(_body: never, id: string): Promise<VaultTransferRequestView> {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
         const request = await this.vaultTransferRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.is(request.legalOfficerAddress))
+            authenticatedUser.require(user => user.is(request.getLegalOfficer()))
             request.accept(moment());
         });
 
@@ -347,7 +347,7 @@ export class VaultTransferRequestController extends ApiController {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
 
         const request = await this.vaultTransferRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.address === request.getDescription().requesterAddress);
+            authenticatedUser.require(user => user.toValidAccountId().equals(request.getDescription().requesterAddress));
             request.cancel(moment());
         });
 
@@ -366,7 +366,7 @@ export class VaultTransferRequestController extends ApiController {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
 
         const request = await this.vaultTransferRequestService.update(id, async request => {
-            authenticatedUser.require(user => user.address === request.getDescription().requesterAddress);
+            authenticatedUser.require(user => user.toValidAccountId().equals(request.getDescription().requesterAddress));
             request.resubmit();
         });
 

--- a/src/logion/controllers/vote.controller.ts
+++ b/src/logion/controllers/vote.controller.ts
@@ -10,6 +10,7 @@ import {
     AuthenticationService
 } from "@logion/rest-api-core";
 import { VoteRepository, VoteAggregateRoot, Ballot, VoteResult } from "../model/vote.model.js";
+import { ValidAccountId } from "@logion/node-api";
 
 type VoteView = components["schemas"]["VoteView"];
 type FetchVotesResponseView = components["schemas"]["FetchVotesResponseView"];
@@ -51,7 +52,7 @@ export class VoteController extends ApiController {
     @HttpGet('/:legalOfficerAddress')
     async fetchVotes(_body: never, legalOfficerAddress: string): Promise<FetchVotesResponseView> {
         const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
-        authenticatedUser.require(user => user.is(legalOfficerAddress));
+        authenticatedUser.require(user => user.is(ValidAccountId.polkadot(legalOfficerAddress)));
         const votes = await this.voteRepository.findAll();
         return {
             votes: votes.map(vote => this.toView(vote))

--- a/src/logion/controllers/vote.controller.ts
+++ b/src/logion/controllers/vote.controller.ts
@@ -72,7 +72,7 @@ export class VoteController extends ApiController {
     private mapBallots(ballots: Ballot[]): BallotsMap {
         const ballotsMap: BallotsMap = {};
         for(const ballot of ballots) {
-            ballotsMap[ballot.voterAddress || "?"] = ballot.result as VoteResult;
+            ballotsMap[ballot.getVoter().address] = ballot.result as VoteResult;
         }
         return ballotsMap;
     }

--- a/src/logion/controllers/workload.controller.ts
+++ b/src/logion/controllers/workload.controller.ts
@@ -9,6 +9,7 @@ import {
     getDefaultResponses,
 } from "@logion/rest-api-core";
 import { WorkloadService } from "../services/workload.service.js";
+import { ValidAccountId } from "@logion/node-api";
 
 export function fillInSpec(spec: OpenAPIV3.Document): void {
     const tagName = 'Workload';
@@ -46,8 +47,9 @@ export class WorkloadController extends ApiController {
     @Async()
     async getWorkloads(body: FetchWorkloadsView): Promise<WorkloadView> {
         await this.authenticationService.authenticatedUser(this.request);
+        const legalOfficers = body.legalOfficerAddresses?.map((address) => ValidAccountId.polkadot(address)) || []
         return {
-            workloads: await this.workloadService.workloadOf(body.legalOfficerAddresses || []),
+            workloads: await this.workloadService.workloadOf(legalOfficers),
         }
     }
 }

--- a/src/logion/model/legalofficer.model.ts
+++ b/src/logion/model/legalofficer.model.ts
@@ -1,5 +1,6 @@
 import { PostalAddress } from "./postaladdress.js";
 import { UserIdentity } from "./useridentity.js";
+import { ValidAccountId } from "@logion/node-api";
 
 interface LegalOfficerPostalAddress extends PostalAddress {
     readonly company: string
@@ -15,6 +16,6 @@ export interface LegalOfficer {
 
 export interface LegalOfficerSettingId {
     id: string,
-    legalOfficerAddress: string,
+    legalOfficer: ValidAccountId,
 }
 

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -3,7 +3,7 @@ import moment, { Moment } from "moment";
 import { Entity, PrimaryColumn, Column, Repository, ManyToOne, JoinColumn, OneToMany, Unique, Index } from "typeorm";
 import { WhereExpressionBuilder } from "typeorm/query-builder/WhereExpressionBuilder.js";
 import { EntityManager } from "typeorm/entity-manager/EntityManager.js";
-import { Fees, UUID, Lgnt } from "@logion/node-api";
+import { Fees, UUID, Lgnt, ValidAccountId } from "@logion/node-api";
 import { appDataSource, Log, requireDefined, badRequest } from "@logion/rest-api-core";
 
 import { components } from "../controllers/components.js";
@@ -20,10 +20,10 @@ import {
 } from "../services/idenfy/idenfy.types.js";
 import { AMOUNT_PRECISION, EmbeddableStorageFees } from "./fees.js";
 import {
-    SupportedAccountId,
-    EmbeddableSupportedAccountId,
+    EmbeddableAccountId,
     accountEquals,
-    polkadotAccount
+    EmbeddableNullableAccountId,
+    DB_SS58_PREFIX
 } from "./supportedaccountid.model.js";
 import { SelectQueryBuilder } from "typeorm/query-builder/SelectQueryBuilder.js";
 import { Hash, HashTransformer } from "../lib/crypto/hashing.js";
@@ -50,9 +50,9 @@ export interface CollectionParams {
 }
 
 export interface LocRequestDescription {
-    readonly requesterAddress?: SupportedAccountId;
+    readonly requesterAddress?: ValidAccountId;
     readonly requesterIdentityLoc?: string;
-    readonly ownerAddress: string;
+    readonly ownerAddress: ValidAccountId;
     readonly description: string;
     readonly createdOn: string;
     readonly userIdentity: UserIdentity | undefined;
@@ -74,7 +74,7 @@ export interface LocRequestDecision {
 interface FileDescriptionMandatoryFields {
     readonly name: string;
     readonly hash: Hash;
-    readonly submitter: SupportedAccountId;
+    readonly submitter: ValidAccountId;
     readonly restrictedDelivery: boolean;
     readonly size: number;
 }
@@ -102,7 +102,7 @@ export interface FileDescription extends FileDescriptionMandatoryFields, ItemLif
 }
 
 interface MetadataItemDescriptionMandatoryFields {
-    readonly submitter: SupportedAccountId;
+    readonly submitter: ValidAccountId;
 }
 
 export interface MetadataItemParams extends MetadataItemDescriptionMandatoryFields {
@@ -129,7 +129,7 @@ export interface ItemLifecycle {
 export interface LinkParams {
     readonly target: string;
     readonly nature: string;
-    readonly submitter: SupportedAccountId;
+    readonly submitter: ValidAccountId;
 }
 
 export interface LinkDescription extends LinkParams, ItemLifecycle {
@@ -486,8 +486,8 @@ export class LocRequestAggregateRoot {
         this.mutateAllItems(item => item.lifecycle?.prePublishOrAcknowledge(this.isPublishAcknowledge(item)), this.links, item => item.status === "REVIEW_ACCEPTED");
     }
 
-    private isPublishAcknowledge(item: { submitter?: EmbeddableSupportedAccountId }) {
-        return item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toSupportedAccountId())
+    private isPublishAcknowledge(item: { submitter?: EmbeddableAccountId }) {
+        return item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toValidAccountId())
     }
 
     cancelPreOpen(autoPublish: boolean): void {
@@ -520,7 +520,7 @@ export class LocRequestAggregateRoot {
         return {
             requesterAddress: this.getRequester(),
             requesterIdentityLoc: this.requesterIdentityLocId,
-            ownerAddress: this.ownerAddress!,
+            ownerAddress: this.getOwner(),
             description: this.description!,
             createdOn: this.createdOn!,
             userIdentity,
@@ -539,11 +539,8 @@ export class LocRequestAggregateRoot {
         };
     }
 
-    getRequester(): SupportedAccountId | undefined {
-        return (this.requesterAddressType === "Polkadot" || this.requesterAddressType === "Ethereum") ? {
-            address: this.requesterAddress!,
-            type: this.requesterAddressType!,
-        } : undefined
+    getRequester(): ValidAccountId | undefined {
+        return this.requester?.toValidAccountId();
     }
 
     getDecision(): LocRequestDecision | undefined {
@@ -570,7 +567,7 @@ export class LocRequestAggregateRoot {
         file.contentType = fileDescription.contentType;
         file.lifecycle = EmbeddableLifecycle.fromSubmissionType(submissionType);
         file.nature = fileDescription.nature;
-        file.submitter = EmbeddableSupportedAccountId.from(fileDescription.submitter);
+        file.submitter = EmbeddableAccountId.from(fileDescription.submitter);
         file.size = fileDescription.size.toString();
         file.restrictedDelivery = fileDescription.restrictedDelivery;
         file.delivered = [];
@@ -616,57 +613,57 @@ export class LocRequestAggregateRoot {
         this.mutateFile(hash, item => item.lifecycle!.reject(reason));
     }
 
-    prePublishOrAcknowledgeFile(hash: Hash, contributor: SupportedAccountId) {
+    prePublishOrAcknowledgeFile(hash: Hash, contributor: ValidAccountId) {
         if(!this.canPrePublishOrAcknowledgeFile(hash, contributor)) {
             throw new Error("Contributor cannot confirm");
         }
-        this.mutateFile(hash, item => item.lifecycle!.prePublishOrAcknowledge(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toSupportedAccountId())));
+        this.mutateFile(hash, item => item.lifecycle!.prePublishOrAcknowledge(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toValidAccountId())));
     }
 
-    cancelPrePublishOrAcknowledgeFile(hash: Hash, contributor: SupportedAccountId) {
+    cancelPrePublishOrAcknowledgeFile(hash: Hash, contributor: ValidAccountId) {
         if(!this.canPrePublishOrAcknowledgeFile(hash, contributor)) {
             throw new Error("Contributor cannot cancel");
         }
-        this.mutateFile(hash, item => item.lifecycle!.cancelPrePublishOrAcknowledge(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toSupportedAccountId())));
+        this.mutateFile(hash, item => item.lifecycle!.cancelPrePublishOrAcknowledge(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toValidAccountId())));
     }
 
-    isOwner(account?: SupportedAccountId) {
+    isOwner(account?: ValidAccountId) {
         return accountEquals(account, this.getOwner());
     }
 
-    canPreAcknowledgeFile(hash: Hash, contributor: SupportedAccountId): boolean {
+    canPreAcknowledgeFile(hash: Hash, contributor: ValidAccountId): boolean {
         const file = this.getFileOrThrow(hash);
         return this.canPreAcknowledge(file, contributor);
     }
 
-    private canPreAcknowledge(submitted: Submitted, contributor: SupportedAccountId): boolean {
+    private canPreAcknowledge(submitted: Submitted, contributor: ValidAccountId): boolean {
         const owner = this.getOwner();
         if (accountEquals(contributor, owner)) {
             return true;
         }
-        const submitter = submitted.submitter?.toSupportedAccountId();
+        const submitter = submitted.submitter?.toValidAccountId();
         return this.isVerifiedIssuer(submitter) && accountEquals(contributor, submitter);
     }
 
-    preAcknowledgeFile(hash: Hash, contributor: SupportedAccountId, acknowledgedOn?: Moment) {
+    preAcknowledgeFile(hash: Hash, contributor: ValidAccountId, acknowledgedOn?: Moment) {
         if(!this.canPreAcknowledgeFile(hash, contributor)) {
             throw new Error("Contributor cannot ack");
         }
         this.mutateFile(hash, file => file.lifecycle!.preAcknowledge(
-            this.isVerifiedIssuer(file.submitter?.toSupportedAccountId()),
+            this.isVerifiedIssuer(file.submitter?.toValidAccountId()),
             this.isVerifiedIssuer(contributor),
             acknowledgedOn
         ))
     }
 
-    cancelPreAcknowledgeFile(hash: Hash, contributor: SupportedAccountId) {
+    cancelPreAcknowledgeFile(hash: Hash, contributor: ValidAccountId) {
         if(!this.canPreAcknowledgeFile(hash, contributor)) {
             throw new Error("Contributor cannot cancel");
         }
         this.mutateFile(hash, file => file.lifecycle!.cancelPreAcknowledge(this.isVerifiedIssuer(contributor)));
     }
 
-    canPrePublishOrAcknowledgeFile(hash: Hash, contributor: SupportedAccountId): boolean {
+    canPrePublishOrAcknowledgeFile(hash: Hash, contributor: ValidAccountId): boolean {
         this.ensureOpen();
         const file = this.getFileOrThrow(hash);
         return this.canPrePublishOrAcknowledge(file, contributor);
@@ -678,8 +675,8 @@ export class LocRequestAggregateRoot {
         }
     }
 
-    private canPrePublishOrAcknowledge(submitted: Submitted, contributor: SupportedAccountId): boolean {
-        const submitter = submitted.submitter?.toSupportedAccountId();
+    private canPrePublishOrAcknowledge(submitted: Submitted, contributor: ValidAccountId): boolean {
+        const submitter = submitted.submitter?.toValidAccountId();
         const owner = this.getOwner();
         if (submitter?.type !== "Polkadot" && accountEquals(owner, contributor)) {
             return true;
@@ -692,11 +689,11 @@ export class LocRequestAggregateRoot {
         }
     }
 
-    isRequester(account?: SupportedAccountId) {
+    isRequester(account?: ValidAccountId) {
         return accountEquals(account, this.getRequester());
     }
 
-    isVerifiedIssuer(account?: SupportedAccountId) {
+    isVerifiedIssuer(account?: ValidAccountId) {
         return !this.isOwner(account)
             && !this.isRequester(account)
     }
@@ -749,7 +746,7 @@ export class LocRequestAggregateRoot {
             oid: file!.oid,
             cid: file!.cid,
             nature: file!.nature!,
-            submitter: file!.submitter!.toSupportedAccountId(),
+            submitter: file!.submitter!.toValidAccountId(),
             restrictedDelivery: file!.restrictedDelivery || false,
             size: parseInt(file.size!),
             fees: file.fees && file.fees.getDescription(),
@@ -758,20 +755,20 @@ export class LocRequestAggregateRoot {
         };
     }
 
-    private itemViewable(item: { status?: ItemStatus, submitter?: { type?: string, address?: string } }, viewerAddress?: SupportedAccountId): boolean {
-        return item.status === 'ACKNOWLEDGED' ||
+    private itemViewable(itemStatus: ItemStatus | undefined, itemSubmitter: EmbeddableAccountId | undefined, viewerAddress?: ValidAccountId): boolean {
+        return itemStatus === 'ACKNOWLEDGED' ||
             accountEquals(viewerAddress, this.getOwner()) ||
-            accountEquals(viewerAddress, item.submitter) ||
-            (accountEquals(viewerAddress, this.getRequester()) && this.notAcknowledgedItemViewableByRequester(item));
+            accountEquals(viewerAddress, itemSubmitter?.toValidAccountId()) ||
+            (accountEquals(viewerAddress, this.getRequester()) && this.notAcknowledgedItemViewableByRequester(itemStatus, itemSubmitter));
     }
 
-    private notAcknowledgedItemViewableByRequester(item: { status?: ItemStatus, submitter?: { type?: string, address?: string } }) {
-        return accountEquals(item.submitter, this.getOwner())
-            || (item.status === "REVIEW_ACCEPTED" || item.status === "PUBLISHED"); // submitted by verified issuer
+    private notAcknowledgedItemViewableByRequester(itemStatus: ItemStatus | undefined, itemSubmitter: EmbeddableAccountId | undefined) {
+        return accountEquals(itemSubmitter?.toValidAccountId(), this.getOwner())
+            || (itemStatus === "REVIEW_ACCEPTED" || itemStatus === "PUBLISHED"); // submitted by verified issuer
     }
 
-    getFiles(viewerAddress?: SupportedAccountId): FileDescription[] {
-        return orderAndMap(this.files?.filter(item => this.itemViewable(item, viewerAddress)), file => this.toFileDescription(file));
+    getFiles(viewerAddress?: ValidAccountId): FileDescription[] {
+        return orderAndMap(this.files?.filter(item => this.itemViewable(item.status, item.submitter, viewerAddress)), file => this.toFileDescription(file));
     }
 
     open(createdOn: Moment, items: LocItems) {
@@ -812,13 +809,13 @@ export class LocRequestAggregateRoot {
     }
 
     private ensureAllItemsAckedOrPublishedOnChain() {
-        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toSupportedAccountId())) && !item.lifecycle?.isPublishedOnChain(), this.metadata)) {
+        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toValidAccountId())) && !item.lifecycle?.isPublishedOnChain(), this.metadata)) {
             throw new Error("A metadata item was not yet published nor acknowledged");
         }
-        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toSupportedAccountId())) && !item.lifecycle?.isPublishedOnChain(), this.files)) {
+        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toValidAccountId())) && !item.lifecycle?.isPublishedOnChain(), this.files)) {
             throw new Error("A file was not yet published nor acknowledged");
         }
-        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toSupportedAccountId())) && !item.lifecycle?.isPublishedOnChain(), this.links)) {
+        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toValidAccountId())) && !item.lifecycle?.isPublishedOnChain(), this.links)) {
             throw new Error("A link was not yet published nor acknowledged");
         }
     }
@@ -839,24 +836,24 @@ export class LocRequestAggregateRoot {
         }
     }
 
-    private isSubmittedByVerifiedIssuerButNotAcknowledgedOnChain(submitter?: EmbeddableSupportedAccountId, lifecycle?: EmbeddableLifecycle) {
-        return this.isVerifiedIssuer(submitter?.toSupportedAccountId()) && !lifecycle?.acknowledgedByVerifiedIssuerOn;
+    private isSubmittedByVerifiedIssuerButNotAcknowledgedOnChain(submitter?: EmbeddableAccountId, lifecycle?: EmbeddableLifecycle) {
+        return this.isVerifiedIssuer(submitter?.toValidAccountId()) && !lifecycle?.acknowledgedByVerifiedIssuerOn;
     }
 
     private ackAllItemsByOwner() {
-        this.mutateAllItems(item => item.lifecycle?.preAcknowledge(this.isVerifiedIssuer(item.submitter?.toSupportedAccountId()), false), this.metadata);
-        this.mutateAllItems(item => item.lifecycle?.preAcknowledge(this.isVerifiedIssuer(item.submitter?.toSupportedAccountId()), false), this.files);
-        this.mutateAllItems(item => item.lifecycle?.preAcknowledge(this.isVerifiedIssuer(item.submitter?.toSupportedAccountId()), false), this.links);
+        this.mutateAllItems(item => item.lifecycle?.preAcknowledge(this.isVerifiedIssuer(item.submitter?.toValidAccountId()), false), this.metadata);
+        this.mutateAllItems(item => item.lifecycle?.preAcknowledge(this.isVerifiedIssuer(item.submitter?.toValidAccountId()), false), this.files);
+        this.mutateAllItems(item => item.lifecycle?.preAcknowledge(this.isVerifiedIssuer(item.submitter?.toValidAccountId()), false), this.links);
     }
 
     private ensureAllItemsAckedOnChain() {
-        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toSupportedAccountId())), this.metadata)) {
+        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toValidAccountId())), this.metadata)) {
             throw new Error("A metadata item was not yet acknowledged");
         }
-        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toSupportedAccountId())), this.files)) {
+        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toValidAccountId())), this.files)) {
             throw new Error("A file was not yet acknowledged");
         }
-        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toSupportedAccountId())), this.links)) {
+        if(this.itemExists(item => !item.lifecycle?.isAcknowledgedOnChain(this.isVerifiedIssuer(item.submitter?.toValidAccountId())), this.links)) {
             throw new Error("A link was not yet acknowledged");
         }
     }
@@ -903,7 +900,7 @@ export class LocRequestAggregateRoot {
         item.nameHash = nameHash;
         item.value = itemDescription.value;
         item.lifecycle = EmbeddableLifecycle.fromSubmissionType(submissionType);
-        item.submitter = EmbeddableSupportedAccountId.from(itemDescription.submitter);
+        item.submitter = EmbeddableAccountId.from(itemDescription.submitter);
         item._toAdd = true;
         this.metadata!.push(item);
     }
@@ -917,14 +914,14 @@ export class LocRequestAggregateRoot {
             nameHash: item.nameHash!,
             name: item.name!,
             value: item.value!,
-            submitter: item.submitter!.toSupportedAccountId(),
+            submitter: item.submitter!.toValidAccountId(),
             fees: item.inclusionFee ? new Fees({ inclusionFee: Lgnt.fromCanonical(BigInt(item.inclusionFee)) }) : undefined,
             ...(item.lifecycle!.getDescription()),
         })
     }
 
-    getMetadataItems(viewerAddress?: SupportedAccountId): MetadataItemDescription[] {
-        return orderAndMap(this.metadata?.filter(item => this.itemViewable(item, viewerAddress)), this.toMetadataItemDescription);
+    getMetadataItems(viewerAddress?: ValidAccountId): MetadataItemDescription[] {
+        return orderAndMap(this.metadata?.filter(item => this.itemViewable(item.status, item.submitter, viewerAddress)), this.toMetadataItemDescription);
     }
 
     setMetadataItemAddedOn(nameHash: Hash, addedOn: Moment) {
@@ -937,7 +934,7 @@ export class LocRequestAggregateRoot {
         metadataItem._toUpdate = true;
     }
 
-    removeMetadataItem(remover: SupportedAccountId, nameHash: Hash): void {
+    removeMetadataItem(remover: ValidAccountId, nameHash: Hash): void {
         this.ensureEditable();
         const removedItemIndex: number = this.metadata!.findIndex(link => link.nameHash?.equalTo(nameHash));
         if (removedItemIndex === -1) {
@@ -953,8 +950,8 @@ export class LocRequestAggregateRoot {
         deleteIndexedChild(removedItemIndex, this.metadata!, this._metadataToDelete)
     }
 
-    private canRemove(address: SupportedAccountId, item: Submitted): boolean {
-        return accountEquals(address, item.submitter)
+    private canRemove(address: ValidAccountId, item: Submitted): boolean {
+        return accountEquals(address, item.submitter?.toValidAccountId())
             && (item.lifecycle?.status === "DRAFT" || item.lifecycle?.status === "REVIEW_REJECTED");
     }
 
@@ -972,26 +969,26 @@ export class LocRequestAggregateRoot {
         this.mutateMetadataItem(nameHash, item => item.lifecycle!.reject(reason));
     }
 
-    prePublishOrAcknowledgeMetadataItem(nameHash: Hash, contributor: SupportedAccountId) {
+    prePublishOrAcknowledgeMetadataItem(nameHash: Hash, contributor: ValidAccountId) {
         if(!this.canPrePublishOrAcknowledgeMetadataItem(nameHash, contributor)) {
             throw new Error("Contributor cannot confirm");
         }
-        this.mutateMetadataItem(nameHash, item => item.lifecycle!.prePublishOrAcknowledge(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toSupportedAccountId())));
+        this.mutateMetadataItem(nameHash, item => item.lifecycle!.prePublishOrAcknowledge(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toValidAccountId())));
     }
 
-    cancelPrePublishOrAcknowledgeMetadataItem(nameHash: Hash, contributor: SupportedAccountId) {
+    cancelPrePublishOrAcknowledgeMetadataItem(nameHash: Hash, contributor: ValidAccountId) {
         if(!this.canPrePublishOrAcknowledgeMetadataItem(nameHash, contributor)) {
             throw new Error("Contributor cannot confirm");
         }
-        this.mutateMetadataItem(nameHash, item => item.lifecycle!.cancelPrePublishOrAcknowledge(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toSupportedAccountId())));
+        this.mutateMetadataItem(nameHash, item => item.lifecycle!.cancelPrePublishOrAcknowledge(item.submitter?.type !== "Polkadot" || this.isOwner(item.submitter.toValidAccountId())));
     }
 
-    canPreAcknowledgeMetadataItem(nameHash: Hash, contributor: SupportedAccountId): boolean {
+    canPreAcknowledgeMetadataItem(nameHash: Hash, contributor: ValidAccountId): boolean {
         const metadata = this.getMetadataOrThrow(nameHash);
         return this.canPreAcknowledge(metadata, contributor);
     }
 
-    canPrePublishOrAcknowledgeMetadataItem(nameHash: Hash, contributor: SupportedAccountId): boolean {
+    canPrePublishOrAcknowledgeMetadataItem(nameHash: Hash, contributor: ValidAccountId): boolean {
         this.ensureOpen();
         const metadata = this.getMetadataOrThrow(nameHash);
         return this.canPrePublishOrAcknowledge(metadata, contributor);
@@ -1004,18 +1001,18 @@ export class LocRequestAggregateRoot {
         );
     }
 
-    preAcknowledgeMetadataItem(nameHash: Hash, contributor: SupportedAccountId, acknowledgedOn?: Moment) {
+    preAcknowledgeMetadataItem(nameHash: Hash, contributor: ValidAccountId, acknowledgedOn?: Moment) {
         if(!this.canPreAcknowledgeMetadataItem(nameHash, contributor)) {
             throw new Error("Contributor cannot ack");
         }
         this.mutateMetadataItem(nameHash, item => item.lifecycle!.preAcknowledge(
-            this.isVerifiedIssuer(item.submitter?.toSupportedAccountId()),
+            this.isVerifiedIssuer(item.submitter?.toValidAccountId()),
             this.isVerifiedIssuer(contributor),
             acknowledgedOn
         ))
     }
 
-    cancelPreAcknowledgeMetadataItem(nameHash: Hash, contributor: SupportedAccountId) {
+    cancelPreAcknowledgeMetadataItem(nameHash: Hash, contributor: ValidAccountId) {
         if(!this.canPreAcknowledgeMetadataItem(nameHash, contributor)) {
             throw new Error("Contributor cannot cancel");
         }
@@ -1046,7 +1043,7 @@ export class LocRequestAggregateRoot {
         file._toUpdate = true;
     }
 
-    removeFile(removerAddress: SupportedAccountId, hash: Hash): FileDescription {
+    removeFile(removerAddress: ValidAccountId, hash: Hash): FileDescription {
         this.ensureEditable();
         const removedFileIndex: number = this.files!.findIndex(file => file.hash === hash.toHex());
         if (removedFileIndex === -1) {
@@ -1075,7 +1072,7 @@ export class LocRequestAggregateRoot {
         item.target = itemDescription.target;
         item.nature = itemDescription.nature
         item.lifecycle = EmbeddableLifecycle.fromSubmissionType(submissionType);
-        item.submitter = EmbeddableSupportedAccountId.from(itemDescription.submitter);
+        item.submitter = EmbeddableAccountId.from(itemDescription.submitter);
         item._toAdd = true;
         this.links!.push(item);
     }
@@ -1088,14 +1085,14 @@ export class LocRequestAggregateRoot {
         return {
             target: link.target!,
             nature: link.nature!,
-            submitter: link.submitter!.toSupportedAccountId(),
+            submitter: link.submitter!.toValidAccountId(),
             fees: link.inclusionFee ? new Fees({ inclusionFee: Lgnt.fromCanonical(BigInt(link.inclusionFee)) }) : undefined,
             ...(link.lifecycle!.getDescription()),
         }
     }
 
-    getLinks(viewerAddress?: SupportedAccountId): LinkDescription[] {
-        return orderAndMap(this.links?.filter(link => this.itemViewable(link, viewerAddress)), this.toLinkDescription);
+    getLinks(viewerAddress?: ValidAccountId): LinkDescription[] {
+        return orderAndMap(this.links?.filter(link => this.itemViewable(link.status, link.submitter, viewerAddress)), this.toLinkDescription);
     }
 
     setLinkAddedOn(target: string, addedOn: Moment) {
@@ -1108,7 +1105,7 @@ export class LocRequestAggregateRoot {
         link._toUpdate = true;
     }
 
-    removeLink(remover: SupportedAccountId, target: string): void {
+    removeLink(remover: ValidAccountId, target: string): void {
         this.ensureEditable();
         const removedLinkIndex: number = this.links!.findIndex(link => link.target === target);
         if (removedLinkIndex === -1) {
@@ -1138,45 +1135,45 @@ export class LocRequestAggregateRoot {
         this.mutateLink(target, item => item.lifecycle!.reject(reason));
     }
 
-    prePublishOrAcknowledgeLink(target: string, contributor: SupportedAccountId) {
+    prePublishOrAcknowledgeLink(target: string, contributor: ValidAccountId) {
         if (!this.canPrePublishOrAcknowledgeLink(target, contributor)) {
             throw new Error("Contributor cannot confirm");
         }
-        this.mutateLink(target, link => link.lifecycle!.prePublishOrAcknowledge(link.submitter?.type !== "Polkadot" || this.isOwner(link.submitter.toSupportedAccountId())));
+        this.mutateLink(target, link => link.lifecycle!.prePublishOrAcknowledge(link.submitter?.type !== "Polkadot" || this.isOwner(link.submitter.toValidAccountId())));
     }
 
-    cancelPrePublishOrAcknowledgeLink(target: string, contributor: SupportedAccountId) {
+    cancelPrePublishOrAcknowledgeLink(target: string, contributor: ValidAccountId) {
         if (!this.canPrePublishOrAcknowledgeLink(target, contributor)) {
             throw new Error("Contributor cannot confirm");
         }
-        this.mutateLink(target, link => link.lifecycle!.cancelPrePublishOrAcknowledge(link.submitter?.type !== "Polkadot" || this.isOwner(link.submitter.toSupportedAccountId())));
+        this.mutateLink(target, link => link.lifecycle!.cancelPrePublishOrAcknowledge(link.submitter?.type !== "Polkadot" || this.isOwner(link.submitter.toValidAccountId())));
     }
 
-    preAcknowledgeLink(target: string, contributor: SupportedAccountId, acknowledgedOn?: Moment) {
+    preAcknowledgeLink(target: string, contributor: ValidAccountId, acknowledgedOn?: Moment) {
         if(!this.canPreAcknowledgeLink(target, contributor)) {
             throw new Error("Contributor cannot ack");
         }
         this.mutateLink(target, link => link.lifecycle!.preAcknowledge(
-            this.isVerifiedIssuer(link.submitter?.toSupportedAccountId()),
+            this.isVerifiedIssuer(link.submitter?.toValidAccountId()),
             this.isVerifiedIssuer(contributor),
             acknowledgedOn
         ))
     }
 
-    cancelPreAcknowledgeLink(target: string, contributor: SupportedAccountId) {
+    cancelPreAcknowledgeLink(target: string, contributor: ValidAccountId) {
         if(!this.canPreAcknowledgeLink(target, contributor)) {
             throw new Error("Contributor cannot ack");
         }
         this.mutateLink(target, link => link.lifecycle!.cancelPreAcknowledge(this.isVerifiedIssuer(contributor)));
     }
 
-    canPrePublishOrAcknowledgeLink(target: string, contributor: SupportedAccountId): boolean {
+    canPrePublishOrAcknowledgeLink(target: string, contributor: ValidAccountId): boolean {
         this.ensureOpen();
         const link = this.getLinkOrThrow(target);
         return this.canPrePublishOrAcknowledge(link, contributor);
     }
 
-    canPreAcknowledgeLink(target: string, contributor: SupportedAccountId): boolean {
+    canPreAcknowledgeLink(target: string, contributor: ValidAccountId): boolean {
         const link = this.getLinkOrThrow(target);
         return this.canPreAcknowledge(link, contributor);
     }
@@ -1354,22 +1351,25 @@ export class LocRequestAggregateRoot {
         link.setFee(inclusionFee);
     }
 
-    getOwner(): SupportedAccountId {
-        return polkadotAccount(this.ownerAddress || "");
+    getOwner(): ValidAccountId {
+        return ValidAccountId.polkadot(this.ownerAddress || "");
     }
 
-    canOpen(user: SupportedAccountId | undefined): boolean {
+    canOpen(user: ValidAccountId | undefined): boolean {
+        const requester = this.getRequester();
         return user !== undefined
-            && accountEquals(user, this.getRequester())
+            && requester != undefined
+            && user.equals(requester)
             && user.type === 'Polkadot'
             && (this.status === 'REVIEW_ACCEPTED' || this.status === 'OPEN')
     }
 
-    isValidPolkadotIdentityLocOrThrow(requesterAddress: string, ownerAddress: string) {
+    isValidPolkadotIdentityLocOrThrow(requesterAddress: ValidAccountId, ownerAddress: ValidAccountId) {
+        const requester = this.getRequester();
         const valid = this.locType === "Identity"
-            && this.requesterAddressType === "Polkadot"
-            && this.requesterAddress === requesterAddress
-            && this.ownerAddress === ownerAddress
+            && requester !== undefined
+            && requesterAddress.equals(requester)
+            && ownerAddress.equals(this.getOwner())
             && this.status === "CLOSED"
             && !this.isVoid();
         if (!valid) {
@@ -1383,11 +1383,8 @@ export class LocRequestAggregateRoot {
     @Column({ length: 255 })
     status?: LocRequestStatus;
 
-    @Column({ length: 255, name: "requester_address", nullable: true })
-    requesterAddress?: string;
-
-    @Column({ length: 255, name: "requester_address_type", nullable: true })
-    requesterAddressType?: string;
+    @Column(() => EmbeddableNullableAccountId, { prefix: "requester" })
+    requester?: EmbeddableNullableAccountId;
 
     // NOTE: As of 24-01-2024, the requester identity LOC is always populated for Transaction anc Collection LOCs,
     // regardless of the type identity (POLKADOT or LOGION) of the requester.
@@ -1522,8 +1519,8 @@ export class LocFile extends Child implements HasIndex, Submitted {
     @Column({ length: 255, nullable: true })
     nature?: string;
 
-    @Column(() => EmbeddableSupportedAccountId, { prefix: "submitter" })
-    submitter?: EmbeddableSupportedAccountId;
+    @Column(() => EmbeddableAccountId, { prefix: "submitter" })
+    submitter?: EmbeddableAccountId;
 
     @ManyToOne(() => LocRequestAggregateRoot, request => request.files)
     @JoinColumn({ name: "request_id", referencedColumnName: "id" })
@@ -1646,8 +1643,8 @@ export class LocMetadataItem extends Child implements HasIndex, Submitted {
     @Column("text", { name: "value", default: "", nullable: true })
     value?: string;
 
-    @Column(() => EmbeddableSupportedAccountId, { prefix: "submitter" })
-    submitter?: EmbeddableSupportedAccountId;
+    @Column(() => EmbeddableAccountId, { prefix: "submitter" })
+    submitter?: EmbeddableAccountId;
 
     @ManyToOne(() => LocRequestAggregateRoot, request => request.metadata)
     @JoinColumn({ name: "request_id" })
@@ -1679,7 +1676,7 @@ export class LocMetadataItem extends Child implements HasIndex, Submitted {
 }
 
 interface Submitted {
-    submitter?: EmbeddableSupportedAccountId;
+    submitter?: EmbeddableAccountId;
     lifecycle?: EmbeddableLifecycle;
 }
 
@@ -1711,8 +1708,8 @@ export class LocLink extends Child implements HasIndex, Submitted {
         this._toUpdate = true;
     }
 
-    @Column(() => EmbeddableSupportedAccountId, { prefix: "submitter" })
-    submitter?: EmbeddableSupportedAccountId;
+    @Column(() => EmbeddableAccountId, { prefix: "submitter" })
+    submitter?: EmbeddableAccountId;
 
     @Column(() => EmbeddableLifecycle, { prefix: "" })
     lifecycle?: EmbeddableLifecycle
@@ -1733,8 +1730,8 @@ export class LocLink extends Child implements HasIndex, Submitted {
 
 export interface FetchLocRequestsSpecification {
 
-    readonly expectedRequesterAddress?: string;
-    readonly expectedOwnerAddress?: string | string[];
+    readonly expectedRequesterAddress?: ValidAccountId;
+    readonly expectedOwnerAddress?: ValidAccountId[];
     readonly expectedStatuses?: LocRequestStatus[];
     readonly expectedLocTypes?: LocType[];
     readonly expectedIdentityLocType?: IdentityLocType;
@@ -1847,16 +1844,16 @@ export class LocRequestRepository {
 
         if (specification.expectedRequesterAddress) {
             builder.andWhere("request.requester_address = :expectedRequesterAddress",
-                { expectedRequesterAddress: specification.expectedRequesterAddress });
+                { expectedRequesterAddress: specification.expectedRequesterAddress.getAddress(DB_SS58_PREFIX) });
         }
 
         if (specification.expectedOwnerAddress !== undefined) {
-            if(typeof specification.expectedOwnerAddress === "string") {
+            if(specification.expectedOwnerAddress.length === 1) {
                 builder.andWhere("request.owner_address = :expectedOwnerAddress",
-                    { expectedOwnerAddress: specification.expectedOwnerAddress });
+                    { expectedOwnerAddress: specification.expectedOwnerAddress[0].getAddress(DB_SS58_PREFIX) });
             } else {
-                builder.andWhere("request.owner_address IN (:...expectedOwnerAddress)",
-                    { expectedOwnerAddress: specification.expectedOwnerAddress });
+                builder.andWhere("request.owner_address IN (:...expectedOwnerAddresses)",
+                    { expectedOwnerAddresses: specification.expectedOwnerAddress.map(account => account.getAddress(DB_SS58_PREFIX)) });
             }
         }
 
@@ -1942,16 +1939,16 @@ export class LocRequestRepository {
         return await this.deliveredRepository.findOneBy({ requestId, deliveredFileHash: deliveredFileHash.toHex() })
     }
 
-    async getValidPolkadotIdentityLoc(requesterAddress: SupportedAccountId | undefined, ownerAddress: string): Promise<LocRequestAggregateRoot | undefined> {
-        if (requesterAddress === undefined) {
+    async getValidPolkadotIdentityLoc(requester: ValidAccountId | undefined, owner: ValidAccountId): Promise<LocRequestAggregateRoot | undefined> {
+        if (requester === undefined) {
             return undefined;
         }
 
         const identityLoc = (await this.findBy({
             expectedLocTypes: [ "Identity" ],
-            expectedIdentityLocType: requesterAddress.type,
-            expectedRequesterAddress: requesterAddress.address,
-            expectedOwnerAddress: ownerAddress,
+            expectedIdentityLocType: requester.type,
+            expectedRequesterAddress: requester,
+            expectedOwnerAddress: [ owner ],
             expectedStatuses: [ "CLOSED" ]
         })).find(loc => loc.getVoidInfo() === null);
 
@@ -2052,15 +2049,14 @@ export class LocRequestFactory {
         request.status = params.draft ? "DRAFT" : nonDraftStatus;
 
         if (description.requesterAddress) {
-            request.requesterAddress = description.requesterAddress.address;
-            request.requesterAddressType = description.requesterAddress.type;
+            request.requester = EmbeddableNullableAccountId.from(description.requesterAddress);
         }
         if (description.requesterIdentityLoc) {
             const identityLoc = await this.repository.findById(description.requesterIdentityLoc);
             request._requesterIdentityLoc = identityLoc ? identityLoc : undefined;
             request.requesterIdentityLocId = description.requesterIdentityLoc;
         }
-        request.ownerAddress = description.ownerAddress;
+        request.ownerAddress = description.ownerAddress.getAddress(DB_SS58_PREFIX);
         request.description = description.description;
         request.locType = description.locType;
         request.createdOn = description.createdOn;

--- a/src/logion/model/lofile.model.ts
+++ b/src/logion/model/lofile.model.ts
@@ -3,6 +3,7 @@ import { injectable } from "inversify";
 
 import { appDataSource } from "@logion/rest-api-core";
 import { LegalOfficerSettingId } from "./legalofficer.model.js";
+import { DB_SS58_PREFIX } from "./supportedaccountid.model.js";
 
 @Entity("lo_file")
 export class LoFileAggregateRoot {
@@ -40,7 +41,10 @@ export class LoFileRepository {
     readonly repository: Repository<LoFileAggregateRoot>;
 
     public async findById(params: LegalOfficerSettingId): Promise<LoFileAggregateRoot | null> {
-        return this.repository.findOneBy(params)
+        return this.repository.findOneBy({
+            id: params.id,
+            legalOfficerAddress: params.legalOfficer.getAddress(DB_SS58_PREFIX)
+        })
     }
 
     public async save(root: LoFileAggregateRoot): Promise<void> {
@@ -54,7 +58,7 @@ export class LoFileFactory {
     public newLoFile(description: LoFileDescription): LoFileAggregateRoot {
         const root = new LoFileAggregateRoot();
         root.id = description.id;
-        root.legalOfficerAddress = description.legalOfficerAddress;
+        root.legalOfficerAddress = description.legalOfficer.getAddress(DB_SS58_PREFIX);
         root.contentType = description.contentType;
         root.oid = description.oid;
         return root;

--- a/src/logion/model/protectionrequest.model.ts
+++ b/src/logion/model/protectionrequest.model.ts
@@ -82,14 +82,14 @@ export class ProtectionRequestAggregateRoot {
         }
     }
 
-    updateOtherLegalOfficer(address: string) {
+    updateOtherLegalOfficer(account: ValidAccountId) {
         if(this.status === 'ACTIVATED') {
             throw badRequest("Cannot update the LO of an already activated protection")
         }
         if (this.isRecovery) {
             throw badRequest("Cannot update the LO of a recovery request")
         }
-        this.otherLegalOfficerAddress = address;
+        this.otherLegalOfficerAddress = account.getAddress(DB_SS58_PREFIX);
     }
 
     @PrimaryColumn({ type: "uuid" })

--- a/src/logion/model/setting.model.ts
+++ b/src/logion/model/setting.model.ts
@@ -2,6 +2,8 @@ import { injectable } from 'inversify';
 import { Entity, PrimaryColumn, Column, Repository } from "typeorm";
 import { appDataSource } from "@logion/rest-api-core";
 import { LegalOfficerSettingId } from "./legalofficer.model.js";
+import { DB_SS58_PREFIX } from "./supportedaccountid.model.js";
+import { ValidAccountId } from "@logion/node-api";
 
 @Entity("setting")
 export class SettingAggregateRoot {
@@ -33,12 +35,17 @@ export class SettingRepository {
         await this.repository.save(setting);
     }
 
-    async findByLegalOfficer(legalOfficerAddress: string): Promise<SettingAggregateRoot[]> {
-        return await this.repository.findBy({ legalOfficerAddress });
+    async findByLegalOfficer(legalOfficer: ValidAccountId): Promise<SettingAggregateRoot[]> {
+        return await this.repository.findBy({
+            legalOfficerAddress: legalOfficer.getAddress(DB_SS58_PREFIX)
+        });
     }
 
     async findById(params: LegalOfficerSettingId): Promise<SettingAggregateRoot | null> {
-        return await this.repository.findOneBy(params);
+        return await this.repository.findOneBy({
+            id: params.id,
+            legalOfficerAddress: params.legalOfficer.getAddress(DB_SS58_PREFIX),
+        });
     }
 }
 
@@ -50,10 +57,10 @@ export interface SettingDescription extends LegalOfficerSettingId {
 export class SettingFactory {
 
     newSetting(params: SettingDescription): SettingAggregateRoot {
-        const { id, legalOfficerAddress, value } = params;
+        const { id, legalOfficer, value } = params;
         const root = new SettingAggregateRoot();
         root.id = id;
-        root.legalOfficerAddress = legalOfficerAddress;
+        root.legalOfficerAddress = legalOfficer.getAddress(DB_SS58_PREFIX);
         root.value = value;
         return root;
     }

--- a/src/logion/model/supportedaccountid.model.ts
+++ b/src/logion/model/supportedaccountid.model.ts
@@ -1,8 +1,5 @@
-import { components } from "../controllers/components.js";
 import { Column } from "typeorm";
 import { ValidAccountId, AnyAccountId, AccountType, AccountId } from "@logion/node-api";
-
-export type SupportedAccountId = components["schemas"]["SupportedAccountId"];
 
 export class EmbeddableNullableAccountId {
 
@@ -54,13 +51,6 @@ export class EmbeddableAccountId {
         embeddable.address = validAccountId.getAddress(DB_SS58_PREFIX);
         return embeddable;
     }
-}
-
-export function accountEquals(left: ValidAccountId | undefined, right: ValidAccountId | undefined): boolean {
-    if (left === undefined || right === undefined) {
-        return false;
-    }
-    return left.equals(right);
 }
 
 export function validAccountId(account: AccountId | undefined): ValidAccountId | undefined {

--- a/src/logion/model/supportedaccountid.model.ts
+++ b/src/logion/model/supportedaccountid.model.ts
@@ -1,10 +1,38 @@
 import { components } from "../controllers/components.js";
 import { Column } from "typeorm";
+import { ValidAccountId, AnyAccountId, AccountType, AccountId } from "@logion/node-api";
 
 export type SupportedAccountId = components["schemas"]["SupportedAccountId"];
-type AddressType = components["schemas"]["AddressType"];
 
-export class EmbeddableSupportedAccountId {
+export class EmbeddableNullableAccountId {
+
+    @Column({ length: 255, name: "_address_type", nullable: true })
+    type?: string;
+
+    @Column({ length: 255, name: "_address", nullable: true })
+    address?: string;
+
+    toValidAccountId(): ValidAccountId | undefined {
+        if (this.type && this.address) {
+            const accountId = new AnyAccountId(
+                this.address,
+                this.type as AccountType
+            );
+            return accountId.toValidAccountId();
+        } else {
+            return undefined;
+        }
+    }
+
+    static from(validAccountId: ValidAccountId): EmbeddableNullableAccountId {
+        const embeddable = new EmbeddableNullableAccountId();
+        embeddable.type = validAccountId.type;
+        embeddable.address = validAccountId.getAddress(DB_SS58_PREFIX);
+        return embeddable;
+    }
+}
+
+export class EmbeddableAccountId {
 
     @Column({ length: 255, name: "_address_type" })
     type?: string;
@@ -12,41 +40,43 @@ export class EmbeddableSupportedAccountId {
     @Column({ length: 255, name: "_address" })
     address?: string;
 
-    toSupportedAccountId(): SupportedAccountId {
-        return {
-            type: (this.type || "Polkadot") as AddressType,
-            address: this.address || "",
-        }
+    toValidAccountId(): ValidAccountId {
+        const accountId = new AnyAccountId(
+            this.address || "",
+            (this.type || "Polkadot") as AccountType
+        );
+        return accountId.toValidAccountId();
     }
 
-    static from(supportedAccountId: SupportedAccountId): EmbeddableSupportedAccountId {
-        const embeddable = new EmbeddableSupportedAccountId();
-        embeddable.type = supportedAccountId.type;
-        embeddable.address = supportedAccountId.address;
+    static from(validAccountId: ValidAccountId): EmbeddableAccountId {
+        const embeddable = new EmbeddableAccountId();
+        embeddable.type = validAccountId.type;
+        embeddable.address = validAccountId.getAddress(DB_SS58_PREFIX);
         return embeddable;
     }
 }
 
-type AnyAccountId = {
-    type?: string | AddressType;
-    address?: string;
-}
-
-export function accountEquals(left: AnyAccountId | undefined, right: AnyAccountId | undefined): boolean {
-    if (
-        left === undefined || right === undefined ||
-        left.address === undefined || right.address === undefined ||
-        left.type === undefined || right.type === undefined
-    ) {
+export function accountEquals(left: ValidAccountId | undefined, right: ValidAccountId | undefined): boolean {
+    if (left === undefined || right === undefined) {
         return false;
     }
-    return left.type === right.type &&
-        left.address === right.address;
+    return left.equals(right);
 }
 
-export function polkadotAccount(address: string): SupportedAccountId {
-    return {
-        type: "Polkadot",
-        address
+export function validAccountId(account: AccountId | undefined): ValidAccountId | undefined {
+    if (account === undefined) {
+        return undefined;
     }
+    return new AnyAccountId(account.address, account.type).toValidAccountId();
 }
+
+/*
+ * Prior to Solo-to-para migration, the SS58 prefix was implicit,
+ * i.e. one user was correctly identified if and only if he/she
+ * used always the same prefix, 42.
+ *
+ * As of the migration to parachain, user must be able to be identified
+ * with an address encoded with any prefix, and find
+ * his/her data back, stored with the prefix 42.
+ */
+export const DB_SS58_PREFIX = 42;

--- a/src/logion/model/vote.model.ts
+++ b/src/logion/model/vote.model.ts
@@ -3,6 +3,8 @@ import { injectable } from "inversify";
 import { appDataSource } from "@logion/rest-api-core";
 import moment, { Moment } from "moment";
 import { Child, saveChildren } from "./child.js";
+import { ValidAccountId } from "@logion/node-api";
+import { DB_SS58_PREFIX } from "./supportedaccountid.model.js";
 
 export type VoteStatus = "PENDING" | "APPROVED" | "REJECTED";
 
@@ -36,10 +38,10 @@ export class VoteAggregateRoot {
         }
     }
 
-    addBallot(voterAddress: string, result: VoteResult) {
+    addBallot(voter: ValidAccountId, result: VoteResult) {
         const ballot = new Ballot();
         ballot.voteId = this.voteId;
-        ballot.voterAddress = voterAddress;
+        ballot.voterAddress = voter.getAddress(DB_SS58_PREFIX);
         ballot.result = result;
         ballot.vote = this;
         ballot._toAdd = true;

--- a/src/logion/model/vote.model.ts
+++ b/src/logion/model/vote.model.ts
@@ -81,6 +81,10 @@ export class Ballot extends Child {
     @ManyToOne(() => VoteAggregateRoot, request => request.ballots)
     @JoinColumn({ name: "vote_id" })
     vote?: VoteAggregateRoot;
+
+    getVoter(): ValidAccountId {
+        return ValidAccountId.polkadot(this.voterAddress || "");
+    }
 }
 
 @injectable()

--- a/src/logion/services/directory.service.ts
+++ b/src/logion/services/directory.service.ts
@@ -39,6 +39,6 @@ export class DirectoryService {
 
     async isLegalOfficerAddressOnNode(account: ValidAccountId): Promise<boolean> {
         const authorityService = await this.authorityService;
-        return (await authorityService.isLegalOfficerOnNode(account.address))
+        return (await authorityService.isLegalOfficerOnNode(account))
     }
 }

--- a/src/logion/services/directory.service.ts
+++ b/src/logion/services/directory.service.ts
@@ -3,6 +3,7 @@ import { LegalOfficer } from "../model/legalofficer.model.js";
 import axios, { AxiosInstance } from "axios";
 import { badRequest, AuthenticationSystemFactory } from "@logion/rest-api-core";
 import { AuthorityService } from "@logion/authenticator";
+import { ValidAccountId } from "@logion/node-api";
 
 @injectable()
 export class DirectoryService {
@@ -19,24 +20,25 @@ export class DirectoryService {
         this.authorityService = authenticationSystem.then(system => system.authorityService);
     }
 
-    async get(address: string): Promise<LegalOfficer> {
-        return await this.axios.get(`/api/legal-officer/${ address }`)
+    async get(account: ValidAccountId): Promise<LegalOfficer> {
+        return await this.axios.get(`/api/legal-officer/${ account.address }`)
             .then(response => response.data);
     }
 
-    async requireLegalOfficerAddressOnNode(address: string | undefined): Promise<string> {
+    async requireLegalOfficerAddressOnNode(address: string | undefined): Promise<ValidAccountId> {
         if (!address) {
             throw badRequest("Missing Legal Officer address")
         }
-        if (await this.isLegalOfficerAddressOnNode(address)) {
-            return address;
+        const account = ValidAccountId.polkadot(address);
+        if (await this.isLegalOfficerAddressOnNode(account)) {
+            return account;
         } else {
             throw badRequest(`Address ${ address } is not the one of a Legal Officer on this node.`)
         }
     }
 
-    async isLegalOfficerAddressOnNode(address: string): Promise<boolean> {
+    async isLegalOfficerAddressOnNode(account: ValidAccountId): Promise<boolean> {
         const authorityService = await this.authorityService;
-        return (await authorityService.isLegalOfficerOnNode(address))
+        return (await authorityService.isLegalOfficerOnNode(account.address))
     }
 }

--- a/src/logion/services/settings.service.ts
+++ b/src/logion/services/settings.service.ts
@@ -10,8 +10,8 @@ export abstract class SettingService {
     ) {}
 
     async createOrUpdate(params: SettingDescription) {
-        const { id, legalOfficerAddress, value } = params;
-        let setting = await this.settingRepository.findById({ id, legalOfficerAddress });
+        const { id, legalOfficer, value } = params;
+        let setting = await this.settingRepository.findById({ id, legalOfficer });
         if(setting) {
             setting.update(value);
         } else {

--- a/src/logion/services/sponsorship.service.ts
+++ b/src/logion/services/sponsorship.service.ts
@@ -2,7 +2,7 @@ import { injectable } from "inversify";
 import { Sponsorship, UUID, ValidAccountId } from "@logion/node-api";
 import { LocRequestRepository } from "../model/locrequest.model.js";
 import { PolkadotService } from "@logion/rest-api-core";
-import { accountEquals, validAccountId } from "../model/supportedaccountid.model.js";
+import { validAccountId } from "../model/supportedaccountid.model.js";
 
 @injectable()
 export class SponsorshipService {
@@ -28,8 +28,8 @@ export class SponsorshipService {
         if (await this.locRequestRepository.existsBy({ expectedSponsorshipId: sponsorshipId })) {
             throw Error("This sponsorship is already used in a draft/requested LOC")
         }
-        if (!accountEquals(validAccountId(sponsorship.legalOfficer), legalOfficer) ||
-            !accountEquals(validAccountId(sponsorship.sponsoredAccount), requester)) {
+        if (!legalOfficer.equals(validAccountId(sponsorship.legalOfficer)) ||
+            !requester.equals(validAccountId(sponsorship.sponsoredAccount))) {
             throw Error("This sponsorship is not applicable to your request")
         }
     }

--- a/src/logion/services/sponsorship.service.ts
+++ b/src/logion/services/sponsorship.service.ts
@@ -1,8 +1,8 @@
 import { injectable } from "inversify";
-import { Sponsorship, UUID } from "@logion/node-api";
+import { Sponsorship, UUID, ValidAccountId } from "@logion/node-api";
 import { LocRequestRepository } from "../model/locrequest.model.js";
 import { PolkadotService } from "@logion/rest-api-core";
-import { accountEquals, SupportedAccountId } from "../model/supportedaccountid.model.js";
+import { accountEquals, validAccountId } from "../model/supportedaccountid.model.js";
 
 @injectable()
 export class SponsorshipService {
@@ -17,7 +17,7 @@ export class SponsorshipService {
         return (await this.polkadotService.readyApi()).queries.getSponsorship(sponsorshipId);
     }
 
-    async validateSponsorship(sponsorshipId: UUID, legalOfficer: SupportedAccountId, requester: SupportedAccountId): Promise<void> {
+    async validateSponsorship(sponsorshipId: UUID, legalOfficer: ValidAccountId, requester: ValidAccountId): Promise<void> {
         const sponsorship = await this.getSponsorship(sponsorshipId);
         if (sponsorship === undefined) {
             throw new Error("Sponsorship not found")
@@ -28,8 +28,8 @@ export class SponsorshipService {
         if (await this.locRequestRepository.existsBy({ expectedSponsorshipId: sponsorshipId })) {
             throw Error("This sponsorship is already used in a draft/requested LOC")
         }
-        if (!accountEquals(sponsorship.legalOfficer, legalOfficer) ||
-            !accountEquals(sponsorship.sponsoredAccount, requester)) {
+        if (!accountEquals(validAccountId(sponsorship.legalOfficer), legalOfficer) ||
+            !accountEquals(validAccountId(sponsorship.sponsoredAccount), requester)) {
             throw Error("This sponsorship is not applicable to your request")
         }
     }

--- a/src/logion/services/transactionsync.service.ts
+++ b/src/logion/services/transactionsync.service.ts
@@ -6,6 +6,7 @@ import { TransactionService } from "./transaction.service.js";
 import { BlockWithTransactions, Transaction } from './transaction.vo.js';
 import { BlockExtrinsics } from "./types/responses/Block.js";
 import { Block } from "../model/block.model.js";
+import { ValidAccountId } from "@logion/node-api";
 
 @injectable()
 export class TransactionSynchronizer {
@@ -30,6 +31,8 @@ export class TransactionSynchronizer {
 
     private toEntity(blockWithTransactions: BlockWithTransactions, transaction: Transaction): TransactionAggregateRoot {
         const createdOn = blockWithTransactions.timestamp!.toISOString();
+        const from = ValidAccountId.polkadot(transaction.from);
+        const to = transaction.to ? ValidAccountId.polkadot(transaction.to) : null;
         const description: TransactionDescription = {
             ...transaction,
             id: uuid(),
@@ -37,6 +40,8 @@ export class TransactionSynchronizer {
                 blockNumber: blockWithTransactions.blockNumber!,
                 chainType: blockWithTransactions.chainType!,
             }),
+            from,
+            to,
             createdOn,
         };
         return this.transactionFactory.newTransaction(description);

--- a/src/logion/services/verifiedissuerselection.service.ts
+++ b/src/logion/services/verifiedissuerselection.service.ts
@@ -17,7 +17,7 @@ export abstract class VerifiedIssuerSelectionService {
     async selectUnselect(locRequest: LocRequestAggregateRoot, verifiedIssuerLocRequest: LocRequestAggregateRoot, select: boolean) {
         const id: VerifiedIssuerSelectionId = {
             locRequestId: requireDefined(locRequest.id),
-            issuer: requireDefined(verifiedIssuerLocRequest.requesterAddress),
+            issuer: requireDefined(verifiedIssuerLocRequest.getRequester()),
         };
         let selection = await this.verifiedIssuerSelectionRepository.findById(id);
         if(selection) {

--- a/src/logion/services/votesynchronization.service.ts
+++ b/src/logion/services/votesynchronization.service.ts
@@ -4,7 +4,7 @@ import { injectable } from "inversify";
 import { VoteFactory } from "../model/vote.model.js";
 import { VoteService } from "./vote.service.js";
 import { JsonExtrinsic, toString, extractUuid, findEventsData } from "./types/responses/Extrinsic.js";
-import { Adapters } from "@logion/node-api";
+import { Adapters, ValidAccountId } from "@logion/node-api";
 
 const { logger } = Log;
 
@@ -64,7 +64,7 @@ export class VoteSynchronizer {
             const closed = data[2].isTrue;
             const approved = data[3].isTrue;
 
-            const voter = Adapters.asString(ballot.voter);
+            const voter = ValidAccountId.polkadot(Adapters.asString(ballot.voter));
             const result = Adapters.asString(ballot.status);
             logger.info(`Adding ballot for voter ${voter} to vote ${voteId}`);
             await this.voteService.update(voteId, async vote => {

--- a/test/helpers/Mock.ts
+++ b/test/helpers/Mock.ts
@@ -1,6 +1,5 @@
 import { Hash, ValidAccountId } from "@logion/node-api";
 import { It } from "moq.ts";
-import { SupportedAccountId } from "../../src/logion/model/supportedaccountid.model.js";
 
 export function ItIsHash(expected: Hash) {
     return It.Is<Hash>(given => given.equalTo(expected));

--- a/test/helpers/Mock.ts
+++ b/test/helpers/Mock.ts
@@ -1,4 +1,4 @@
-import { Hash } from "@logion/node-api";
+import { Hash, ValidAccountId } from "@logion/node-api";
 import { It } from "moq.ts";
 import { SupportedAccountId } from "../../src/logion/model/supportedaccountid.model.js";
 
@@ -6,6 +6,6 @@ export function ItIsHash(expected: Hash) {
     return It.Is<Hash>(given => given.equalTo(expected));
 }
 
-export function ItIsAccount(account: string) {
-    return It.Is<SupportedAccountId>(given => given.address === account && given.type === "Polkadot");
+export function ItIsAccount(account: ValidAccountId) {
+    return It.Is<ValidAccountId>(given => given.equals(account));
 }

--- a/test/helpers/addresses.ts
+++ b/test/helpers/addresses.ts
@@ -1,10 +1,12 @@
-import { validAccountId } from "@logion/rest-api-core/dist/TestUtil.js";
+import { ValidAccountId } from "@logion/node-api";
 
-export const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+// Note to developers: in order to ensure that tests are properly configured, all addresses are encoded
+// using a different custom prefix: 0 (= Polkadot)
+export const ALICE = "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5";
 export const DEFAULT_LEGAL_OFFICER = ALICE;
-export const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
-export const CHARLY = "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y";
+export const BOB = "14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3";
+export const CHARLY = "14Gjs1TD93gnwEBfDMHoCgsuf1s2TVKUP6Z1qKmAZnZ8cW5q";
 
-export const ALICE_ACCOUNT = validAccountId(ALICE);
-export const BOB_ACCOUNT = validAccountId(BOB);
-export const CHARLY_ACCOUNT = validAccountId(CHARLY);
+export const ALICE_ACCOUNT = ValidAccountId.polkadot(ALICE);
+export const BOB_ACCOUNT = ValidAccountId.polkadot(BOB);
+export const CHARLY_ACCOUNT = ValidAccountId.polkadot(CHARLY);

--- a/test/helpers/addresses.ts
+++ b/test/helpers/addresses.ts
@@ -1,9 +1,13 @@
 import { ValidAccountId } from "@logion/node-api";
 
-// Note to developers: in order to ensure that tests are properly configured, all addresses are encoded
+// Note to developers: Addresses are encoded
 // using a different custom prefix: 0 (= Polkadot)
+// As a consequence, those 3 constants should be used only in REST API URL or payload,
+// where prefix is irrelevant.
+//
+// For any other usage, (i.e. mocking behavior, asserting value, etc.)
+// You should use either ALICE_ACCOUNT.getAddress(DB_SS58_PREFIX) or ALICE_ACCOUNT.address
 export const ALICE = "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5";
-export const DEFAULT_LEGAL_OFFICER = ALICE;
 export const BOB = "14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3";
 export const CHARLY = "14Gjs1TD93gnwEBfDMHoCgsuf1s2TVKUP6Z1qKmAZnZ8cW5q";
 

--- a/test/integration/model/lofile.model.spec.ts
+++ b/test/integration/model/lofile.model.spec.ts
@@ -1,7 +1,8 @@
 import { LoFileRepository, LoFileAggregateRoot, LoFileDescription } from "../../../src/logion/model/lofile.model.js";
 import { TestDb } from "@logion/rest-api-core";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import { LegalOfficerSettingId } from "../../../src/logion/model/legalofficer.model.js";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 
@@ -21,13 +22,13 @@ describe("LoFileRepository", () => {
 
 
     it("finds a file", async () => {
-        const params: LegalOfficerSettingId = { id: "sof-header", legalOfficerAddress: ALICE };
+        const params: LegalOfficerSettingId = { id: "sof-header", legalOfficer: ALICE_ACCOUNT };
         const loFile = await repository.findById(params);
         check(loFile, { ...params, contentType: "image/png", oid: 123 });
     })
 
     it("updates an existing file", async () => {
-        const params: LegalOfficerSettingId = { id: "sof-oath", legalOfficerAddress: ALICE };
+        const params: LegalOfficerSettingId = { id: "sof-oath", legalOfficer: ALICE_ACCOUNT };
         const loFile = await repository.findById(params);
         check(loFile, { ...params, contentType: "image/jpeg", oid: 456 });
 
@@ -46,9 +47,9 @@ describe("LoFileRepository", () => {
     })
 
     function check(loFile: LoFileAggregateRoot | null, description: LoFileDescription) {
-        const { id, legalOfficerAddress, contentType, oid } = description;
+        const { id, legalOfficer, contentType, oid } = description;
         expect(loFile?.id).toEqual(id)
-        expect(loFile?.legalOfficerAddress).toEqual(legalOfficerAddress)
+        expect(loFile?.legalOfficerAddress).toEqual(legalOfficer.getAddress(DB_SS58_PREFIX))
         expect(loFile?.contentType).toEqual(contentType)
         expect(loFile?.oid).toEqual(oid)
     }

--- a/test/integration/model/setting.model.spec.ts
+++ b/test/integration/model/setting.model.spec.ts
@@ -1,6 +1,7 @@
 import { TestDb } from "@logion/rest-api-core";
 import { SettingRepository, SettingAggregateRoot } from "../../../src/logion/model/setting.model.js";
-import { ALICE, BOB, CHARLY } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT, CHARLY_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 const { connect, disconnect, executeScript } = TestDb;
 
@@ -19,12 +20,12 @@ describe("LoFileRepository", () => {
     });
 
     it("finds by id", async () => {
-        const setting = await repository.findById({ id: "setting-1", legalOfficerAddress: ALICE });
+        const setting = await repository.findById({ id: "setting-1", legalOfficer: ALICE_ACCOUNT });
         expect(setting?.value).toEqual("value-1");
     })
 
     it("finds by legal officer", async () => {
-        const settings = await repository.findByLegalOfficer(ALICE);
+        const settings = await repository.findByLegalOfficer(ALICE_ACCOUNT);
         checkArray(settings, ["value-1", "value-2"])
     })
 
@@ -32,10 +33,10 @@ describe("LoFileRepository", () => {
         const setting = new SettingAggregateRoot();
         setting.id = "setting-3";
         setting.value = "value-3";
-        setting.legalOfficerAddress = CHARLY;
+        setting.legalOfficerAddress = CHARLY_ACCOUNT.getAddress(DB_SS58_PREFIX);
         await repository.save(setting);
 
-        const settings = await repository.findByLegalOfficer(CHARLY);
+        const settings = await repository.findByLegalOfficer(CHARLY_ACCOUNT);
         checkArray(settings, ["charly-value-1", "charly-value-2", "value-3"])
     })
 
@@ -44,10 +45,10 @@ describe("LoFileRepository", () => {
         const setting = new SettingAggregateRoot();
         setting.id = "setting-2";
         setting.value = "new-value-2";
-        setting.legalOfficerAddress = BOB;
+        setting.legalOfficerAddress = BOB_ACCOUNT.getAddress(DB_SS58_PREFIX);
         await repository.save(setting);
 
-        const settings = await repository.findByLegalOfficer(BOB);
+        const settings = await repository.findByLegalOfficer(BOB_ACCOUNT);
         checkArray(settings, ["bob-value-1", "new-value-2"])
     })
 

--- a/test/integration/model/transaction.model.spec.ts
+++ b/test/integration/model/transaction.model.spec.ts
@@ -6,6 +6,7 @@ import {
 import moment from "moment";
 import { EmbeddableFees } from "../../../src/logion/model/fees.js";
 import { Block, EmbeddableBlock } from "../../../src/logion/model/block.model.js";
+import { ValidAccountId } from "@logion/node-api";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 
@@ -24,22 +25,26 @@ describe('TransactionRepository', () => {
     });
 
     it("finds transactions of 5DPPdRwkgigKt2L7jxRfAoV4tfS89KgXsx47Wk3Kat5K6xPg", async () => {
-        const transactions = await repository.findBy({ address: "5DPPdRwkgigKt2L7jxRfAoV4tfS89KgXsx47Wk3Kat5K6xPg", chainType: "Solo" });
+        const account = ValidAccountId.polkadot("5DPPdRwkgigKt2L7jxRfAoV4tfS89KgXsx47Wk3Kat5K6xPg");
+        const transactions = await repository.findBy({ account, chainType: "Solo" });
         expect(transactions.length).toBe(2); // 2 and 3 in SQL file
     });
 
     it("finds transactions of 5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY", async () => {
-        const transactions = await repository.findBy({ address: "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY", chainType: "Solo" });
+        const account = ValidAccountId.polkadot("5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY");
+        const transactions = await repository.findBy({ account, chainType: "Solo" });
         expect(transactions.length).toBe(2); // 1 and 4 in SQL file
     });
 
     it("finds transactions of 5CSbpCKSTvZefZYddesUQ9w6NDye2PHbf12MwBZGBgzGeGoo", async () => {
-        const transactions = await repository.findBy({ address: "5CSbpCKSTvZefZYddesUQ9w6NDye2PHbf12MwBZGBgzGeGoo", chainType: "Solo" });
+        const account = ValidAccountId.polkadot("5CSbpCKSTvZefZYddesUQ9w6NDye2PHbf12MwBZGBgzGeGoo");
+        const transactions = await repository.findBy({ account, chainType: "Solo" });
         expect(transactions.length).toBe(1); // 1 in SQL file
     });
 
     it("finds no transaction for Unknown", async () => {
-        const transactions = await repository.findBy({ address: "Unknown", chainType: "Solo" });
+        const unknown = ValidAccountId.polkadot("5Hmyf1onCjbo9zaZP1ygMpzvDqdoRG8yiCjCUocGbvnKKCmm");
+        const transactions = await repository.findBy({ account: unknown, chainType: "Solo" });
         expect(transactions.length).toBe(0);
     });
 

--- a/test/integration/model/vaulttransferrequest.model.spec.ts
+++ b/test/integration/model/vaulttransferrequest.model.spec.ts
@@ -5,7 +5,9 @@ import {
     VaultTransferRequestRepository,
     VaultTransferRequestStatus,
 } from "../../../src/logion/model/vaulttransferrequest.model.js";
-import { ALICE, BOB } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
+import { ValidAccountId } from "@logion/node-api";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 
@@ -35,7 +37,7 @@ describe('VaultTransferRequestRepository queries', () => {
     });
 
     it("findByRequesterAddressOnly", async () => {
-        let requesterAddress = "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW";
+        let requesterAddress = ValidAccountId.polkadot("5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
         const specification = new FetchVaultTransferRequestsSpecification({
             expectedRequesterAddress: requesterAddress
         });
@@ -58,7 +60,7 @@ describe('VaultTransferRequestRepository queries', () => {
 
     it("finds workload", async () => {
         const specification = new FetchVaultTransferRequestsSpecification({
-            expectedLegalOfficerAddress: [ ALICE, BOB ],
+            expectedLegalOfficerAddress: [ ALICE_ACCOUNT, BOB_ACCOUNT ],
             expectedStatuses: [ 'PENDING' ],
         });
 
@@ -88,7 +90,7 @@ describe('VaultTransferRequestRepository updates', () => {
         const request = new VaultTransferRequestAggregateRoot();
         request.id = '9a7df79e-9d3a-4ef8-b4e1-496bbe30a639';
         request.requesterAddress = '5HQqkmkt6KqxQACPQ2uvH4mHrXouTSbtyT9XWJj8TUaaCE7q';
-        request.legalOfficerAddress = ALICE;
+        request.legalOfficerAddress = ALICE_ACCOUNT.getAddress(DB_SS58_PREFIX);
         request.origin = '5HQqkmkt6KqxQACPQ2uvH4mHrXouTSbtyT9XWJj8TUaaCE7q';
         request.destination = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
         request.amount = '10000';

--- a/test/integration/model/verifiedthirdpartyselection.model.spec.ts
+++ b/test/integration/model/verifiedthirdpartyselection.model.spec.ts
@@ -1,5 +1,6 @@
 import { TestDb } from "@logion/rest-api-core";
 import { VerifiedIssuerAggregateRoot, VerifiedIssuerSelectionRepository } from "../../../src/logion/model/verifiedissuerselection.model.js";
+import { ValidAccountId } from "@logion/node-api";
 
 const { connect, disconnect, checkNumOfRows, executeScript } = TestDb;
 
@@ -20,7 +21,7 @@ describe("VerifiedIssuerSelectionRepository - read", () => {
     it("finds by ID", async () => {
         const nomination = await repository.findById({
             locRequestId: "a7b80f86-1c51-4aff-ba32-d8361bb462b1",
-            issuer: "5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX",
+            issuer: ValidAccountId.polkadot("5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX"),
         });
         expect(nomination).toBeDefined();
     });
@@ -31,13 +32,13 @@ describe("VerifiedIssuerSelectionRepository - read", () => {
     });
 
     it("finds by issuer address", async () => {
-        const nominations = await repository.findBy({ issuer: "5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX" });
+        const nominations = await repository.findBy({ issuer: ValidAccountId.polkadot("5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX") });
         expect(nominations.length).toBe(1);
     });
 
     it("finds selected only", async () => {
         const nominations = await repository.findBy({
-            issuer: "5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb",
+            issuer: ValidAccountId.polkadot("5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb"),
             selected: true,
         });
         expect(nominations.length).toBe(1);

--- a/test/integration/model/vote.model.spec.ts
+++ b/test/integration/model/vote.model.spec.ts
@@ -1,6 +1,7 @@
 import { TestDb } from "@logion/rest-api-core";
-import { ALICE, BOB } from "@logion/rest-api-core/dist/TestApp.js";
 import { VoteRepository, VoteAggregateRoot, Ballot } from "../../../src/logion/model/vote.model.js";
+import { ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 const { connect, disconnect, executeScript } = TestDb;
 
@@ -31,7 +32,7 @@ describe("VoteRepository", () => {
         expect(vote?.createdOn?.toISOString()).toEqual("2022-09-30T22:00:00.000Z")
         expect(vote?.status).toEqual("REJECTED");
         expect(vote?.ballots?.length).toEqual(2);
-        expect(vote?.ballots?.find(ballot => ballot.voterAddress === ALICE && ballot.result === "Yes")).toBeDefined();
-        expect(vote?.ballots?.find(ballot => ballot.voterAddress === BOB && ballot.result === "No")).toBeDefined();
+        expect(vote?.ballots?.find(ballot => ballot.voterAddress === ALICE_ACCOUNT.getAddress(DB_SS58_PREFIX) && ballot.result === "Yes")).toBeDefined();
+        expect(vote?.ballots?.find(ballot => ballot.voterAddress === BOB_ACCOUNT.getAddress(DB_SS58_PREFIX) && ballot.result === "No")).toBeDefined();
     });
 })

--- a/test/resources/mail/loc-requested.pug
+++ b/test/resources/mail/loc-requested.pug
@@ -3,7 +3,7 @@
 |
 if (loc.requesterAddress !== undefined)
     | Identification key:
-    | #{loc.requesterAddress}
+    | #{loc.requesterAddress.address}
 else if (loc.requesterIdentityLoc !== undefined)
     | Identification LOC:
     | #{loc.requesterIdentityLoc}

--- a/test/resources/mail/protection-requested.pug
+++ b/test/resources/mail/protection-requested.pug
@@ -1,5 +1,5 @@
 | Your protection is requested
 | Dear Legal Officer,
 | The following user has requested your protection:
-| #{walletUser.firstName} #{walletUser.lastName}(#{protection.requesterAddress})
+| #{walletUser.firstName} #{walletUser.lastName}(#{protection.requesterAddress.address})
 |

--- a/test/unit/controllers/collection.controller.spec.ts
+++ b/test/unit/controllers/collection.controller.spec.ts
@@ -31,7 +31,7 @@ import {
 import { fileExists } from "../../helpers/filehelper.js";
 import { OwnershipCheckService } from "../../../src/logion/services/ownershipcheck.service.js";
 import { RestrictedDeliveryService } from "../../../src/logion/services/restricteddelivery.service.js";
-import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import {
     LocRequestService,
     NonTransactionalLocRequestService

--- a/test/unit/controllers/collection.controller.spec.ts
+++ b/test/unit/controllers/collection.controller.spec.ts
@@ -1,7 +1,7 @@
 import { TestApp } from "@logion/rest-api-core";
 import { Container } from "inversify";
 import { Mock, It } from "moq.ts";
-import { CollectionItem, Hash, ItemFile } from "@logion/node-api";
+import { CollectionItem, Hash, ItemFile, ValidAccountId } from "@logion/node-api";
 import { writeFile } from "fs/promises";
 import { CollectionController } from "../../../src/logion/controllers/collection.controller.js";
 import {
@@ -31,17 +31,20 @@ import {
 import { fileExists } from "../../helpers/filehelper.js";
 import { OwnershipCheckService } from "../../../src/logion/services/ownershipcheck.service.js";
 import { RestrictedDeliveryService } from "../../../src/logion/services/restricteddelivery.service.js";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import {
     LocRequestService,
     NonTransactionalLocRequestService
 } from "../../../src/logion/services/locrequest.service.js";
-import { polkadotAccount, EmbeddableSupportedAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
+import {
+    EmbeddableAccountId,
+    EmbeddableNullableAccountId
+} from "../../../src/logion/model/supportedaccountid.model.js";
 import { ItIsHash } from "../../helpers/Mock.js";
 
 const collectionLocId = "d61e2e12-6c06-4425-aeee-2a0e969ac14e";
-const collectionLocOwner = ALICE;
-const collectionRequester = "5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX";
+const collectionLocOwner = ALICE_ACCOUNT;
+const collectionRequester = ValidAccountId.polkadot("5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX");
 const itemId = Hash.fromHex("0x818f1c9cd44ed4ca11f2ede8e865c02a82f9f8a158d8d17368a6818346899705");
 const timestamp = moment();
 
@@ -377,7 +380,7 @@ function testDownloadFiles(fileType: FileType) {
             .expect(403)
             .expect('Content-Type', /application\/json/)
             .then(response => {
-                expect(response.body.errorMessage).toBe("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY does not seem to be the owner of this item's underlying token");
+                expect(response.body.errorMessage).toBe("vQx5kESPn8dWyX4KxMCKqUyCaWUwtui1isX6PVNcZh2Ghjitr does not seem to be the owner of this item's underlying token");
             });
     })
 }
@@ -580,7 +583,7 @@ function mockModel(
         }
         collectionFile.request = collectionLoc;
         collectionFile.requestId = collectionLocId;
-        collectionFile.submitter = EmbeddableSupportedAccountId.from(polkadotAccount(collectionRequester));
+        collectionFile.submitter = EmbeddableAccountId.from(collectionRequester);
         collectionFile.index = 0;
         collectionFile.name = FILE_NAME;
         collectionFile.contentType = CONTENT_TYPE;
@@ -669,8 +672,8 @@ function mockModel(
     }
     container.bind(CollectionRepository).toConstantValue(collectionRepository.object())
 
-    collectionLoc.ownerAddress = collectionLocOwner;
-    collectionLoc.requesterAddress = collectionRequester;
+    collectionLoc.ownerAddress = collectionLocOwner.address;
+    collectionLoc.requester = EmbeddableNullableAccountId.from(collectionRequester);
     collectionLoc.locType = "Collection";
     collectionLoc.status = "CLOSED";
     locRequestRepository.setup(instance => instance.findById(collectionLocId))

--- a/test/unit/controllers/idenfy.controller.spec.ts
+++ b/test/unit/controllers/idenfy.controller.spec.ts
@@ -8,7 +8,7 @@ import { IdenfyController } from "../../../src/logion/controllers/idenfy.control
 import { LocRequestAggregateRoot, LocRequestRepository } from "../../../src/logion/model/locrequest.model.js";
 import { IdenfyService, IdenfyVerificationCreation } from "../../../src/logion/services/idenfy/idenfy.service.js";
 import { mockRequester } from "./locrequest.controller.shared.js";
-import { polkadotAccount } from "../../../src/logion/model/supportedaccountid.model.js";
+import { ValidAccountId } from "@logion/node-api";
 import express, { Express } from 'express';
 import { Dino } from 'dinoloop';
 import { ApplicationErrorController } from "@logion/rest-api-core/dist/ApplicationErrorController.js";
@@ -54,7 +54,7 @@ describe("IdenfyController", () => {
 
 function mockVerification(container: Container, requester: string) {
     const locRequest = new Mock<LocRequestAggregateRoot>();
-    mockRequester(locRequest, polkadotAccount(requester));
+    mockRequester(locRequest, ValidAccountId.polkadot(requester));
 
     const repository = new Mock<LocRequestRepository>();
     repository.setup(instance => instance.findById(REQUEST_ID)).returnsAsync(locRequest.object());

--- a/test/unit/controllers/idenfy.controller.spec.ts
+++ b/test/unit/controllers/idenfy.controller.spec.ts
@@ -1,5 +1,5 @@
 import { AuthenticationService, TestApp } from "@logion/rest-api-core";
-import { ALICE, AuthenticationServiceMock, BOB, mockAuthenticationWithCondition } from "@logion/rest-api-core/dist/TestApp.js";
+import { ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
 import bodyParser from "body-parser";
 import { Container } from "inversify";
 import request from "supertest";
@@ -19,7 +19,7 @@ const { setupApp } = TestApp;
 describe("IdenfyController", () => {
 
     it("creates verification session for LOC requester", async () => {
-        const app = setupApp(IdenfyController, container => mockVerification(container, ALICE));
+        const app = setupApp(IdenfyController, container => mockVerification(container, ALICE_ACCOUNT.address));
 
         await request(app)
             .post(`/api/idenfy/verification-session/${ REQUEST_ID }`)
@@ -32,7 +32,7 @@ describe("IdenfyController", () => {
     });
 
     it("fails at creating verification session for others", async () => {
-        const app = setupApp(IdenfyController, container => mockVerification(container, BOB));
+        const app = setupApp(IdenfyController, container => mockVerification(container, BOB_ACCOUNT.address));
 
         await request(app)
             .post(`/api/idenfy/verification-session/${ REQUEST_ID }`)

--- a/test/unit/controllers/locrequest.controller.creation.spec.ts
+++ b/test/unit/controllers/locrequest.controller.creation.spec.ts
@@ -26,8 +26,7 @@ import {
     EXISTING_SPONSORSHIP_ID,
     ETHEREUM_REQUESTER
 } from "./locrequest.controller.shared.js";
-import { UUID } from "@logion/node-api";
-import { SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
+import { UUID, ValidAccountId } from "@logion/node-api";
 import { LocalsObject } from "pug";
 
 const { mockAuthenticationForUserOrLegalOfficer, mockAuthenticationFailureWithInvalidSignature, setupApp } = TestApp;
@@ -175,6 +174,10 @@ async function testLocRequestCreationWithEmbeddedUserIdentity(isLegalOfficer: bo
         .post('/api/loc-request')
         .send({
             ...data,
+            requesterAddress: {
+                address: data.requesterAddress?.address,
+                type: data.requesterAddress?.type,
+            },
             fees: {
                 legalFee: data.fees?.legalFee?.toString(),
                 valueFee: data.fees?.valueFee?.toString(),
@@ -277,8 +280,8 @@ function mockModelForCreation(container: Container, locType: LocType, notificati
 
     sponsorshipService.setup(instance => instance.validateSponsorship(
         It.Is<UUID>(sponsorshipId => sponsorshipId.toString() === EXISTING_SPONSORSHIP_ID.toString()),
-        It.IsAny<SupportedAccountId>(),
-        It.IsAny<SupportedAccountId>()
+        It.IsAny<ValidAccountId>(),
+        It.IsAny<ValidAccountId>()
     )).throws(new Error("This sponsorship ID is already used"));
 }
 

--- a/test/unit/controllers/locrequest.controller.items.spec.ts
+++ b/test/unit/controllers/locrequest.controller.items.spec.ts
@@ -29,10 +29,6 @@ import {
     POLKADOT_REQUESTER,
 } from "./locrequest.controller.shared.js";
 import { mockAuthenticationForUserOrLegalOfficer } from "@logion/rest-api-core/dist/TestApp.js";
-import {
-    SupportedAccountId,
-    accountEquals
-} from "../../../src/logion/model/supportedaccountid.model.js";
 import { ItIsAccount, ItIsHash } from "../../helpers/Mock.js";
 
 const { mockAuthenticationWithCondition, setupApp } = TestApp;
@@ -278,7 +274,7 @@ describe('LocRequestController - Items -', () => {
             .delete(`/api/loc-request/${ REQUEST_ID }/links/${ SOME_LINK_TARGET }`)
             .expect(200)
         locRequest.verify(instance => instance.removeLink(
-            It.Is<ValidAccountId>(account => accountEquals(account, POLKADOT_REQUESTER)),
+            It.Is<ValidAccountId>(account => account.equals(POLKADOT_REQUESTER)),
             SOME_LINK_TARGET
         ))
     })
@@ -428,12 +424,12 @@ function mockModelForDeleteFile(container: Container, request: Mock<LocRequestAg
 
     if (issuerMode !== 'NOT_ISSUER') {
         request.setup(instance => instance.removeFile(
-            It.Is<ValidAccountId>(account => accountEquals(account, ISSUER)),
+            It.Is<ValidAccountId>(account => account.equals(ISSUER)),
             SOME_DATA_HASH
         )).returns(SOME_FILE);
     } else {
         request.setup(instance => instance.removeFile(
-            It.Is<ValidAccountId>(account => accountEquals(account, ALICE_ACCOUNT)),
+            It.Is<ValidAccountId>(account => account.equals(ALICE_ACCOUNT)),
             SOME_DATA_HASH
         )).returns(SOME_FILE);
     }
@@ -449,12 +445,12 @@ async function testDeleteFileSuccess(app: Express, locRequest: Mock<LocRequestAg
         .expect(200);
     if(issuerMode !== 'NOT_ISSUER') {
         locRequest.verify(instance => instance.removeFile(
-            It.Is<ValidAccountId>(account => accountEquals(account, ISSUER)),
+            It.Is<ValidAccountId>(account => account.equals(ISSUER)),
             ItIsHash(SOME_DATA_HASH)
         ));
     } else {
         locRequest.verify(instance => instance.removeFile(
-            It.Is<ValidAccountId>(account => accountEquals(account, POLKADOT_REQUESTER)),
+            It.Is<ValidAccountId>(account => account.equals(POLKADOT_REQUESTER)),
             ItIsHash(SOME_DATA_HASH)
         ));
     }
@@ -471,7 +467,7 @@ function mockModelForConfirmFile(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getFile(ItIsHash(SOME_DATA_HASH))).returns({ submitter: ALICE_ACCOUNT } as FileDescription);
-    request.setup(instance => instance.canPrePublishOrAcknowledgeFile(ItIsHash(SOME_DATA_HASH), It.IsAny<SupportedAccountId>())).returns(true);
+    request.setup(instance => instance.canPrePublishOrAcknowledgeFile(ItIsHash(SOME_DATA_HASH), It.IsAny<ValidAccountId>())).returns(true);
     request.setup(instance => instance.prePublishOrAcknowledgeFile(ItIsHash(SOME_DATA_HASH), ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }
@@ -480,7 +476,7 @@ function mockModelForAckFile(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getFile(ItIsHash(SOME_DATA_HASH))).returns({ submitter: ALICE_ACCOUNT } as FileDescription);
-    request.setup(instance => instance.canPreAcknowledgeFile(ItIsHash(SOME_DATA_HASH), It.IsAny<SupportedAccountId>())).returns(true);
+    request.setup(instance => instance.canPreAcknowledgeFile(ItIsHash(SOME_DATA_HASH), It.IsAny<ValidAccountId>())).returns(true);
     request.setup(instance => instance.preAcknowledgeFile(ItIsHash(SOME_DATA_HASH), ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }
@@ -531,9 +527,9 @@ async function testDeleteMetadataSuccess(app: Express, locRequest: Mock<LocReque
         .delete(`/api/loc-request/${ REQUEST_ID }/metadata/${ SOME_DATA_NAME_HASH.toHex() }`)
         .expect(200);
     if(isVerifiedIssuer) {
-        locRequest.verify(instance => instance.removeMetadataItem(It.Is<ValidAccountId>(account => accountEquals(account, ISSUER)), ItIsHash(SOME_DATA_NAME_HASH)));
+        locRequest.verify(instance => instance.removeMetadataItem(It.Is<ValidAccountId>(account => account.equals(ISSUER)), ItIsHash(SOME_DATA_NAME_HASH)));
     } else {
-        locRequest.verify(instance => instance.removeMetadataItem(It.Is<ValidAccountId>(account => accountEquals(account, POLKADOT_REQUESTER)), ItIsHash(SOME_DATA_NAME_HASH)));
+        locRequest.verify(instance => instance.removeMetadataItem(It.Is<ValidAccountId>(account => account.equals(POLKADOT_REQUESTER)), ItIsHash(SOME_DATA_NAME_HASH)));
     }
 }
 
@@ -542,7 +538,7 @@ async function testDeleteMetadataForbidden(app: Express, locRequest: Mock<LocReq
         .delete(`/api/loc-request/${ REQUEST_ID }/metadata/${ SOME_DATA_NAME_HASH.toHex() }`)
         .expect(403);
     locRequest.verify(
-        instance => instance.removeMetadataItem(It.IsAny<SupportedAccountId>(), It.IsAny<Hash>()),
+        instance => instance.removeMetadataItem(It.IsAny<ValidAccountId>(), It.IsAny<Hash>()),
         Times.Never()
     );
 }
@@ -587,7 +583,7 @@ function mockModelForConfirmMetadata(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns({ submitter: ALICE_ACCOUNT } as MetadataItemDescription);
-    request.setup(instance => instance.canPrePublishOrAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), It.IsAny<SupportedAccountId>())).returns(true);
+    request.setup(instance => instance.canPrePublishOrAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), It.IsAny<ValidAccountId>())).returns(true);
     request.setup(instance => instance.prePublishOrAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }
@@ -596,7 +592,7 @@ function mockModelForAckMetadata(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns({ submitter: ALICE_ACCOUNT } as MetadataItemDescription);
-    request.setup(instance => instance.canPreAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), It.IsAny<SupportedAccountId>())).returns(true);
+    request.setup(instance => instance.canPreAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), It.IsAny<ValidAccountId>())).returns(true);
     request.setup(instance => instance.preAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }
@@ -605,7 +601,7 @@ function mockModelForConfirmLink(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getLink(SOME_LINK_TARGET)).returns({ submitter: ALICE_ACCOUNT } as LinkDescription);
-    request.setup(instance => instance.canPrePublishOrAcknowledgeLink(SOME_LINK_TARGET, It.IsAny<SupportedAccountId>())).returns(true);
+    request.setup(instance => instance.canPrePublishOrAcknowledgeLink(SOME_LINK_TARGET, It.IsAny<ValidAccountId>())).returns(true);
     request.setup(instance => instance.prePublishOrAcknowledgeLink(SOME_LINK_TARGET, ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }
@@ -614,7 +610,7 @@ function mockModelForAckLink(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
     request.setup(instance => instance.getLink(SOME_LINK_TARGET)).returns({ submitter: ALICE_ACCOUNT } as LinkDescription);
-    request.setup(instance => instance.canPreAcknowledgeLink(SOME_LINK_TARGET, It.IsAny<SupportedAccountId>())).returns(true);
+    request.setup(instance => instance.canPreAcknowledgeLink(SOME_LINK_TARGET, It.IsAny<ValidAccountId>())).returns(true);
     request.setup(instance => instance.preAcknowledgeLink(SOME_LINK_TARGET, ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
 }

--- a/test/unit/controllers/locrequest.controller.items.spec.ts
+++ b/test/unit/controllers/locrequest.controller.items.spec.ts
@@ -5,7 +5,7 @@ import { writeFile } from 'fs/promises';
 import { LocRequestController } from "../../../src/logion/controllers/locrequest.controller.js";
 import { Container } from "inversify";
 import request from "supertest";
-import { ALICE_ACCOUNT, ALICE, BOB_ACCOUNT } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
 import { Mock, It, Times } from "moq.ts";
 import {
     LocRequestAggregateRoot,
@@ -470,7 +470,7 @@ async function testDeleteFileForbidden(app: Express) {
 function mockModelForConfirmFile(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
-    request.setup(instance => instance.getFile(ItIsHash(SOME_DATA_HASH))).returns({ submitter: { type: "Polkadot", address: ALICE } } as FileDescription);
+    request.setup(instance => instance.getFile(ItIsHash(SOME_DATA_HASH))).returns({ submitter: ALICE_ACCOUNT } as FileDescription);
     request.setup(instance => instance.canPrePublishOrAcknowledgeFile(ItIsHash(SOME_DATA_HASH), It.IsAny<SupportedAccountId>())).returns(true);
     request.setup(instance => instance.prePublishOrAcknowledgeFile(ItIsHash(SOME_DATA_HASH), ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
@@ -479,7 +479,7 @@ function mockModelForConfirmFile(container: Container) {
 function mockModelForAckFile(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
-    request.setup(instance => instance.getFile(ItIsHash(SOME_DATA_HASH))).returns({ submitter: { type: "Polkadot", address: ALICE } } as FileDescription);
+    request.setup(instance => instance.getFile(ItIsHash(SOME_DATA_HASH))).returns({ submitter: ALICE_ACCOUNT } as FileDescription);
     request.setup(instance => instance.canPreAcknowledgeFile(ItIsHash(SOME_DATA_HASH), It.IsAny<SupportedAccountId>())).returns(true);
     request.setup(instance => instance.preAcknowledgeFile(ItIsHash(SOME_DATA_HASH), ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
@@ -586,7 +586,7 @@ function mockModelForAddLink(container: Container, request: Mock<LocRequestAggre
 function mockModelForConfirmMetadata(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
-    request.setup(instance => instance.getMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns({ submitter: { type: "Polkadot", address: ALICE } } as MetadataItemDescription);
+    request.setup(instance => instance.getMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns({ submitter: ALICE_ACCOUNT } as MetadataItemDescription);
     request.setup(instance => instance.canPrePublishOrAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), It.IsAny<SupportedAccountId>())).returns(true);
     request.setup(instance => instance.prePublishOrAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
@@ -595,7 +595,7 @@ function mockModelForConfirmMetadata(container: Container) {
 function mockModelForAckMetadata(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
-    request.setup(instance => instance.getMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns({ submitter: { type: "Polkadot", address: ALICE } } as MetadataItemDescription);
+    request.setup(instance => instance.getMetadataItem(ItIsHash(SOME_DATA_NAME_HASH))).returns({ submitter: ALICE_ACCOUNT } as MetadataItemDescription);
     request.setup(instance => instance.canPreAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), It.IsAny<SupportedAccountId>())).returns(true);
     request.setup(instance => instance.preAcknowledgeMetadataItem(ItIsHash(SOME_DATA_NAME_HASH), ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
@@ -604,7 +604,7 @@ function mockModelForAckMetadata(container: Container) {
 function mockModelForConfirmLink(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
-    request.setup(instance => instance.getLink(SOME_LINK_TARGET)).returns({ submitter: { type: "Polkadot", address: ALICE } } as LinkDescription);
+    request.setup(instance => instance.getLink(SOME_LINK_TARGET)).returns({ submitter: ALICE_ACCOUNT } as LinkDescription);
     request.setup(instance => instance.canPrePublishOrAcknowledgeLink(SOME_LINK_TARGET, It.IsAny<SupportedAccountId>())).returns(true);
     request.setup(instance => instance.prePublishOrAcknowledgeLink(SOME_LINK_TARGET, ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);
@@ -613,7 +613,7 @@ function mockModelForConfirmLink(container: Container) {
 function mockModelForAckLink(container: Container) {
     const { request, repository } = buildMocksForUpdate(container);
     setupRequest(request, REQUEST_ID, "Transaction", "OPEN", testData);
-    request.setup(instance => instance.getLink(SOME_LINK_TARGET)).returns({ submitter: { type: "Polkadot", address: ALICE } } as LinkDescription);
+    request.setup(instance => instance.getLink(SOME_LINK_TARGET)).returns({ submitter: ALICE_ACCOUNT } as LinkDescription);
     request.setup(instance => instance.canPreAcknowledgeLink(SOME_LINK_TARGET, It.IsAny<SupportedAccountId>())).returns(true);
     request.setup(instance => instance.preAcknowledgeLink(SOME_LINK_TARGET, ItIsAccount(ALICE_ACCOUNT))).returns();
     mockPolkadotIdentityLoc(repository, false);

--- a/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
+++ b/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
@@ -19,7 +19,6 @@ import {
     POLKADOT_REQUESTER,
 } from "./locrequest.controller.shared.js";
 import { BOB_ACCOUNT } from "../../helpers/addresses.js";
-import { SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model";
 import { ValidAccountId } from "@logion/node-api";
 
 const { setupApp, mockLegalOfficerOnNode, mockAuthenticationWithAuthenticatedUser, mockAuthenticatedUser } = TestApp;
@@ -210,7 +209,7 @@ function mockModelForAccept(container: Container, notificationService: Mock<Noti
     const { request } = buildMocksForDecision(container, notificationService);
     request.setup(instance => instance.accept(It.Is<string>(It.IsAny<Moment>())))
         .returns();
-    request.setup(instance => instance.canOpen(It.IsAny<SupportedAccountId>()))
+    request.setup(instance => instance.canOpen(It.IsAny<ValidAccountId>()))
         .returns(true);
 }
 
@@ -247,11 +246,11 @@ function mockModelForOpen(container: Container, locType: LocType, userIdentity?:
         userIdentity
     };
     setupRequest(request, REQUEST_ID, locType, "REVIEW_ACCEPTED", data);
-    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params.address === POLKADOT_REQUESTER.address)))
+    request.setup(instance => instance.canOpen(It.Is<ValidAccountId>(params => params.address === POLKADOT_REQUESTER.address)))
         .returns(true);
-    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params.address !== POLKADOT_REQUESTER.address)))
+    request.setup(instance => instance.canOpen(It.Is<ValidAccountId>(params => params.address !== POLKADOT_REQUESTER.address)))
         .returns(false);
-    request.setup(instance => instance.canOpen(It.Is<SupportedAccountId>(params => params === undefined)))
+    request.setup(instance => instance.canOpen(It.Is<ValidAccountId>(params => params === undefined)))
         .returns(false);
     request.setup(instance => instance.preOpen(It.IsAny())).returns();
 }

--- a/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
+++ b/test/unit/controllers/locrequest.controller.lifecycle.spec.ts
@@ -18,7 +18,7 @@ import {
     userIdentities,
     POLKADOT_REQUESTER,
 } from "./locrequest.controller.shared.js";
-import { BOB, BOB_ACCOUNT } from "../../helpers/addresses.js";
+import { BOB_ACCOUNT } from "../../helpers/addresses.js";
 import { SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model";
 import { ValidAccountId } from "@logion/node-api";
 

--- a/test/unit/controllers/locrequest.controller.shared.ts
+++ b/test/unit/controllers/locrequest.controller.shared.ts
@@ -1,7 +1,7 @@
 import { LocRequestAdapter, UserPrivateData } from "../../../src/logion/controllers/adapters/locrequestadapter.js";
 import { Container } from "inversify";
 import request from "supertest";
-import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import { Mock, It } from "moq.ts";
 import {
     LocRequestRepository,
@@ -242,7 +242,7 @@ function mockOtherDependencies(container: Container, existingMocks?: {
     const directoryService = new Mock<DirectoryService>();
     directoryService
         .setup(instance => instance.get(It.IsAny<string>()))
-        .returns(Promise.resolve(notifiedLegalOfficer(ALICE)))
+        .returns(Promise.resolve(notifiedLegalOfficer(ALICE_ACCOUNT.address)))
     directoryService
         .setup(instance => instance.requireLegalOfficerAddressOnNode(It.IsAny<string>()))
         .returns(Promise.resolve(ALICE_ACCOUNT));
@@ -313,7 +313,7 @@ export function setupRequest(
         .returns({
             ...description,
             createdOn: "2022-08-31T16:01:15.651Z",
-            ownerAddress: description.ownerAddress || ALICE,
+            ownerAddress: description.ownerAddress || ALICE_ACCOUNT.address,
             requesterAddress: description.requesterAddress,
             requesterIdentityLoc: description.requesterIdentityLoc,
         } as LocRequestDescription);
@@ -401,7 +401,7 @@ export function setupLocFetch(locId: string, locBatch: Mock<LocBatch>, nodeApi: 
     const locIdUuid = new UUID(locId);
     nodeApi.setup(instance => instance.batch.locs(It.Is<UUID[]>(ids => ids.length === 1 && ids[0].toString() === locIdUuid.toString())))
         .returns(locBatch.object());
-    nodeApi.setup(instance => instance.queries.getLegalOfficerVerifiedIssuers(ALICE)).returnsAsync([]);
+    nodeApi.setup(instance => instance.queries.getLegalOfficerVerifiedIssuers(ALICE_ACCOUNT.address)).returnsAsync([]);
 }
 
 export function buildMocksForUpdate(container: Container, existingMocks?: Partial<Mocks>): Mocks {

--- a/test/unit/controllers/lofile.controller.spec.ts
+++ b/test/unit/controllers/lofile.controller.spec.ts
@@ -12,20 +12,20 @@ import {
 import request from "supertest";
 import { writeFile } from "fs/promises";
 import { LoFileService, NonTransactionalLoFileService } from "../../../src/logion/services/lofile.service.js";
-import { ALICE, BOB } from "../../helpers/addresses.js";
+import { ALICE, ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
 import { LegalOfficerSettingId } from "../../../src/logion/model/legalofficer.model.js";
 import { mockAuthenticatedUser, mockAuthenticationWithAuthenticatedUser } from "@logion/rest-api-core/dist/TestApp.js";
 import { Hash } from "@logion/node-api";
 
 const existingFile: LoFileDescription = {
     id: 'file1',
-    legalOfficerAddress: ALICE,
+    legalOfficer: ALICE_ACCOUNT,
     contentType: 'text/plain',
     oid: 123
 }
 const newFile: LoFileDescription = {
     id: 'file2',
-    legalOfficerAddress: ALICE,
+    legalOfficer: ALICE_ACCOUNT,
     contentType: 'text/plain',
     oid: 456
 }
@@ -106,7 +106,7 @@ describe("LoFileController", () => {
     });
 
     it("fails to upload an new file if different LO", async () => {
-        const authenticatedUser = mockAuthenticatedUser(false, BOB);
+        const authenticatedUser = mockAuthenticatedUser(false, BOB_ACCOUNT);
         const mock = mockAuthenticationWithAuthenticatedUser(authenticatedUser);
 
         const app = setupApp(LoFileController, mockModel, mock);
@@ -123,7 +123,7 @@ describe("LoFileController", () => {
     });
 
     it("fails to upload an existing file if different LO", async () => {
-        const authenticatedUser = mockAuthenticatedUser(false, BOB);
+        const authenticatedUser = mockAuthenticatedUser(false, BOB_ACCOUNT);
         const mock = mockAuthenticationWithAuthenticatedUser(authenticatedUser);
 
         const app = setupApp(LoFileController, mockModel, mock);
@@ -140,7 +140,7 @@ describe("LoFileController", () => {
     });
 
     it("fails to download if different LO", async () => {
-        const authenticatedUser = mockAuthenticatedUser(false, BOB);
+        const authenticatedUser = mockAuthenticatedUser(false, BOB_ACCOUNT);
         const mock = mockAuthenticationWithAuthenticatedUser(authenticatedUser);
 
         const app = setupApp(LoFileController, mockModel, mock);
@@ -178,13 +178,13 @@ function mockModel(container: Container): void {
     repository.setup(instance => instance
         .findById(It.Is<LegalOfficerSettingId>(param =>
             param.id === existingFile.id &&
-            param.legalOfficerAddress === existingFile.legalOfficerAddress
+            param.legalOfficer.equals(existingFile.legalOfficer)
         )))
         .returns(Promise.resolve(existingEntity.object()));
     repository.setup(instance => instance
         .findById(It.Is<LegalOfficerSettingId>(param =>
             param.id === newFile.id &&
-            param.legalOfficerAddress === newFile.legalOfficerAddress
+            param.legalOfficer.equals(newFile.legalOfficer)
         )))
         .returns(Promise.resolve(null))
     repository.setup(instance => instance.save(It.IsAny<LoFileAggregateRoot>()))

--- a/test/unit/controllers/protectionrequest.controller.spec.ts
+++ b/test/unit/controllers/protectionrequest.controller.spec.ts
@@ -13,7 +13,7 @@ import {
     LegalOfficerDecision,
     LegalOfficerDecisionDescription,
 } from '../../../src/logion/model/protectionrequest.model.js';
-import { ALICE, BOB, CHARLY, BOB_ACCOUNT, ALICE_ACCOUNT } from '../../helpers/addresses.js';
+import { ALICE, BOB, CHARLY, BOB_ACCOUNT, ALICE_ACCOUNT, CHARLY_ACCOUNT } from '../../helpers/addresses.js';
 import { ProtectionRequestController } from '../../../src/logion/controllers/protectionrequest.controller.js';
 import { NotificationService, Template } from "../../../src/logion/services/notification.service.js";
 import moment from "moment";
@@ -250,7 +250,7 @@ function mockModelForFetch(container: Container): void {
         decisionOn: DECISION_TIMESTAMP
     })
 
-    protectionRequest.setup(instance => instance.legalOfficerAddress).returns(ALICE);
+    protectionRequest.setup(instance => instance.legalOfficerAddress).returns(ALICE_ACCOUNT.getAddress(DB_SS58_PREFIX));
     protectionRequest.setup(instance => instance.createdOn).returns(TIMESTAMP);
     protectionRequest.setup(instance => instance.isRecovery).returns(false);
     protectionRequest.setup(instance => instance.addressToRecover).returns(null);
@@ -443,7 +443,7 @@ describe("User", () => {
             .expect(204);
 
         notificationService.verify(instance => instance.notify("alice@logion.network", "protection-updated", It.IsAny<any>()))
-        protectionRequest.verify(instance => instance.updateOtherLegalOfficer(It.Is<string>(value => value === CHARLY)))
+        protectionRequest.verify(instance => instance.updateOtherLegalOfficer(It.Is<string>(value => value === CHARLY_ACCOUNT.getAddress(DB_SS58_PREFIX))))
         repository.verify(instance => instance.save(protectionRequest.object()));
     });
 
@@ -513,7 +513,7 @@ function mockNotificationAndDirectoryService(container: Container) {
     const directoryService = new Mock<DirectoryService>();
     directoryService
         .setup(instance => instance.get(It.IsAny<string>()))
-        .returns(Promise.resolve(notifiedLegalOfficer(ALICE)))
+        .returns(Promise.resolve(notifiedLegalOfficer(ALICE_ACCOUNT.address)))
     directoryService
         .setup(instance => instance.requireLegalOfficerAddressOnNode(It.IsAny<string>()))
         .returns(Promise.resolve(ALICE_ACCOUNT));
@@ -560,7 +560,7 @@ function mockModelForUserCancel(container: Container, protectionRequest: Mock<Pr
 
 function mockModelForUserUpdate(container: Container, protectionRequest: Mock<ProtectionRequestAggregateRoot>, repository: Mock<ProtectionRequestRepository>): void {
     mockModelForUser(container, protectionRequest, repository);
-    protectionRequest.setup(instance => instance.updateOtherLegalOfficer(CHARLY))
+    protectionRequest.setup(instance => instance.updateOtherLegalOfficer(CHARLY_ACCOUNT.getAddress(DB_SS58_PREFIX)))
         .returns(undefined);
 }
 

--- a/test/unit/controllers/protectionrequest.controller.spec.ts
+++ b/test/unit/controllers/protectionrequest.controller.spec.ts
@@ -443,7 +443,7 @@ describe("User", () => {
             .expect(204);
 
         notificationService.verify(instance => instance.notify("alice@logion.network", "protection-updated", It.IsAny<any>()))
-        protectionRequest.verify(instance => instance.updateOtherLegalOfficer(It.Is<string>(value => value === CHARLY_ACCOUNT.getAddress(DB_SS58_PREFIX))))
+        protectionRequest.verify(instance => instance.updateOtherLegalOfficer(It.Is<ValidAccountId>(value => value.equals(CHARLY_ACCOUNT))))
         repository.verify(instance => instance.save(protectionRequest.object()));
     });
 
@@ -457,7 +457,7 @@ describe("User", () => {
                 otherLegalOfficerAddress: CHARLY
             })
             .expect(401);
-        protectionRequest.verify(instance => instance.updateOtherLegalOfficer(It.IsAny<string>()), Times.Never())
+        protectionRequest.verify(instance => instance.updateOtherLegalOfficer(It.IsAny<ValidAccountId>()), Times.Never())
     });
 
 })
@@ -560,7 +560,7 @@ function mockModelForUserCancel(container: Container, protectionRequest: Mock<Pr
 
 function mockModelForUserUpdate(container: Container, protectionRequest: Mock<ProtectionRequestAggregateRoot>, repository: Mock<ProtectionRequestRepository>): void {
     mockModelForUser(container, protectionRequest, repository);
-    protectionRequest.setup(instance => instance.updateOtherLegalOfficer(CHARLY_ACCOUNT.getAddress(DB_SS58_PREFIX)))
+    protectionRequest.setup(instance => instance.updateOtherLegalOfficer(It.Is<ValidAccountId>(value => value.equals(CHARLY_ACCOUNT))))
         .returns(undefined);
 }
 

--- a/test/unit/controllers/records.controller.spec.ts
+++ b/test/unit/controllers/records.controller.spec.ts
@@ -42,7 +42,7 @@ const timestamp = moment();
 const ITEM_TOKEN_OWNER = "0x900edc98db53508e6742723988B872dd08cd09c3";
 
 const recordId = Hash.fromHex("0x59772b9c70d6cc244274937445f7c5b56ec6fe0a11292c4ed68848655515a1e6");
-const recordSubmitter = "5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb";
+const recordSubmitter = ValidAccountId.polkadot("5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb");
 const SOME_DATA = 'some data';
 const SOME_DATA_HASH = Hash.fromHex('0x1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee');
 const FILE_NAME = "'a-file.pdf'";

--- a/test/unit/controllers/setting.controller.spec.ts
+++ b/test/unit/controllers/setting.controller.spec.ts
@@ -13,6 +13,7 @@ import { NonTransactionalSettingService, SettingService } from '../../../src/log
 import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import { LegalOfficerSettingId } from "../../../src/logion/model/legalofficer.model.js";
 import { ItIsAccount } from "../../helpers/Mock.js";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 const { setupApp } = TestApp;
 
@@ -58,7 +59,7 @@ function mockForList(container: Container) {
     createAndBindMocks(container);
 
     setting.setup(instance => instance.id).returns(settingId);
-    setting.setup(instance => instance.legalOfficerAddress).returns(ALICE);
+    setting.setup(instance => instance.legalOfficerAddress).returns(ALICE_ACCOUNT.getAddress(DB_SS58_PREFIX));
     setting.setup(instance => instance.value).returns(settingValue);
 
     settingRepository.setup(instance => instance.findByLegalOfficer(ItIsAccount(ALICE_ACCOUNT))).returnsAsync([ setting.object() ]);

--- a/test/unit/controllers/setting.controller.spec.ts
+++ b/test/unit/controllers/setting.controller.spec.ts
@@ -10,8 +10,9 @@ import {
     SettingDescription
 } from '../../../src/logion/model/setting.model.js';
 import { NonTransactionalSettingService, SettingService } from '../../../src/logion/services/settings.service.js';
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import { LegalOfficerSettingId } from "../../../src/logion/model/legalofficer.model.js";
+import { ItIsAccount } from "../../helpers/Mock.js";
 
 const { setupApp } = TestApp;
 
@@ -60,7 +61,7 @@ function mockForList(container: Container) {
     setting.setup(instance => instance.legalOfficerAddress).returns(ALICE);
     setting.setup(instance => instance.value).returns(settingValue);
 
-    settingRepository.setup(instance => instance.findByLegalOfficer(ALICE)).returnsAsync([ setting.object() ]);
+    settingRepository.setup(instance => instance.findByLegalOfficer(ItIsAccount(ALICE_ACCOUNT))).returnsAsync([ setting.object() ]);
 }
 
 function createAndBindMocks(container: Container) {
@@ -79,13 +80,13 @@ function mockForCreate(container: Container) {
     createAndBindMocks(container);
 
     settingFactory.setup(instance => instance
-        .newSetting(It.Is<SettingDescription>(args => args.id === settingId && args.legalOfficerAddress === ALICE && args.value === settingValue)))
+        .newSetting(It.Is<SettingDescription>(args => args.id === settingId && args.legalOfficer.equals(ALICE_ACCOUNT) && args.value === settingValue)))
         .returns(setting.object());
-    
+
     settingRepository.setup(instance => instance
-        .findById(It.Is<LegalOfficerSettingId>(args => args.id === settingId && args.legalOfficerAddress === ALICE)))
+        .findById(It.Is<LegalOfficerSettingId>(args => args.id === settingId && args.legalOfficer.equals(ALICE_ACCOUNT))))
         .returnsAsync(null);
-    settingRepository.setup(instance => instance.save(setting.object())).returnsAsync();    
+    settingRepository.setup(instance => instance.save(setting.object())).returnsAsync();
 }
 
 const settingId = "some-id";
@@ -97,7 +98,7 @@ function mockForUpdate(container: Container) {
     setting.setup(instance => instance.update(settingValue)).returns();
 
     settingRepository.setup(instance => instance
-        .findById(It.Is<LegalOfficerSettingId>(args => args.id === settingId && args.legalOfficerAddress === ALICE)))
+        .findById(It.Is<LegalOfficerSettingId>(args => args.id === settingId && args.legalOfficer.equals(ALICE_ACCOUNT))))
         .returnsAsync(setting.object());
     settingRepository.setup(instance => instance.save(setting.object())).returnsAsync();
 }

--- a/test/unit/controllers/transaction.controller.spec.ts
+++ b/test/unit/controllers/transaction.controller.spec.ts
@@ -1,4 +1,4 @@
-import { ChainType, Fees, Lgnt, LogionNodeApiClass } from "@logion/node-api";
+import { ChainType, Fees, Lgnt, LogionNodeApiClass, ValidAccountId } from "@logion/node-api";
 import { PolkadotService, TestApp } from '@logion/rest-api-core';
 import request from 'supertest';
 import { TransactionController } from '../../../src/logion/controllers/transaction.controller.js';
@@ -9,7 +9,7 @@ import {
     TransactionAggregateRoot,
     TransactionDescription
 } from "../../../src/logion/model/transaction.model.js";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import { Block } from "../../../src/logion/model/block.model.js";
 
 describe('TransactionController', () => {
@@ -28,7 +28,7 @@ describe('TransactionController', () => {
 
                 const transaction0 = response.body.transactions[0];
                 expect(transaction0.id).toBeDefined();
-                expect(transaction0.from).toBe(ALICE);
+                expect(transaction0.from).toBe(ALICE_ACCOUNT.address);
                 expect(transaction0.to).toBeUndefined();
                 expect(transaction0.pallet).toBe("pallet");
                 expect(transaction0.method).toBe("method");
@@ -45,7 +45,7 @@ describe('TransactionController', () => {
 
                 const transaction1 = response.body.transactions[1];
                 expect(transaction1.id).toBeDefined();
-                expect(transaction1.from).toBe(ALICE);
+                expect(transaction1.from).toBe(ALICE_ACCOUNT.address);
                 expect(transaction1.to).toBeUndefined();
                 expect(transaction1.pallet).toBe("pallet");
                 expect(transaction1.method).toBe("method");
@@ -73,7 +73,7 @@ function transactionDescription(fees: Fees): TransactionDescription {
             chainType: "Solo",
         }),
         extrinsicIndex: 1,
-        from: ALICE,
+        from: ALICE_ACCOUNT,
         to: null,
         createdOn: TIMESTAMP,
         pallet: "pallet",
@@ -118,8 +118,8 @@ function mockModelForFetch(container: Container): void {
     const repository = new Mock<TransactionRepository>();
     const transactions: TransactionAggregateRoot[] = [ successfulTransaction.object(), failedTransaction.object() ];
     repository.setup(instance => instance.findBy(
-        It.Is<{ address: string, chainType: ChainType }>(
-            spec => spec.address === ALICE && spec.chainType === "Solo"
+        It.Is<{ account: ValidAccountId, chainType: ChainType }>(
+            spec => spec.account.equals(ALICE_ACCOUNT) && spec.chainType === "Solo"
         )
     )).returns(Promise.resolve(transactions));
 

--- a/test/unit/controllers/vaulttransferrequest.controller.spec.ts
+++ b/test/unit/controllers/vaulttransferrequest.controller.spec.ts
@@ -237,7 +237,7 @@ function mockModelForReject(container: Container, verifies: boolean): void {
     mockOtherDependencies(container, repository);
 }
 
-const ALICE_LEGAL_OFFICER = notifiedLegalOfficer(ALICE);
+const ALICE_LEGAL_OFFICER = notifiedLegalOfficer(ALICE_ACCOUNT.address);
 
 function mockOtherDependencies(container: Container, repository: Mock<VaultTransferRequestRepository>) {
     notificationService = new Mock<NotificationService>();

--- a/test/unit/controllers/vaulttransferrequest.controller.spec.ts
+++ b/test/unit/controllers/vaulttransferrequest.controller.spec.ts
@@ -10,7 +10,7 @@ import {
     VaultTransferRequestDescription,
     VaultTransferRequestDecision,
 } from '../../../src/logion/model/vaulttransferrequest.model.js';
-import { ALICE, BOB } from '../../helpers/addresses.js';
+import { ALICE, BOB_ACCOUNT, ALICE_ACCOUNT } from '../../helpers/addresses.js';
 import { VaultTransferRequestController } from '../../../src/logion/controllers/vaulttransferrequest.controller.js';
 import { NotificationService, Template } from "../../../src/logion/services/notification.service.js";
 import moment from "moment";
@@ -26,14 +26,15 @@ import { UserIdentity } from '../../../src/logion/model/useridentity.js';
 import { PostalAddress } from '../../../src/logion/model/postaladdress.js';
 import { NonTransactionalVaultTransferRequestService, VaultTransferRequestService } from '../../../src/logion/services/vaulttransferrequest.service.js';
 import { LocRequestAggregateRoot, LocRequestDescription, LocRequestRepository } from '../../../src/logion/model/locrequest.model.js';
-import { LogionNodeApiClass } from '@logion/node-api';
+import { LogionNodeApiClass, ValidAccountId } from '@logion/node-api';
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 const { mockAuthenticatedUser, mockAuthenticationWithAuthenticatedUser, mockAuthenticationWithCondition, setupApp, mockLegalOfficerOnNode } = TestApp;
 
 describe('VaultTransferRequestController', () => {
 
     function authenticatedLLONotProtectingVault() {
-        const authenticatedUser = mockLegalOfficerOnNode(BOB);
+        const authenticatedUser = mockLegalOfficerOnNode(BOB_ACCOUNT);
         return mockAuthenticationWithAuthenticatedUser(authenticatedUser);
     }
 
@@ -60,17 +61,17 @@ describe('VaultTransferRequestController', () => {
 describe('VaultTransferRequestController', () => {
 
     it('creates with valid request', async () => {
-        const authenticatedUser = mockAuthenticatedUser(true, REQUESTER_ADDRESS);
+        const authenticatedUser = mockAuthenticatedUser(true, REQUESTER);
         const mock = mockAuthenticationWithAuthenticatedUser(authenticatedUser);
         const app = setupApp(VaultTransferRequestController, mockModelForRequest, mock);
 
         await request(app)
             .post('/api/vault-transfer-request')
             .send({
-                requesterAddress: REQUESTER_ADDRESS,
+                requesterAddress: REQUESTER.address,
                 legalOfficerAddress: ALICE,
-                origin: REQUESTER_ADDRESS,
-                destination: DESTINATION,
+                origin: REQUESTER.address,
+                destination: DESTINATION.address,
                 amount: "1000",
                 call: "0x0303005e017e03e2ee7a0a97e2e5df5cd902aa0b976d65eac998889ea40992efc3d254070010a5d4e8",
                 block: "4242",
@@ -101,7 +102,7 @@ describe('VaultTransferRequestController', () => {
         await request(app)
             .put('/api/vault-transfer-request')
             .send({
-                requesterAddress: "",
+                requesterAddress: "5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ",
                 statuses: ["ACCEPTED", "REJECTED"]
             })
             .expect(200)
@@ -111,8 +112,8 @@ describe('VaultTransferRequestController', () => {
                 expect(response.body.requests.length).toBe(1);
                 expect(response.body.requests[0].id).toBe(description.id);
                 expect(response.body.requests[0].createdOn).toBe(description.createdOn);
-                expect(response.body.requests[0].origin).toBe(description.origin);
-                expect(response.body.requests[0].destination).toBe(description.destination);
+                expect(response.body.requests[0].origin).toBe(description.origin.address);
+                expect(response.body.requests[0].destination).toBe(description.destination.address);
                 expect(response.body.requests[0].amount).toBe(description.amount.toString());
                 expect(response.body.requests[0].block).toBe(description.timepoint.blockNumber.toString());
                 expect(response.body.requests[0].index).toBe(description.timepoint.extrinsicIndex);
@@ -129,8 +130,8 @@ describe('VaultTransferRequestController', () => {
         await request(app)
             .put('/api/vault-transfer-request')
             .send({
-                requesterAddress: "",
-                legalOfficerAddress: [ ALICE ],
+                requesterAddress: "5CXLTF2PFBE89tTYsrofGPkSfGTdmW4ciw4vAfgcKhjggRgZ",
+                legalOfficerAddress: ALICE,
                 decisionStatuses: ["ACCEPTED", "REJECTED"]
             })
             .expect(401);
@@ -167,7 +168,7 @@ describe('VaultTransferRequestController', () => {
     });
 
     it('lets requester cancel', async () => {
-        const authenticatedUser = mockAuthenticatedUser(true, REQUESTER_ADDRESS);
+        const authenticatedUser = mockAuthenticatedUser(true, REQUESTER);
         const mock = mockAuthenticationWithAuthenticatedUser(authenticatedUser);
         const app = setupApp(VaultTransferRequestController, container => mockModelForAcceptOrCancel(container, true), mock);
 
@@ -188,7 +189,7 @@ describe('VaultTransferRequestController', () => {
     });
 
     it('lets requester resubmit', async () => {
-        const authenticatedUser = mockAuthenticatedUser(true, REQUESTER_ADDRESS);
+        const authenticatedUser = mockAuthenticatedUser(true, REQUESTER);
         const mock = mockAuthenticationWithAuthenticatedUser(authenticatedUser);
         const app = setupApp(VaultTransferRequestController, container => mockModelForAcceptOrCancel(container, true), mock);
 
@@ -214,6 +215,7 @@ const DECISION_TIMESTAMP = moment().toISOString();
 function mockModelForReject(container: Container, verifies: boolean): void {
     const vaultTransferRequest = mockVaultTransferRequest();
     vaultTransferRequest.setup(instance => instance.reject).returns(() => {});
+    vaultTransferRequest.setup(instance => instance.getLegalOfficer()).returns(ALICE_ACCOUNT);
     const decision = new Mock<VaultTransferRequestDecision>();
     decision.setup(instance => instance.rejectReason)
         .returns(REJECT_REASON)
@@ -246,11 +248,11 @@ function mockOtherDependencies(container: Container, repository: Mock<VaultTrans
 
     const directoryService = new Mock<DirectoryService>();
     directoryService
-        .setup(instance => instance.get(It.IsAny<string>()))
+        .setup(instance => instance.get(It.IsAny<ValidAccountId>()))
         .returns(Promise.resolve(ALICE_LEGAL_OFFICER));
     directoryService
         .setup(instance => instance.requireLegalOfficerAddressOnNode(It.IsAny<string>()))
-        .returns(Promise.resolve(ALICE));
+        .returns(Promise.resolve(ALICE_ACCOUNT));
     container.bind(DirectoryService).toConstantValue(directoryService.object());
 
     const protectionRequest = new Mock<ProtectionRequestAggregateRoot>();
@@ -279,7 +281,7 @@ function mockPolkadotService(): PolkadotService {
 
                     ],
                 });
-            } 
+            }
         }
     } as unknown as LogionNodeApiClass;
     polkadotService.setup(instance => instance.readyApi()).returns(Promise.resolve(api));
@@ -300,24 +302,25 @@ function mockLocRequestRepository(): LocRequestRepository {
 
 function mockVaultTransferRequest(): Mock<VaultTransferRequestAggregateRoot> {
     const vaultTransferRequest = new Mock<VaultTransferRequestAggregateRoot>()
-    vaultTransferRequest.setup(instance => instance.requesterAddress).returns(REQUESTER_ADDRESS)
+    vaultTransferRequest.setup(instance => instance.requesterAddress).returns(REQUESTER.getAddress(DB_SS58_PREFIX))
+    vaultTransferRequest.setup(instance => instance.getRequester()).returns(REQUESTER)
     vaultTransferRequest.setup(instance => instance.getDescription()).returns(description)
     return vaultTransferRequest
 }
 
-const REQUESTER_ADDRESS = "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY";
-const DESTINATION = "5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX";
+const REQUESTER = ValidAccountId.polkadot("5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY");
+const DESTINATION = ValidAccountId.polkadot("5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX");
 const TIMESTAMP = "2021-06-10T16:25:23.668294";
 const REJECT_REASON = "Illegal";
 const REQUEST_ID = "716f7a39-b570-42aa-bcf3-52679ce3cb44";
 
 const description: VaultTransferRequestDescription = {
-    requesterAddress: REQUESTER_ADDRESS,
-    legalOfficerAddress: ALICE,
+    requesterAddress: REQUESTER,
+    legalOfficerAddress: ALICE_ACCOUNT,
     id: REQUEST_ID,
     createdOn: moment.now().toString(),
     amount: 1000n,
-    origin: REQUESTER_ADDRESS,
+    origin: REQUESTER,
     destination: DESTINATION,
     timepoint: {
         blockNumber: 4242n,
@@ -345,11 +348,11 @@ const REQUESTER_IDENTITY_LOC_ID = "77c2fef4-6f1d-44a1-a49d-3485c2eb06ee";
 const protectionRequestDescription: ProtectionRequestDescription = {
     addressToRecover: null,
     requesterIdentityLocId: REQUESTER_IDENTITY_LOC_ID,
-    legalOfficerAddress: ALICE,
+    legalOfficerAddress: ALICE_ACCOUNT,
     createdOn: TIMESTAMP,
     isRecovery: false,
-    otherLegalOfficerAddress: BOB,
-    requesterAddress: REQUESTER_ADDRESS,
+    otherLegalOfficerAddress: BOB_ACCOUNT,
+    requesterAddress: REQUESTER,
 };
 
 function mockModelForFetch(container: Container): void {
@@ -389,7 +392,7 @@ function mockVaultTransferRequestModel(container: Container): void {
     root.setup(instance => instance.decision).returns(decision.object());
     factory.setup(instance => instance.newVaultTransferRequest(
             It.Is<VaultTransferRequestDescription>(description =>
-                description.requesterAddress === REQUESTER_ADDRESS)))
+                description.requesterAddress.equals(REQUESTER))))
         .returns(root.object());
     container.bind(VaultTransferRequestFactory).toConstantValue(factory.object());
     mockOtherDependencies(container, repository);
@@ -402,6 +405,7 @@ function mockModelForAcceptOrCancel(container: Container, verifies: boolean): vo
     vaultTransferRequest.setup(instance => instance.accept(It.IsAny())).returns(undefined);
     vaultTransferRequest.setup(instance => instance.cancel(It.IsAny())).returns(undefined);
     vaultTransferRequest.setup(instance => instance.resubmit()).returns(undefined);
+    vaultTransferRequest.setup(instance => instance.getLegalOfficer()).returns(ALICE_ACCOUNT);
     const decision = new Mock<VaultTransferRequestDecision>();
     decision.setup(instance => instance.decisionOn)
         .returns(DECISION_TIMESTAMP)

--- a/test/unit/controllers/vote.controller.spec.ts
+++ b/test/unit/controllers/vote.controller.spec.ts
@@ -4,7 +4,8 @@ import { Mock } from "moq.ts";
 import request from "supertest";
 import { VoteController } from "../../../src/logion/controllers/vote.controller.js";
 import { VoteRepository, VoteAggregateRoot, Ballot } from "../../../src/logion/model/vote.model.js";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 const { setupApp } = TestApp;
 
@@ -25,7 +26,7 @@ describe("VoteController", () => {
                 expect(response.body.votes[0].voteId).toEqual(VOTE_ID);
                 expect(response.body.votes[0].locId).toEqual(LOC_ID);
                 expect(response.body.votes[0].createdOn).toEqual(CREATED_ON);
-                expect(response.body.votes[0].ballots[ALICE]).toEqual("Yes");
+                expect(response.body.votes[0].ballots[ALICE_ACCOUNT.address]).toEqual("Yes");
                 expect(response.body.votes[0].status).toEqual("APPROVED");
             })
     })
@@ -41,7 +42,7 @@ function mockForFetch(container: Container) {
     const ballot = new Ballot();
     ballot.vote = vote.object();
     ballot.voteId = VOTE_ID;
-    ballot.voterAddress = ALICE;
+    ballot.voterAddress = ALICE_ACCOUNT.getAddress(DB_SS58_PREFIX);
     ballot.result = "Yes";
     ballots.push(ballot);
     vote.setup(instance => instance.ballots).returns(ballots);

--- a/test/unit/controllers/workload.controller.spec.ts
+++ b/test/unit/controllers/workload.controller.spec.ts
@@ -2,9 +2,10 @@ import { TestApp } from "@logion/rest-api-core";
 import { Container } from "inversify";
 import { Mock, It } from "moq.ts";
 import request from "supertest";
-import { ALICE, BOB } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
 import { WorkloadController } from "../../../src/logion/controllers/workload.controller.js";
 import { WorkloadService } from "../../../src/logion/services/workload.service.js";
+import { ValidAccountId } from "@logion/node-api";
 
 const { setupApp } = TestApp;
 
@@ -15,7 +16,7 @@ describe("WorkloadController", () => {
         await request(app)
             .put(`/api/workload`)
             .send({
-                legalOfficerAddresses: [ ALICE, BOB ]
+                legalOfficerAddresses: [ ALICE_ACCOUNT.address, BOB_ACCOUNT.address ]
             })
             .expect(200)
             .expect('Content-Type', /application\/json/)
@@ -28,9 +29,9 @@ describe("WorkloadController", () => {
 
 function mockForFetch(container: Container) {
     const service = new Mock<WorkloadService>();
-    service.setup(instance => instance.workloadOf(It.Is<string[]>(params =>
-        params.includes(ALICE) &&
-        params.includes(BOB)
+    service.setup(instance => instance.workloadOf(It.Is<ValidAccountId[]>(params =>
+        params[0].equals(ALICE_ACCOUNT) &&
+        params[1].equals(BOB_ACCOUNT)
     ))).returnsAsync({
         ALICE: 42,
         BOB: 24,

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from "uuid";
-import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import moment, { Moment } from "moment";
 import {
     LocRequestDescription,
@@ -2045,8 +2045,8 @@ function givenRequestWithStatus(status: LocRequestStatus) {
     request.requester = EmbeddableNullableAccountId.from(SUBMITTER)
 }
 
-const OWNER = ALICE;
 const OWNER_ACCOUNT = ALICE_ACCOUNT;
+const OWNER = OWNER_ACCOUNT.address;
 
 let request: LocRequestAggregateRoot;
 

--- a/test/unit/model/locrequest.model.spec.ts
+++ b/test/unit/model/locrequest.model.spec.ts
@@ -26,21 +26,15 @@ import {
     PublicSeal,
     LATEST_SEAL_VERSION
 } from "../../../src/logion/services/seal.service.js";
-import { UUID } from "@logion/node-api";
+import { UUID, ValidAccountId } from "@logion/node-api";
 import { IdenfyVerificationSession, IdenfyVerificationStatus } from "src/logion/services/idenfy/idenfy.types.js";
-import { SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
 import { Hash } from "../../../src/logion/lib/crypto/hashing.js";
 import { POLKADOT_REQUESTER } from "../controllers/locrequest.controller.shared.js";
+import { EmbeddableNullableAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
 
-const SUBMITTER: SupportedAccountId = {
-    type: "Polkadot",
-    address: "5DDGQertEH5qvKVXUmpT3KNGViCX582Qa2WWb8nGbkmkRHvw"
-};
+const SUBMITTER = ValidAccountId.polkadot("vQtS4iX2RGv5ERHZVg7Xsi54Qw5wXkQkK4tuNt7nTVVn8F6AN");
 
-const VERIFIED_ISSUER: SupportedAccountId = {
-    type: "Polkadot",
-    address: "5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX"
-};
+const VERIFIED_ISSUER = ValidAccountId.polkadot("5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX");
 
 const PUBLIC_SEAL: PublicSeal = {
     hash: Hash.fromHex("0x48aedf4e08e46b24970d97db566bfa6668581cc2f37791bac0c9817a4508607a"),
@@ -66,8 +60,9 @@ describe("LocRequestFactory", () => {
         const requesterIdentityLoc = new Mock<LocRequestAggregateRoot>();
         requesterIdentityLoc.setup(instance => instance.id).returns(requesterIdentityLocId);
         if (requesterAddress) {
-            requesterIdentityLoc.setup(instance => instance.requesterAddress).returns(requesterAddress);
-            requesterIdentityLoc.setup(instance => instance.requesterAddressType).returns("Polkadot");
+            const requester = ValidAccountId.polkadot(requesterAddress);
+            requesterIdentityLoc.setup(instance => instance.requester).returns(EmbeddableNullableAccountId.from(requester));
+            requesterIdentityLoc.setup(instance => instance.getRequester()).returns(requester);
         }
         repository.setup(instance => instance.findById(requesterIdentityLocId)).returns(Promise.resolve(requesterIdentityLoc.object()));
         return requesterIdentityLocId;
@@ -306,9 +301,9 @@ describe("LocRequestFactory", () => {
 
     function createDescription(locType: LocType, requesterAddress?: string, requesterIdentityLoc?: string, userIdentity?: UserIdentity, userPostalAddress?: PostalAddress, seal?: PublicSeal): LocRequestDescription {
         return {
-            requesterAddress: requesterAddress ? { type: "Polkadot", address: requesterAddress } : undefined,
+            requesterAddress: requesterAddress !== undefined ? ValidAccountId.polkadot(requesterAddress) : undefined,
             requesterIdentityLoc,
-            ownerAddress: ALICE,
+            ownerAddress: ALICE_ACCOUNT,
             description: "Mrs ALice, I want to sell my last art work",
             createdOn: moment().toISOString(),
             userIdentity,
@@ -735,7 +730,7 @@ describe("LocRequestAggregateRoot (metadata)", () => {
 
     it("submitter removes previously added metadata item", () => testRemovesItem(SUBMITTER));
 
-    function testRemovesItem(remover: SupportedAccountId) {
+    function testRemovesItem(remover: ValidAccountId) {
         givenRequestWithStatus('OPEN');
         const items: MetadataItemParams[] = [
             {
@@ -1270,7 +1265,7 @@ describe("LocRequestAggregateRoot (files)", () => {
 
     it("submitter removes previously added files", () => testRemovesFile(SUBMITTER));
 
-    function testRemovesFile(remover: SupportedAccountId) {
+    function testRemovesFile(remover: ValidAccountId) {
         givenRequestWithStatus('OPEN');
         const files: FileParams[] = [
             {
@@ -2047,8 +2042,7 @@ function givenRequestWithStatus(status: LocRequestStatus) {
     request.metadata = [];
     request.links = [];
     request.ownerAddress = OWNER;
-    request.requesterAddress = SUBMITTER.address;
-    request.requesterAddressType = SUBMITTER.type;
+    request.requester = EmbeddableNullableAccountId.from(SUBMITTER)
 }
 
 const OWNER = ALICE;
@@ -2263,7 +2257,7 @@ function whenSettingMetadataItemAddedOn(nameHash: Hash, addedOn:Moment) {
     request.setMetadataItemAddedOn(nameHash, addedOn);
 }
 
-function whenConfirmingMetadataItem(nameHash: Hash, contributor: SupportedAccountId) {
+function whenConfirmingMetadataItem(nameHash: Hash, contributor: ValidAccountId) {
     request.prePublishOrAcknowledgeMetadataItem(nameHash, contributor);
 }
 
@@ -2284,7 +2278,7 @@ function whenSettingFileAddedOn(hash: Hash, addedOn:Moment) {
     request.setFileAddedOn(hash, addedOn);
 }
 
-function whenConfirmingFile(hash: Hash, contributor: SupportedAccountId) {
+function whenConfirmingFile(hash: Hash, contributor: ValidAccountId) {
     request.prePublishOrAcknowledgeFile(hash, contributor);
 }
 
@@ -2305,7 +2299,7 @@ function whenSettingLinkAddedOn(target: string, addedOn:Moment) {
     request.setLinkAddedOn(target, addedOn);
 }
 
-function whenConfirmingLink(target: string, contributor: SupportedAccountId) {
+function whenConfirmingLink(target: string, contributor: ValidAccountId) {
     request.prePublishOrAcknowledgeLink(target, contributor);
 }
 
@@ -2325,15 +2319,15 @@ function thenExposesLocCreatedDate(expectedDate: Moment) {
     expect(request.getLocCreatedDate().isSame(expectedDate)).toBe(true);
 }
 
-function whenRemovingMetadataItem(remover: SupportedAccountId, nameHash: Hash) {
+function whenRemovingMetadataItem(remover: ValidAccountId, nameHash: Hash) {
     request.removeMetadataItem(remover, nameHash);
 }
 
-function whenRemovingLink(remover: SupportedAccountId, target: string) {
+function whenRemovingLink(remover: ValidAccountId, target: string) {
     request.removeLink(remover, target);
 }
 
-function whenRemovingFile(remover: SupportedAccountId, hash: Hash) {
+function whenRemovingFile(remover: ValidAccountId, hash: Hash) {
     removedFile = request.removeFile(remover, hash);
 }
 
@@ -2450,7 +2444,7 @@ function thenStatusIs(expectedStatus: LocRequestStatus) {
     expect(request.status).toBe(expectedStatus);
 }
 
-function givenAcceptedLocWithAllAccepted(submitter: SupportedAccountId) {
+function givenAcceptedLocWithAllAccepted(submitter: ValidAccountId) {
     givenRequestWithStatus("DRAFT");
 
     const fileHash = Hash.of("hash1");
@@ -2490,7 +2484,7 @@ function givenAcceptedLocWithAllAccepted(submitter: SupportedAccountId) {
     return { itemNameHash, fileHash, requesterLinkTarget };
 }
 
-function givenOpenLocWithAllAccepted(submitter: SupportedAccountId) {
+function givenOpenLocWithAllAccepted(submitter: ValidAccountId) {
     const items = givenAcceptedLocWithAllAccepted(submitter);
 
     request.preOpen(false);

--- a/test/unit/model/lofile.model.spec.ts
+++ b/test/unit/model/lofile.model.spec.ts
@@ -1,11 +1,11 @@
 import { LoFileFactory, LoFileAggregateRoot, LoFileDescription } from "../../../src/logion/model/lofile.model.js";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT } from "../../helpers/addresses.js";
 
 describe("LO File model", () => {
 
     const description: LoFileDescription = {
         id: "sof-header",
-        legalOfficerAddress: ALICE,
+        legalOfficer: ALICE_ACCOUNT,
         contentType: "image/png",
         oid: 123,
     };

--- a/test/unit/model/protectionrequest.model.spec.ts
+++ b/test/unit/model/protectionrequest.model.spec.ts
@@ -6,7 +6,7 @@ import {
     ProtectionRequestFactory,
     ProtectionRequestAggregateRoot, ProtectionRequestStatus,
 } from '../../../src/logion/model/protectionrequest.model.js';
-import { BOB, CHARLY, ALICE } from '../../helpers/addresses.js';
+import { CHARLY, ALICE_ACCOUNT, BOB_ACCOUNT } from '../../helpers/addresses.js';
 import { Mock, It } from "moq.ts";
 import {
     LocRequestRepository,
@@ -16,6 +16,8 @@ import {
 import { EmbeddableUserIdentity } from "../../../src/logion/model/useridentity.js";
 import { EmbeddablePostalAddress } from "../../../src/logion/model/postaladdress.js";
 import { expectAsyncToThrow } from "../../helpers/asynchelper.js";
+import { ValidAccountId } from "@logion/node-api";
+import { EmbeddableNullableAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
 
 describe('ProtectionRequestFactoryTest', () => {
 
@@ -138,10 +140,10 @@ const userPostalAddress = {
     country: "Belgium",
 };
 const description: ProtectionRequestDescription = {
-    requesterAddress: "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW",
+    requesterAddress: ValidAccountId.polkadot("5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW"),
     requesterIdentityLocId: "80124e8a-a7d8-456f-a7be-deb4e0983e87",
-    legalOfficerAddress: ALICE,
-    otherLegalOfficerAddress: BOB,
+    legalOfficerAddress: ALICE_ACCOUNT,
+    otherLegalOfficerAddress: BOB_ACCOUNT,
     createdOn: moment().toISOString(),
     isRecovery: false,
     addressToRecover: null,
@@ -159,9 +161,8 @@ async function newProtectionRequestUsingFactory(status?: ProtectionRequestStatus
     }
     identityLoc.userIdentity = EmbeddableUserIdentity.from(userIdentity);
     identityLoc.userPostalAddress = EmbeddablePostalAddress.from(userPostalAddress);
-    identityLoc.requesterAddress = description.requesterAddress;
-    identityLoc.requesterAddressType = "Polkadot";
-    identityLoc.ownerAddress = description.legalOfficerAddress;
+    identityLoc.requester = EmbeddableNullableAccountId.from(description.requesterAddress);
+    identityLoc.ownerAddress = description.legalOfficerAddress.address;
 
     const locRequestRepository = new Mock<LocRequestRepository>();
     locRequestRepository.setup(instance => instance.findById(It.IsAny<string>()))

--- a/test/unit/model/protectionrequest.model.spec.ts
+++ b/test/unit/model/protectionrequest.model.spec.ts
@@ -6,7 +6,7 @@ import {
     ProtectionRequestFactory,
     ProtectionRequestAggregateRoot, ProtectionRequestStatus,
 } from '../../../src/logion/model/protectionrequest.model.js';
-import { CHARLY, ALICE_ACCOUNT, BOB_ACCOUNT } from '../../helpers/addresses.js';
+import { CHARLY_ACCOUNT, ALICE_ACCOUNT, BOB_ACCOUNT } from '../../helpers/addresses.js';
 import { Mock, It } from "moq.ts";
 import {
     LocRequestRepository,
@@ -17,7 +17,7 @@ import { EmbeddableUserIdentity } from "../../../src/logion/model/useridentity.j
 import { EmbeddablePostalAddress } from "../../../src/logion/model/postaladdress.js";
 import { expectAsyncToThrow } from "../../helpers/asynchelper.js";
 import { ValidAccountId } from "@logion/node-api";
-import { EmbeddableNullableAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
+import { EmbeddableNullableAccountId, DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 describe('ProtectionRequestFactoryTest', () => {
 
@@ -119,8 +119,8 @@ describe('ProtectionRequestAggregateRootTest', () => {
 
     it("updates", async () => {
         const request = await newProtectionRequestUsingFactory();
-        request.updateOtherLegalOfficer(CHARLY);
-        expect(request.otherLegalOfficerAddress).toEqual(CHARLY);
+        request.updateOtherLegalOfficer(CHARLY_ACCOUNT.getAddress(DB_SS58_PREFIX));
+        expect(request.otherLegalOfficerAddress).toEqual(CHARLY_ACCOUNT.getAddress(DB_SS58_PREFIX));
     });
 });
 

--- a/test/unit/model/protectionrequest.model.spec.ts
+++ b/test/unit/model/protectionrequest.model.spec.ts
@@ -119,7 +119,7 @@ describe('ProtectionRequestAggregateRootTest', () => {
 
     it("updates", async () => {
         const request = await newProtectionRequestUsingFactory();
-        request.updateOtherLegalOfficer(CHARLY_ACCOUNT.getAddress(DB_SS58_PREFIX));
+        request.updateOtherLegalOfficer(CHARLY_ACCOUNT);
         expect(request.otherLegalOfficerAddress).toEqual(CHARLY_ACCOUNT.getAddress(DB_SS58_PREFIX));
     });
 });

--- a/test/unit/model/transaction.model.spec.ts
+++ b/test/unit/model/transaction.model.spec.ts
@@ -1,4 +1,4 @@
-import { Fees, Lgnt } from "@logion/node-api";
+import { Fees, Lgnt, ValidAccountId } from "@logion/node-api";
 import moment from "moment";
 import {
     TransactionAggregateRoot,
@@ -6,14 +6,15 @@ import {
     TransactionDescription
 } from "../../../src/logion/model/transaction.model.js";
 import { Block, EmbeddableBlock } from "../../../src/logion/model/block.model.js";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 describe("TransactionAggregateRoot", () => {
 
     it("provides expected description when successful", () => {
         const transaction = aSuccessfulTransaction();
         const description = transaction.getDescription();
-        expect(description.from).toBe(transaction.from!);
-        expect(description.to).toBe(transaction.to!);
+        expect(description.from.getAddress(DB_SS58_PREFIX)).toBe(transaction.from!);
+        expect(description.to?.getAddress(DB_SS58_PREFIX)).toBe(transaction.to!);
         expect(description.createdOn).toBe(transaction.createdOn!);
         expect(description.transferValue.toString()).toBe(transaction.transferValue!);
         expect(description.error).toBeUndefined()
@@ -22,8 +23,8 @@ describe("TransactionAggregateRoot", () => {
     it("provides expected description when not successful", () => {
         const transaction = aNotSuccessfulTransaction();
         const description = transaction.getDescription();
-        expect(description.from).toBe(transaction.from!);
-        expect(description.to).toBe(transaction.to!);
+        expect(description.from.getAddress(DB_SS58_PREFIX)).toBe(transaction.from!);
+        expect(description.to?.getAddress(DB_SS58_PREFIX)).toBe(transaction.to!);
         expect(description.createdOn).toBe(transaction.createdOn!);
         expect(description.transferValue.toString()).toBe(transaction.transferValue!);
         expect(description.error).toEqual({ section: "aSection", name: "aName", details: "someDetails" })
@@ -49,8 +50,8 @@ function aTransaction(): TransactionAggregateRoot {
     let transaction = new TransactionAggregateRoot();
     transaction.block = EmbeddableBlock.from(Block.soloBlock(1n));
     transaction.extrinsicIndex = 1;
-    transaction.from = "from";
-    transaction.to = "to";
+    transaction.from = "5FbJzFZxa9VuLmdwBzY1nhS5nRbmFC1YrtCARRo8n94pPrqH";
+    transaction.to = "5FgoYarSuwBEW8924ksWt3mDox7fhG7mnzmjRNWgvSiH1kuD";
     transaction.createdOn = moment().toISOString();
     transaction.transferValue = "123456";
     transaction.type = "EXTRINSIC";
@@ -63,8 +64,8 @@ describe("TransactionFactory", () => {
         id: "some-id",
         block: Block.soloBlock(123456n),
         extrinsicIndex: 5,
-        from: "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW",
-        to: "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY",
+        from: ValidAccountId.polkadot("5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW"),
+        to: ValidAccountId.polkadot("5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY"),
         fees: new Fees({ inclusionFee: Lgnt.fromCanonical(12n) }),
         transferValue: 34n,
         tip: 56n,

--- a/test/unit/model/vaulttransferrequest.model.spec.ts
+++ b/test/unit/model/vaulttransferrequest.model.spec.ts
@@ -6,7 +6,8 @@ import {
     VaultTransferRequestFactory,
     VaultTransferRequestAggregateRoot,
 } from '../../../src/logion/model/vaulttransferrequest.model.js';
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
+import { ValidAccountId } from "@logion/node-api";
 
 describe('VaultTransferRequestFactory', () => {
 
@@ -101,10 +102,10 @@ describe('VaultTransferRequestAggregateRoot', () => {
 
 const description: VaultTransferRequestDescription = {
     id: uuid(),
-    requesterAddress: "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW",
-    legalOfficerAddress: ALICE,
-    origin: "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW",
-    destination: "5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX",
+    requesterAddress: ValidAccountId.polkadot("5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW"),
+    legalOfficerAddress: ALICE_ACCOUNT,
+    origin: ValidAccountId.polkadot("5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW"),
+    destination: ValidAccountId.polkadot("5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX"),
     createdOn: moment().toISOString(),
     amount: 10000n,
     timepoint: {

--- a/test/unit/model/vaulttransferrequest.model.spec.ts
+++ b/test/unit/model/vaulttransferrequest.model.spec.ts
@@ -6,7 +6,7 @@ import {
     VaultTransferRequestFactory,
     VaultTransferRequestAggregateRoot,
 } from '../../../src/logion/model/vaulttransferrequest.model.js';
-import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import { ValidAccountId } from "@logion/node-api";
 
 describe('VaultTransferRequestFactory', () => {

--- a/test/unit/model/verifiedthirdpartyselection.model.spec.ts
+++ b/test/unit/model/verifiedthirdpartyselection.model.spec.ts
@@ -16,7 +16,7 @@ function buildSelection(): VerifiedIssuerAggregateRoot {
     return factory.newSelection(SELECTION_ID, ISSUER_LOC_ID);
 }
 
-const ISSUER= ValidAccountId.polkadot("5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb");
+const ISSUER = ValidAccountId.polkadot("5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb");
 const SELECTION_ID: VerifiedIssuerSelectionId = {
     locRequestId: "98c54013-af47-409f-b90d-edcdb71e7cb9",
     issuer: ISSUER,

--- a/test/unit/model/verifiedthirdpartyselection.model.spec.ts
+++ b/test/unit/model/verifiedthirdpartyselection.model.spec.ts
@@ -1,4 +1,5 @@
 import { VerifiedIssuerAggregateRoot, VerifiedIssuerSelectionFactory, VerifiedIssuerSelectionId } from "../../../src/logion/model/verifiedissuerselection.model.js";
+import { ValidAccountId } from "@logion/node-api";
 
 describe("VerifiedIssuerSelectionFactory", () => {
 
@@ -15,9 +16,9 @@ function buildSelection(): VerifiedIssuerAggregateRoot {
     return factory.newSelection(SELECTION_ID, ISSUER_LOC_ID);
 }
 
-const ISSUER_ADDRESS = "5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb";
+const ISSUER= ValidAccountId.polkadot("5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb");
 const SELECTION_ID: VerifiedIssuerSelectionId = {
     locRequestId: "98c54013-af47-409f-b90d-edcdb71e7cb9",
-    issuer: ISSUER_ADDRESS,
+    issuer: ISSUER,
 };
 const ISSUER_LOC_ID = "a3c29d7b-6ad5-44f6-b2df-f09dd841f212";

--- a/test/unit/model/vote.spec.ts
+++ b/test/unit/model/vote.spec.ts
@@ -1,6 +1,7 @@
-import { ALICE, BOB } from "@logion/rest-api-core/dist/TestApp.js";
 import moment from "moment";
 import { VoteAggregateRoot, VoteFactory } from "../../../src/logion/model/vote.model.js";
+import { ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 
 describe("VoteFactory", () => {
 
@@ -24,18 +25,18 @@ describe("VoteAggregateRoot", () => {
 
     it("accepts ballots", () => {
         const vote = buildPendingVote();
-        vote.addBallot(ALICE, "Yes");
-        vote.addBallot(BOB, "No");
+        vote.addBallot(ALICE_ACCOUNT, "Yes");
+        vote.addBallot(BOB_ACCOUNT, "No");
         expect(vote.ballots?.length).toBe(2);
 
         expect(vote.ballots![0].vote).toBe(vote);
         expect(vote.ballots![0].voteId).toBe(vote.voteId);
-        expect(vote.ballots![0].voterAddress).toBe(ALICE);
+        expect(vote.ballots![0].voterAddress).toBe(ALICE_ACCOUNT.getAddress(DB_SS58_PREFIX));
         expect(vote.ballots![0].result).toBe("Yes");
 
         expect(vote.ballots![1].vote).toBe(vote);
         expect(vote.ballots![1].voteId).toBe(vote.voteId);
-        expect(vote.ballots![1].voterAddress).toBe(BOB);
+        expect(vote.ballots![1].voterAddress).toBe(BOB_ACCOUNT.getAddress(DB_SS58_PREFIX));
         expect(vote.ballots![1].result).toBe("No");
     });
 

--- a/test/unit/services/idenfy/idenfy.service.spec.ts
+++ b/test/unit/services/idenfy/idenfy.service.spec.ts
@@ -14,9 +14,7 @@ import { IdenfyVerificationSession } from "../../../../src/logion/services/idenf
 import { NonTransactionalLocRequestService } from "../../../../src/logion/services/locrequest.service.js";
 import { Readable } from "stream";
 import { mockOwner } from "../../controllers/locrequest.controller.shared.js";
-import { accountEquals } from "../../../../src/logion/model/supportedaccountid.model.js";
 import { expectAsyncToThrow } from "../../../helpers/asynchelper.js";
-import { ValidAccountId } from "@logion/node-api";
 
 describe("DisabledIdenfyService", () => {
 
@@ -74,7 +72,7 @@ describe("EnabledIdenfyService", () => {
                 && file.contentType === EXPECTED_FILES[fileType].contentType
                 && file.nature === EXPECTED_FILES[fileType].nature
                 && file.name === EXPECTED_FILES[fileType].name
-                && accountEquals(file.submitter, LOC_OWNER_ACCOUNT)
+                && file.submitter.equals(LOC_OWNER_ACCOUNT)
             ), "MANUAL_BY_USER"));
         }
         locRequestRepository.verify(instance => instance.save(locRequest.object()));

--- a/test/unit/services/idenfy/idenfy.service.spec.ts
+++ b/test/unit/services/idenfy/idenfy.service.spec.ts
@@ -14,11 +14,9 @@ import { IdenfyVerificationSession } from "../../../../src/logion/services/idenf
 import { NonTransactionalLocRequestService } from "../../../../src/logion/services/locrequest.service.js";
 import { Readable } from "stream";
 import { mockOwner } from "../../controllers/locrequest.controller.shared.js";
-import {
-    accountEquals,
-    polkadotAccount
-} from "../../../../src/logion/model/supportedaccountid.model.js";
+import { accountEquals } from "../../../../src/logion/model/supportedaccountid.model.js";
 import { expectAsyncToThrow } from "../../../helpers/asynchelper.js";
+import { ValidAccountId } from "@logion/node-api";
 
 describe("DisabledIdenfyService", () => {
 
@@ -115,7 +113,7 @@ const IDENFY_API_KEY = "api-key";
 const IDENFY_API_SECRET = "api-secret";
 const IDENFY_SIGNING_KEY = "signing-key";
 const IDENFY_SCAN_REF = "3af0b5c9-8ef3-4815-8796-5ab3ed942917";
-const LOC_OWNER_ACCOUNT = polkadotAccount(ALICE);
+const LOC_OWNER_ACCOUNT = ValidAccountId.polkadot(ALICE);
 const VERIFICATION_CREATION: IdenfyVerificationCreation = {
     successUrl: `${ BASE_URL }/user/idenfy?result=success&locId=${ REQUEST_ID }`,
     errorUrl: `${ BASE_URL }/user/idenfy?result=error&locId=${ REQUEST_ID }`,

--- a/test/unit/services/idenfy/idenfy.service.spec.ts
+++ b/test/unit/services/idenfy/idenfy.service.spec.ts
@@ -4,7 +4,7 @@ import { LocRequestAggregateRoot, LocRequestDescription, LocRequestRepository, F
 import { AxiosFactory } from "src/logion/services/axiosfactory.service.js";
 import { FileStorageService } from "src/logion/services/file.storage.service.js";
 import { LocRequestService } from "src/logion/services/locrequest.service.js";
-import { ALICE } from "../../../helpers/addresses.js";
+import { ALICE_ACCOUNT } from "../../../helpers/addresses.js";
 import {
     DisabledIdenfyService,
     EnabledIdenfyService,
@@ -113,7 +113,7 @@ const IDENFY_API_KEY = "api-key";
 const IDENFY_API_SECRET = "api-secret";
 const IDENFY_SIGNING_KEY = "signing-key";
 const IDENFY_SCAN_REF = "3af0b5c9-8ef3-4815-8796-5ab3ed942917";
-const LOC_OWNER_ACCOUNT = ValidAccountId.polkadot(ALICE);
+const LOC_OWNER_ACCOUNT = ALICE_ACCOUNT;
 const VERIFICATION_CREATION: IdenfyVerificationCreation = {
     successUrl: `${ BASE_URL }/user/idenfy?result=success&locId=${ REQUEST_ID }`,
     errorUrl: `${ BASE_URL }/user/idenfy?result=error&locId=${ REQUEST_ID }`,

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -16,7 +16,7 @@ import { DirectoryService } from "../../../src/logion/services/directory.service
 import { VerifiedIssuerSelectionService } from "src/logion/services/verifiedissuerselection.service.js";
 import { NonTransactionalTokensRecordService } from "../../../src/logion/services/tokensrecord.service.js";
 import { TokensRecordRepository } from "../../../src/logion/model/tokensrecord.model.js";
-import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import { Hash } from "../../../src/logion/lib/crypto/hashing.js";
 import { ItIsAccount, ItIsHash } from "../../helpers/Mock.js";
 
@@ -214,11 +214,11 @@ function givenLocExtrinsic(method: string, args: TypesJsonObject) {
     });
     locExtrinsic.setup(instance => instance.error).returns(() => null);
     locExtrinsic.setup(instance => instance.partialFee()).returnsAsync("42");
-    locExtrinsic.setup(instance => instance.signer).returns(ALICE);
+    locExtrinsic.setup(instance => instance.signer).returns(ALICE_ACCOUNT.address);
     if(method === "addFile") {
         locExtrinsic.setup(instance => instance.storageFee).returns({
             fee: 24n,
-            withdrawnFrom: ALICE
+            withdrawnFrom: ALICE_ACCOUNT.address
         });
     }
 }
@@ -319,7 +319,7 @@ function thenLinkUpdated() {
 
 function givenLocRequestExpectsFileUpdated() {
     locRequest.setup(instance => instance.setFileAddedOn(ItIsHash(FILE_HASH), IS_BLOCK_TIME)).returns(undefined);
-    locRequest.setup(instance => instance.setFileFees(ItIsHash(FILE_HASH), IS_EXPECTED_FEES, ALICE)).returns(undefined);
+    locRequest.setup(instance => instance.setFileFees(ItIsHash(FILE_HASH), IS_EXPECTED_FEES, ALICE_ACCOUNT.address)).returns(undefined);
 }
 
 const FILE_HASH = Hash.fromHex("0x37f1c3d493ad2320d7cc935446c9e094249b5070988820b864b417b708695ed7");
@@ -327,7 +327,7 @@ const IS_EXPECTED_FEES = It.Is<Fees>(fees => fees.inclusionFee.canonical === 42n
 
 function thenFileUpdated() {
     locRequest.verify(instance => instance.setFileAddedOn(ItIsHash(FILE_HASH), IS_BLOCK_TIME));
-    locRequest.verify(instance => instance.setFileFees(ItIsHash(FILE_HASH), IS_EXPECTED_FEES, ALICE));
+    locRequest.verify(instance => instance.setFileFees(ItIsHash(FILE_HASH), IS_EXPECTED_FEES, ALICE_ACCOUNT.address));
 }
 
 function givenLocRequestExpectsVoid() {

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -16,7 +16,7 @@ import { DirectoryService } from "../../../src/logion/services/directory.service
 import { VerifiedIssuerSelectionService } from "src/logion/services/verifiedissuerselection.service.js";
 import { NonTransactionalTokensRecordService } from "../../../src/logion/services/tokensrecord.service.js";
 import { TokensRecordRepository } from "../../../src/logion/model/tokensrecord.model.js";
-import { ALICE } from "../../helpers/addresses.js";
+import { ALICE, ALICE_ACCOUNT } from "../../helpers/addresses.js";
 import { Hash } from "../../../src/logion/lib/crypto/hashing.js";
 import { ItIsAccount, ItIsHash } from "../../helpers/Mock.js";
 
@@ -343,25 +343,25 @@ function thenCollectionItemSaved() {
 }
 
 function givenLocRequestExpectsMetadataItemAcknowledged() {
-    locRequest.setup(instance => instance.preAcknowledgeMetadataItem(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.preAcknowledgeMetadataItem(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE_ACCOUNT), IS_BLOCK_TIME)).returns(undefined);
 }
 
 function thenMetadataAcknowledged() {
-    locRequest.verify(instance => instance.preAcknowledgeMetadataItem(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE), IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.preAcknowledgeMetadataItem(IS_EXPECTED_NAME_HASH, ItIsAccount(ALICE_ACCOUNT), IS_BLOCK_TIME));
 }
 
 function givenLocRequestExpectsFileAcknowledged() {
-    locRequest.setup(instance => instance.preAcknowledgeFile(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.preAcknowledgeFile(ItIsHash(FILE_HASH), ItIsAccount(ALICE_ACCOUNT), IS_BLOCK_TIME)).returns(undefined);
 }
 
 function thenFileAcknowledged() {
-    locRequest.verify(instance => instance.preAcknowledgeFile(ItIsHash(FILE_HASH), ItIsAccount(ALICE), IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.preAcknowledgeFile(ItIsHash(FILE_HASH), ItIsAccount(ALICE_ACCOUNT), IS_BLOCK_TIME));
 }
 
 function givenLocRequestExpectsLinkAcknowledged() {
-    locRequest.setup(instance => instance.preAcknowledgeLink(IS_EXPECTED_TARGET, ItIsAccount(ALICE), IS_BLOCK_TIME)).returns(undefined);
+    locRequest.setup(instance => instance.preAcknowledgeLink(IS_EXPECTED_TARGET, ItIsAccount(ALICE_ACCOUNT), IS_BLOCK_TIME)).returns(undefined);
 }
 
 function thenLinkAcknowledged() {
-    locRequest.verify(instance => instance.preAcknowledgeLink(IS_EXPECTED_TARGET, ItIsAccount(ALICE), IS_BLOCK_TIME));
+    locRequest.verify(instance => instance.preAcknowledgeLink(IS_EXPECTED_TARGET, ItIsAccount(ALICE_ACCOUNT), IS_BLOCK_TIME));
 }

--- a/test/unit/services/notification-test-data.ts
+++ b/test/unit/services/notification-test-data.ts
@@ -2,7 +2,7 @@ import {
     ProtectionRequestDescription,
     LegalOfficerDecisionDescription
 } from "../../../src/logion/model/protectionrequest.model.js";
-import { BOB, ALICE, ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
+import { ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
 import { LegalOfficer } from "../../../src/logion/model/legalofficer.model.js";
 import { LocRequestDescription, LocRequestDecision } from "../../../src/logion/model/locrequest.model.js";
 import { VaultTransferRequestDescription } from "src/logion/model/vaulttransferrequest.model.js";
@@ -28,9 +28,9 @@ export function notifiedLegalOfficer(address:string): LegalOfficer {
         additionalDetails: "some details",
         node: "http://localhost:8080",
         userIdentity: {
-            firstName: address === BOB ? "Bob": "Alice",
+            firstName: address === BOB_ACCOUNT.address ? "Bob": "Alice",
             lastName: "Network",
-            email: address === BOB ? "bob@logion.network" : "alice@logion.network",
+            email: address === BOB_ACCOUNT.address ? "bob@logion.network" : "alice@logion.network",
             phoneNumber: "123465",
         },
         postalAddress: {
@@ -81,8 +81,8 @@ const vaultTransfer: VaultTransferRequestDescription = {
 };
 
 export function notificationData() {
-    const lo = notifiedLegalOfficer(ALICE);
-    const otherLo = notifiedLegalOfficer(BOB);
+    const lo = notifiedLegalOfficer(ALICE_ACCOUNT.address);
+    const otherLo = notifiedLegalOfficer(BOB_ACCOUNT.address);
     return {
         protection: notifiedProtection,
         legalOfficer: lo,

--- a/test/unit/services/notification-test-data.ts
+++ b/test/unit/services/notification-test-data.ts
@@ -2,17 +2,18 @@ import {
     ProtectionRequestDescription,
     LegalOfficerDecisionDescription
 } from "../../../src/logion/model/protectionrequest.model.js";
-import { BOB, ALICE } from "../../helpers/addresses.js";
+import { BOB, ALICE, ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
 import { LegalOfficer } from "../../../src/logion/model/legalofficer.model.js";
 import { LocRequestDescription, LocRequestDecision } from "../../../src/logion/model/locrequest.model.js";
 import { VaultTransferRequestDescription } from "src/logion/model/vaulttransferrequest.model.js";
+import { ValidAccountId } from "@logion/node-api";
 
 export const notifiedProtection: ProtectionRequestDescription & { decision: LegalOfficerDecisionDescription } = {
-    requesterAddress: "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY",
+    requesterAddress: ValidAccountId.polkadot("5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY"),
     requesterIdentityLocId: "7a6ca6b7-87ca-4e55-9c5f-422c9f799b74",
-    legalOfficerAddress: ALICE,
-    otherLegalOfficerAddress: BOB,
-    addressToRecover: "5GEZAeYtVZPEEmCT66scGoWS4Jd7AWJdXeNyvxC3LxKP8jCn",
+    legalOfficerAddress: ALICE_ACCOUNT,
+    otherLegalOfficerAddress: BOB_ACCOUNT,
+    addressToRecover: ValidAccountId.polkadot("5GEZAeYtVZPEEmCT66scGoWS4Jd7AWJdXeNyvxC3LxKP8jCn"),
     createdOn: "2021-06-10T16:25:23.668294",
     isRecovery: false,
     decision: {
@@ -43,10 +44,13 @@ export function notifiedLegalOfficer(address:string): LegalOfficer {
     };
 }
 
+const requesterAddress = ValidAccountId.polkadot("5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW");
+
 export function notifiedLOC(): LocRequestDescription & { decision: LocRequestDecision } & { id: string } {
     return {
         id: "15ed922d-5960-4147-a73f-97d362cb7c46",
-        ownerAddress: ALICE,
+        ownerAddress: ALICE_ACCOUNT,
+        requesterAddress,
         description: "Some LOC description",
         createdOn: "2021-06-10T16:25:23.668294",
         locType: "Transaction",
@@ -64,10 +68,10 @@ export function notifiedLOC(): LocRequestDescription & { decision: LocRequestDec
 
 const vaultTransfer: VaultTransferRequestDescription = {
     id: "id",
-    requesterAddress: "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW",
-    legalOfficerAddress: ALICE,
-    origin: "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW",
-    destination: "5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX",
+    requesterAddress: requesterAddress,
+    legalOfficerAddress: ALICE_ACCOUNT,
+    origin: requesterAddress,
+    destination: ValidAccountId.polkadot("5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX"),
     createdOn: "2021-06-10T16:25:23.668294",
     amount: 10000n,
     timepoint: {

--- a/test/unit/services/notification.service.spec.ts
+++ b/test/unit/services/notification.service.spec.ts
@@ -31,7 +31,7 @@ describe("NotificationService", () => {
         const expectedText = [
             "Dear Legal Officer,",
             "The following user has requested your protection:",
-            "John Doe(5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY)",
+            "John Doe(vQxHAE33LeJYV69GCB4o4YcCgnDu8y99u5hy2751fRdxjX9kz)",
             ""
         ].join("\n")
         expect(actualText.length).toEqual(expectedText.length)
@@ -84,7 +84,7 @@ describe("NotificationService", () => {
         notificationService.templatePath = "test/resources/mail";
         let message = notificationService.renderMessage(
             "loc-requested",
-            { loc: { requesterAddress: "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY" } });
+            { loc: { requesterAddress: { address: "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY" }}});
         expect(message.subject).toEqual("SUBJECT")
         expect(message.text).toEqual([
             "Begin",

--- a/test/unit/services/protectionsynchronization.service.spec.ts
+++ b/test/unit/services/protectionsynchronization.service.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../src/logion/model/protectionrequest.model.js';
 import { JsonExtrinsic } from '../../../src/logion/services/types/responses/Extrinsic.js';
 import { ProtectionSynchronizer } from '../../../src/logion/services/protectionsynchronization.service.js';
-import { ALICE, BOB, ALICE_ACCOUNT } from '../../helpers/addresses.js';
+import { BOB_ACCOUNT, ALICE_ACCOUNT } from '../../helpers/addresses.js';
 import { NonTransactionalProtectionRequestService } from '../../../src/logion/services/protectionrequest.service.js';
 import { DirectoryService } from "../../../src/logion/services/directory.service.js";
 import { ValidAccountId } from "@logion/node-api";
@@ -32,8 +32,8 @@ let directoryService: Mock<DirectoryService>;
 function givenCreateRecoveryExtrinsic() {
     locExtrinsic = new Mock<JsonExtrinsic>();
     const legalOfficers = [
-        ALICE,
-        BOB,
+        ALICE_ACCOUNT.address,
+        BOB_ACCOUNT.address,
     ];
     locExtrinsic.setup(instance => instance.call).returns({
         section: "verifiedRecovery",

--- a/test/unit/services/sponsorship.service.spec.ts
+++ b/test/unit/services/sponsorship.service.spec.ts
@@ -1,11 +1,10 @@
 import { Mock, It } from "moq.ts";
-import { UUID, Sponsorship, LogionNodeApiClass } from "@logion/node-api";
+import { UUID, Sponsorship, LogionNodeApiClass, ValidAccountId } from "@logion/node-api";
 import { LocRequestRepository, FetchLocRequestsSpecification } from "../../../src/logion/model/locrequest.model.js";
 import { SponsorshipService } from "../../../src/logion/services/sponsorship.service.js";
 import { PolkadotService } from "@logion/rest-api-core";
 import { ALICE_ACCOUNT, CHARLY_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
 import { POLKADOT_REQUESTER } from "../controllers/locrequest.controller.shared.js";
-import { polkadotAccount, SupportedAccountId } from "../../../src/logion/model/supportedaccountid.model.js";
 import { expectAsyncToThrow } from "../../helpers/asynchelper.js";
 
 const locRequestRepository: Mock<LocRequestRepository> = new Mock<LocRequestRepository>();
@@ -23,7 +22,7 @@ describe("SponsorshipService", () => {
 
     const service = createService();
 
-    async function testError(sponsorshipId: UUID, expectedError: string, legalOfficer?: SupportedAccountId, requester?: SupportedAccountId) {
+    async function testError(sponsorshipId: UUID, expectedError: string, legalOfficer?: ValidAccountId, requester?: ValidAccountId) {
         return expectAsyncToThrow(
             () => service.validateSponsorship(sponsorshipId, legalOfficer ? legalOfficer : ALICE_ACCOUNT, requester ? requester : POLKADOT_REQUESTER),
             expectedError
@@ -52,7 +51,7 @@ describe("SponsorshipService", () => {
     })
 
     it("throws error for wrong Sponsored Account", async () => {
-        const wrongRequester = polkadotAccount("5GnPfHk6Y6qsqSYQ5V6rRSaWxHf86QW1b2DQDGft1FjDT2iN");
+        const wrongRequester = ValidAccountId.polkadot("5GnPfHk6Y6qsqSYQ5V6rRSaWxHf86QW1b2DQDGft1FjDT2iN");
         await testError(validSponsorship, "This sponsorship is not applicable to your request", ALICE_ACCOUNT, wrongRequester)
     })
 

--- a/test/unit/services/transaction.extractor.spec.ts
+++ b/test/unit/services/transaction.extractor.spec.ts
@@ -215,7 +215,7 @@ describe("TransactionExtractor", () => {
             blockNumber: 1739n,
             fee: 0n,
             transferValue: 200000000000000000n,
-            from: "5GsjmoJBjbKpjQiUHeVmSHuUvgonLvJUyLSHfbKDRYz4GK3V",
+            from: "vQx6Y5fTinEKDENnSUzDC73bdN4Yo2D2PUCq9xaKQKHzS63dr",
             to: "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY",
         });
         await expectTransaction(transferParams, 0);

--- a/test/unit/services/transactionsync.service.spec.ts
+++ b/test/unit/services/transactionsync.service.spec.ts
@@ -32,6 +32,8 @@ describe("TransactionSync", () => {
         // Given
         const block = new Mock<BlockExtrinsics>();
         const transaction = new Mock<Transaction>();
+        transaction.setup(instance => instance.from).returns("14Gjs1TD93gnwEBfDMHoCgsuf1s2TVKUP6Z1qKmAZnZ8cW5q");
+        transaction.setup(instance => instance.to).returns(null);
         const transactions = [ transaction.object() ];
         const blockWithTransaction = new BlockWithTransactionsBuilder()
                 .timestamp(moment())

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,12 +1131,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/authenticator@npm:^0.5.6-4":
-  version: 0.5.6-4
-  resolution: "@logion/authenticator@npm:0.5.6-4"
+"@logion/authenticator@npm:^0.5.6-5":
+  version: 0.5.6-5
+  resolution: "@logion/authenticator@npm:0.5.6-5"
   dependencies:
     "@ethersproject/transactions": ^5.7.0
-    "@logion/node-api": ^0.29.0-2
+    "@logion/node-api": ^0.29.0-4
     "@multiversx/sdk-core": ^12.19.1
     "@multiversx/sdk-wallet": ^4.3.0
     ethers: ^6.11.1
@@ -1146,13 +1146,13 @@ __metadata:
     web3-utils: ^4.2.1
   peerDependencies:
     "@logion/node-api": 0.x
-  checksum: 43568b5446ccdfe7b9d0eedc526caa7e2dda64702f83ebe7a326d3c9480d17214b6c06cf3e964dcec98c9c472f7efbb35de6715fb888303c310ff98938217580
+  checksum: 99485487135cfdb300d756a80cf6f7dc017289af009b17e63824869a0f618f65c95b03a6e87b77d2a07218f3c007cb13a844bec3339d33e05c6e09efa8c8355c
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.29.0-2, @logion/node-api@npm:^0.29.0-3":
-  version: 0.29.0-3
-  resolution: "@logion/node-api@npm:0.29.0-3"
+"@logion/node-api@npm:^0.29.0-4":
+  version: 0.29.0-4
+  resolution: "@logion/node-api@npm:0.29.0-4"
   dependencies:
     "@polkadot/api": ^10.12.2
     "@polkadot/util": ^12.6.2
@@ -1160,7 +1160,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 8b7759ec19d4ebbf7eddf1c8a9d6308f2ee83c9fd9232538d04eaa2b35344eaf36554304ac8a95cf40baa5475eb75d990070b49b72bb84f21c3e0c73cc21f016
+  checksum: 2ce96fa554c64816b555b090672bcb3ac2472eee6a50c0d1fd19705d6dfc2ae574ca4828f08891bca3529636b0bdb1162e636a3f46ebb4a6d2edc6a442b9e3e9
   languageName: node
   linkType: hard
 
@@ -1175,11 +1175,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/rest-api-core@npm:^0.4.8-6":
-  version: 0.4.8-6
-  resolution: "@logion/rest-api-core@npm:0.4.8-6"
+"@logion/rest-api-core@npm:^0.4.8-7":
+  version: 0.4.8-7
+  resolution: "@logion/rest-api-core@npm:0.4.8-7"
   dependencies:
-    "@logion/authenticator": ^0.5.6-4
+    "@logion/authenticator": ^0.5.6-5
     dinoloop: ^2.4.0
     express: ^4.18.2
     express-fileupload: ^1.4.0
@@ -1189,7 +1189,7 @@ __metadata:
     swagger-ui-express: ^5.0.0
     typeorm: ^0.3.11
     typeorm-transactional: ^0.4.1
-  checksum: 4b49b7a9c8d32def4c501296bd0b45cacec4cffb053495d38270ccaec0e8172bb8584f28f7bb437cea6e3b3b4da96faacfe6ec75d98a36d5dcb12f2bc862ef8f
+  checksum: 36f38a6a96d71b51c9518c9a53c1240545ad79b6a2efc0cac0d9b56c66e639fb1d806cbfc3fe031250201fc1ab081a1c2625cfe74bf5554edd10b19a175cf32b
   languageName: node
   linkType: hard
 
@@ -6731,9 +6731,9 @@ __metadata:
     "@astar-network/astar-api": ^0.2.8
     "@astar-network/astar-sdk-core": ^0.2.8
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/node-api": ^0.29.0-3
+    "@logion/node-api": ^0.29.0-4
     "@logion/node-exiftool": ^2.3.1
-    "@logion/rest-api-core": ^0.4.8-6
+    "@logion/rest-api-core": ^0.4.8-7
     "@polkadot/api-contract": ^10.12.4
     "@polkadot/wasm-crypto": ^7.3.2
     "@tsconfig/node18": ^1.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,9 +1175,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/rest-api-core@npm:^0.4.8-5":
-  version: 0.4.8-5
-  resolution: "@logion/rest-api-core@npm:0.4.8-5"
+"@logion/rest-api-core@npm:^0.4.8-6":
+  version: 0.4.8-6
+  resolution: "@logion/rest-api-core@npm:0.4.8-6"
   dependencies:
     "@logion/authenticator": ^0.5.6-4
     dinoloop: ^2.4.0
@@ -1189,7 +1189,7 @@ __metadata:
     swagger-ui-express: ^5.0.0
     typeorm: ^0.3.11
     typeorm-transactional: ^0.4.1
-  checksum: 72f3ac9aaff80ffbcd847af58a044a18c8247b498d6c1a7edc84887f17948df8dc2272acf39c56dd7f78c0e848019e979b5207f209e7ba2cd7b0dd144bc40b42
+  checksum: 4b49b7a9c8d32def4c501296bd0b45cacec4cffb053495d38270ccaec0e8172bb8584f28f7bb437cea6e3b3b4da96faacfe6ec75d98a36d5dcb12f2bc862ef8f
   languageName: node
   linkType: hard
 
@@ -6733,7 +6733,7 @@ __metadata:
     "@istanbuljs/nyc-config-typescript": ^1.0.2
     "@logion/node-api": ^0.29.0-3
     "@logion/node-exiftool": ^2.3.1
-    "@logion/rest-api-core": ^0.4.8-5
+    "@logion/rest-api-core": ^0.4.8-6
     "@polkadot/api-contract": ^10.12.4
     "@polkadot/wasm-crypto": ^7.3.2
     "@tsconfig/node18": ^1.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,11 +1131,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/authenticator@npm:^0.5.5":
-  version: 0.5.5
-  resolution: "@logion/authenticator@npm:0.5.5"
+"@logion/authenticator@npm:^0.5.6-4":
+  version: 0.5.6-4
+  resolution: "@logion/authenticator@npm:0.5.6-4"
   dependencies:
     "@ethersproject/transactions": ^5.7.0
+    "@logion/node-api": ^0.29.0-2
     "@multiversx/sdk-core": ^12.19.1
     "@multiversx/sdk-wallet": ^4.3.0
     ethers: ^6.11.1
@@ -1145,13 +1146,13 @@ __metadata:
     web3-utils: ^4.2.1
   peerDependencies:
     "@logion/node-api": 0.x
-  checksum: 13783c7d56a319eb7dba070f499c5eb9fc86d3db8c130412c98a2ed988196e59d9a1f86464c61fb68f86fa0108563c88e2f34c2c3dfcc251f6050e8ecfb5bf7d
+  checksum: 43568b5446ccdfe7b9d0eedc526caa7e2dda64702f83ebe7a326d3c9480d17214b6c06cf3e964dcec98c9c472f7efbb35de6715fb888303c310ff98938217580
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.28.4":
-  version: 0.28.4
-  resolution: "@logion/node-api@npm:0.28.4"
+"@logion/node-api@npm:^0.29.0-2, @logion/node-api@npm:^0.29.0-3":
+  version: 0.29.0-3
+  resolution: "@logion/node-api@npm:0.29.0-3"
   dependencies:
     "@polkadot/api": ^10.12.2
     "@polkadot/util": ^12.6.2
@@ -1159,7 +1160,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 0a2ac1fe3cfb06326a4ca1374b786fafa634830471258d618aafefe0effb2e682a9febe4a301b71e5a9d22c5daaba2beb43f3838ca13ecfea8917da40bb14c3a
+  checksum: 8b7759ec19d4ebbf7eddf1c8a9d6308f2ee83c9fd9232538d04eaa2b35344eaf36554304ac8a95cf40baa5475eb75d990070b49b72bb84f21c3e0c73cc21f016
   languageName: node
   linkType: hard
 
@@ -1174,11 +1175,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/rest-api-core@npm:^0.4.7":
-  version: 0.4.7
-  resolution: "@logion/rest-api-core@npm:0.4.7"
+"@logion/rest-api-core@npm:^0.4.8-5":
+  version: 0.4.8-5
+  resolution: "@logion/rest-api-core@npm:0.4.8-5"
   dependencies:
-    "@logion/authenticator": ^0.5.5
+    "@logion/authenticator": ^0.5.6-4
     dinoloop: ^2.4.0
     express: ^4.18.2
     express-fileupload: ^1.4.0
@@ -1188,7 +1189,7 @@ __metadata:
     swagger-ui-express: ^5.0.0
     typeorm: ^0.3.11
     typeorm-transactional: ^0.4.1
-  checksum: 5fed0d747155c5fdeea3a192c7b9b88b92908c83b50a12a5f4e2c7522c5bcc08dc4b340bac170fa0b2bd7ef71cee624f99c27623ed034d5866fb836800249cc4
+  checksum: 72f3ac9aaff80ffbcd847af58a044a18c8247b498d6c1a7edc84887f17948df8dc2272acf39c56dd7f78c0e848019e979b5207f209e7ba2cd7b0dd144bc40b42
   languageName: node
   linkType: hard
 
@@ -6730,9 +6731,9 @@ __metadata:
     "@astar-network/astar-api": ^0.2.8
     "@astar-network/astar-sdk-core": ^0.2.8
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/node-api": ^0.28.4
+    "@logion/node-api": ^0.29.0-3
     "@logion/node-exiftool": ^2.3.1
-    "@logion/rest-api-core": ^0.4.7
+    "@logion/rest-api-core": ^0.4.8-5
     "@polkadot/api-contract": ^10.12.4
     "@polkadot/wasm-crypto": ^7.3.2
     "@tsconfig/node18": ^1.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,9 +1150,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.29.0-4":
-  version: 0.29.0-4
-  resolution: "@logion/node-api@npm:0.29.0-4"
+"@logion/node-api@npm:^0.29.0-4, @logion/node-api@npm:^0.29.0-5":
+  version: 0.29.0-5
+  resolution: "@logion/node-api@npm:0.29.0-5"
   dependencies:
     "@polkadot/api": ^10.12.2
     "@polkadot/util": ^12.6.2
@@ -1160,7 +1160,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 2ce96fa554c64816b555b090672bcb3ac2472eee6a50c0d1fd19705d6dfc2ae574ca4828f08891bca3529636b0bdb1162e636a3f46ebb4a6d2edc6a442b9e3e9
+  checksum: 77ff276c92d2613ff9874fa1932c56de62d4d13949b1cbff26ed6b0d3bdaa3c305c1b212e6fc4cb68dccecfc22a47da312531b391e91221b0e8e5c3c087a54d8
   languageName: node
   linkType: hard
 
@@ -6731,7 +6731,7 @@ __metadata:
     "@astar-network/astar-api": ^0.2.8
     "@astar-network/astar-sdk-core": ^0.2.8
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/node-api": ^0.29.0-4
+    "@logion/node-api": ^0.29.0-5
     "@logion/node-exiftool": ^2.3.1
     "@logion/rest-api-core": ^0.4.8-7
     "@polkadot/api-contract": ^10.12.4


### PR DESCRIPTION
### DB
Every Polkadot address is saved using default prefix (42) - this ensure the queries to keep on working after the migration.
This includes, but is not limited to, requester, issuer, owner, etc.

### REST API
Each endpoint
* exposes Polkadot addresses using Logion prefix (2021).
* is able to process Polkadot addresses formatted with any prefix.

### Known issues and limitations

- Session: due to the very short TTL of records in session table, the address is stored as given.
- Deliveries: owner of restricted delivery is saved "as given" for several reasons:
  - A ValidAccount cannot be re-constructed from DB content - we currently lack a owner_type [Polkadot, Ethereum, Bech32] field.
  - They are no search based on owner.

logion-network/logion-internal#1216