### PR TITLE
Fix issuer dismissal sync failure

### DIFF
--- a/src/logion/model/verifiedissuerselection.model.ts
+++ b/src/logion/model/verifiedissuerselection.model.ts
@@ -72,7 +72,8 @@ export class VerifiedIssuerSelectionRepository {
         return this.repository.findBy(dbSpec);
     }
 
-    async unselectAll(issuer: string) {
+    async unselectAll(issuerAccount: ValidAccountId) {
+        const issuer = issuerAccount.getAddress(DB_SS58_PREFIX);
         await this.repository.update({ issuer }, { selected: false });
     }
 }

--- a/src/logion/services/verifiedissuerselection.service.ts
+++ b/src/logion/services/verifiedissuerselection.service.ts
@@ -2,6 +2,7 @@ import { DefaultTransactional, requireDefined } from "@logion/rest-api-core";
 import { injectable } from "inversify";
 import { LocRequestAggregateRoot } from "../model/locrequest.model.js";
 import { VerifiedIssuerAggregateRoot, VerifiedIssuerSelectionFactory, VerifiedIssuerSelectionId, VerifiedIssuerSelectionRepository } from "../model/verifiedissuerselection.model.js";
+import { ValidAccountId } from "@logion/node-api";
 
 export abstract class VerifiedIssuerSelectionService {
 
@@ -29,8 +30,8 @@ export abstract class VerifiedIssuerSelectionService {
         } // else (!selection && !select) -> skip
     }
 
-    async unselectAll(issuerAddress: string) {
-        await this.verifiedIssuerSelectionRepository.unselectAll(issuerAddress);
+    async unselectAll(issuerAccount: ValidAccountId) {
+        await this.verifiedIssuerSelectionRepository.unselectAll(issuerAccount);
     }
 }
 
@@ -55,8 +56,8 @@ export class TransactionalVerifiedIssuerSelectionService extends VerifiedIssuerS
     }
 
     @DefaultTransactional()
-    async unselectAll(issuerAddress: string) {
-        return super.unselectAll(issuerAddress);
+    async unselectAll(issuerAccount: ValidAccountId) {
+        return super.unselectAll(issuerAccount);
     }
 }
 

--- a/test/integration/model/verifiedthirdpartyselection.model.spec.ts
+++ b/test/integration/model/verifiedthirdpartyselection.model.spec.ts
@@ -60,7 +60,7 @@ describe("VerifiedIssuerSelectionRepository - write", () => {
     });
 
     it("unselects by issuer LOC ID", async () => {
-        await repository.unselectAll("5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX");
+        await repository.unselectAll(ValidAccountId.polkadot("5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX"));
         checkNumOfRows(`SELECT * FROM issuer_selection WHERE issuer = '5EBxoSssqNo23FvsDeUxjyQScnfEiGxJaNwuwqBH2Twe35BX' AND selected IS TRUE`, 0);
     });
 });


### PR DESCRIPTION
* fix: ID loc retrieval on verified issuer dismissal sync;
* fix: `unselectAll` using wrong prefix.

logion-network/logion-internal#1247