### PR TITLE
Secret Recovery Request

### DIFF
--- a/resources/mail/secret-recovery-requested-legal-officer.pug
+++ b/resources/mail/secret-recovery-requested-legal-officer.pug
@@ -1,0 +1,29 @@
+| logion notification - Secret Recovery request to be reviewed
+| Dear #{legalOfficer.userIdentity.firstName} #{legalOfficer.userIdentity.lastName},
+|
+| Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
+|
+| The following user has requested your help to recover a lost secret, please go to your logion application and start the review and approval process:
+| __________________________________________________________
+|
+| Name:
+| *******
+| #{walletUser.firstName} #{walletUser.lastName}
+|
+| Email:
+| *******
+| #{walletUser.email}
+|
+| Telephone:
+| ************
+| #{walletUser.phoneNumber}
+|
+| Address:
+| *********
+| #{walletUserPostalAddress.line1}
+| #{walletUserPostalAddress.line2}
+| #{walletUserPostalAddress.postalCode} #{walletUserPostalAddress.city}
+| #{walletUserPostalAddress.country}
+| __________________________________________________________
+|
+include /footer.pug

--- a/resources/mail/secret-recovery-requested-user.pug
+++ b/resources/mail/secret-recovery-requested-user.pug
@@ -1,0 +1,12 @@
+| logion notification - Recoverable secret added
+| Dear #{walletUser.firstName} #{walletUser.lastName},
+|
+| You receive this message because you just requested to recover the secret with name #{secretName} linked to your Identity LOC #{loc.id}.
+|
+| Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
+|
+| As a reminder, find below all details of the Legal Officer you'll have to contact in order to recover the secret's value:
+|
+include /legal-officer-details.pug
+|
+include /footer.pug

--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -1921,6 +1921,37 @@
                         }
                     }
                 }
+            },
+            "CreateSecretRecoveryRequestView": {
+                "type": "object",
+                "properties": {
+                    "requesterIdentityLocId": {
+                        "type": "string",
+                        "description": "The id of the identity loc",
+                        "example": "5e4ef4bb-8657-444c-9880-d89e9403fc85"
+                    },
+                    "secretName": {
+                        "type": "string",
+                        "description": "Recoverable secret's name"
+                    },
+                    "challenge": {
+                        "type": "string",
+                        "description": "The challenge"
+                    },
+                    "userIdentity": {
+                        "$ref": "#/components/schemas/UserIdentityView"
+                    },
+                    "userPostalAddress": {
+                        "$ref": "#/components/schemas/PostalAddressView"
+                    }
+                },
+                "required": [
+                    "requesterIdentityLocId",
+                    "secretName",
+                    "challenge",
+                    "userIdentity",
+                    "userPostalAddress"
+                ]
             }
         }
     }

--- a/src/logion/app.support.ts
+++ b/src/logion/app.support.ts
@@ -24,6 +24,7 @@ import { fillInSpec as fillInSpecIdenfy, IdenfyController } from "./controllers/
 import { fillInSpec as fillInSpecVote, VoteController } from "./controllers/vote.controller.js";
 import { fillInSpec as fillInSpecTokensRecord, TokensRecordController } from "./controllers/records.controller.js";
 import { fillInSpec as fillInSpecWorkload, WorkloadController } from "./controllers/workload.controller.js";
+import { fillInSpec as fillInSpecSecretRecovery, SecretRecoveryController } from "./controllers/secret_recovery.controller.js";
 
 const { logger } = Log;
 
@@ -62,6 +63,7 @@ export function predefinedSpec(spec: OpenAPIV3.Document): OpenAPIV3.Document {
     fillInSpecVote(spec);
     fillInSpecTokensRecord(spec);
     fillInSpecWorkload(spec);
+    fillInSpecSecretRecovery(spec);
 
     return spec;
 }
@@ -81,7 +83,7 @@ export function buildExpress(expressConfig?: ExpressConfig): Express {
             predefinedSpec,
             specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE,
             swaggerDocumentOptions: {
-        
+
             },
             alwaysServeDocs: true,
         });
@@ -124,6 +126,7 @@ export function setupApp(expressConfig?: ExpressConfig): Express {
     dino.registerController(VoteController);
     dino.registerController(TokensRecordController);
     dino.registerController(WorkloadController);
+    dino.registerController(SecretRecoveryController);
 
     dino.dependencyResolver<Container>(AppContainer,
         (injector, type) => {

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -63,6 +63,9 @@ import { MultiversxService } from "../services/ownership/multiversx.service.js";
 import { AstarService, ConnectedAstarService } from "../services/ownership/astar.service.js";
 import { WorkloadService } from "../services/workload.service.js";
 import { WorkloadController } from "../controllers/workload.controller.js";
+import { SecretRecoveryController } from "../controllers/secret_recovery.controller.js";
+import { SecretRecoveryRequestRepository } from "../model/secret_recovery.model.js";
+import { SecretRecoveryRequestService } from "../services/secret_recovery.service.js";
 
 const container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -151,6 +154,8 @@ container.bind(SponsorshipService).toSelf();
 container.bind(ConnectedAstarService).toSelf();
 container.bind(AstarService).toService(ConnectedAstarService);
 container.bind(WorkloadService).toSelf();
+container.bind(SecretRecoveryRequestRepository).toSelf();
+container.bind(SecretRecoveryRequestService).toSelf();
 
 // Controllers are stateful so they must not be injected with singleton scope
 container.bind(LocRequestController).toSelf().inTransientScope();
@@ -164,5 +169,6 @@ container.bind(IdenfyController).toSelf().inTransientScope();
 container.bind(VoteController).toSelf().inTransientScope();
 container.bind(TokensRecordController).toSelf().inTransientScope();
 container.bind(WorkloadController).toSelf().inTransientScope();
+container.bind(SecretRecoveryController).toSelf().inTransientScope();
 
 export { container as AppContainer };

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -1038,6 +1038,19 @@ export interface components {
         [key: string]: number;
       };
     };
+    CreateSecretRecoveryRequestView: {
+      /**
+       * @description The id of the identity loc
+       * @example 5e4ef4bb-8657-444c-9880-d89e9403fc85
+       */
+      requesterIdentityLocId: string;
+      /** @description Recoverable secret's name */
+      secretName: string;
+      /** @description The challenge */
+      challenge: string;
+      userIdentity: components["schemas"]["UserIdentityView"];
+      userPostalAddress: components["schemas"]["PostalAddressView"];
+    };
   };
   responses: never;
   parameters: never;

--- a/src/logion/controllers/secret_recovery.controller.ts
+++ b/src/logion/controllers/secret_recovery.controller.ts
@@ -65,15 +65,15 @@ export class SecretRecoveryController extends ApiController {
     @HttpPost('')
     @SendsResponse()
     async createSecretRecoveryRequest(body: CreateSecretRecoveryRequestView) {
+        const { requesterIdentityLocId, challenge, secretName } = body;
         const requesterIdentityLoc = requireDefined(
-            await this.locRequestRepository.findById(body.requesterIdentityLocId),
+            await this.locRequestRepository.findById(requesterIdentityLocId),
             () => badRequest("Identity LOC not found")
         );
         requireDefined(
-            requesterIdentityLoc.secrets?.find(secret => secret.name === body.secretName),
+            requesterIdentityLoc.secrets?.find(secret => secret.name === secretName),
             () => badRequest("Secret not found")
         )
-        const { requesterIdentityLocId, challenge, secretName } = body;
         const userIdentity = {
             firstName: body.userIdentity.firstName || "",
             lastName: body.userIdentity.lastName || "",
@@ -92,8 +92,8 @@ export class SecretRecoveryController extends ApiController {
             legalOfficerAddress: requesterIdentityLoc.getOwner(),
             challenge,
             secretName,
-            userIdentity: userIdentity,
-            userPostalAddress: userPostalAddress,
+            userIdentity,
+            userPostalAddress,
             createdOn: moment()
         })
         await this.secretRecoveryRequestService.add(recoveryRequest);

--- a/src/logion/controllers/secret_recovery.controller.ts
+++ b/src/logion/controllers/secret_recovery.controller.ts
@@ -1,0 +1,138 @@
+import { OpenAPIV3 } from "express-oas-generator";
+import {
+    addTag,
+    setControllerTag,
+    requireDefined,
+    badRequest,
+    getRequestBody,
+    getDefaultResponses,
+    Log
+} from "@logion/rest-api-core";
+import { injectable } from "inversify";
+import { Controller, HttpPost, ApiController, Async, SendsResponse } from "dinoloop";
+import { components } from "./components.js";
+import { SecretRecoveryRequestFactory, SecretRecoveryRequestDescription } from "../model/secret_recovery.model.js";
+import { SecretRecoveryRequestService } from "../services/secret_recovery.service.js";
+import { LocRequestRepository } from "../model/locrequest.model.js";
+import moment from "moment";
+import { NotificationRecipient, Template, NotificationService } from "../services/notification.service.js";
+import { UserPrivateData } from "./adapters/locrequestadapter.js";
+import { LocalsObject } from "pug";
+import { DirectoryService } from "../services/directory.service.js";
+import { ValidAccountId } from "@logion/node-api";
+
+type CreateSecretRecoveryRequestView = components["schemas"]["CreateSecretRecoveryRequestView"];
+
+const { logger } = Log;
+
+export function fillInSpec(spec: OpenAPIV3.Document): void {
+    const tagName = 'SecretRecovery';
+    addTag(spec, {
+        name: tagName,
+        description: "Handling of Secret Recovery Requests"
+    });
+    setControllerTag(spec, /^\/api\/secret-recovery.*/, tagName);
+
+    SecretRecoveryController.createSecretRecoveryRequest(spec);
+}
+
+@injectable()
+@Controller('/secret-recovery')
+export class SecretRecoveryController extends ApiController {
+
+    constructor(
+        private secretRecoveryRequestFactory: SecretRecoveryRequestFactory,
+        private secretRecoveryRequestService: SecretRecoveryRequestService,
+        private locRequestRepository: LocRequestRepository,
+        private directoryService: DirectoryService,
+        private notificationService: NotificationService,
+    ) {
+        super();
+    }
+
+    static createSecretRecoveryRequest(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/secret-recovery"].post!;
+        operationObject.summary = "Creates a new Secret recovery request";
+        operationObject.description = "This is publicly available";
+        operationObject.requestBody = getRequestBody({
+            description: "Secret recovery request creation data",
+            view: "secret-recovery",
+        });
+        operationObject.responses = getDefaultResponses("ProtectionRequestView");
+    }
+
+    @Async()
+    @HttpPost('')
+    @SendsResponse()
+    async createSecretRecoveryRequest(body: CreateSecretRecoveryRequestView) {
+        const requesterIdentityLoc = requireDefined(
+            await this.locRequestRepository.findById(body.requesterIdentityLocId),
+            () => badRequest("Identity LOC not found")
+        );
+        requireDefined(
+            requesterIdentityLoc.secrets?.find(secret => secret.name === body.secretName),
+            () => badRequest("Secret not found")
+        )
+        const { requesterIdentityLocId, challenge, secretName } = body;
+        const userIdentity = {
+            firstName: body.userIdentity.firstName || "",
+            lastName: body.userIdentity.lastName || "",
+            email: body.userIdentity.email || "",
+            phoneNumber: body.userIdentity.phoneNumber || "",
+        };
+        const userPostalAddress = {
+            line1: body.userPostalAddress.line1 || "",
+            line2: body.userPostalAddress.line2 || "",
+            postalCode: body.userPostalAddress.postalCode || "",
+            city: body.userPostalAddress.city || "",
+            country: body.userPostalAddress.country || "",
+        };
+        const recoveryRequest = this.secretRecoveryRequestFactory.newSecretRecoveryRequest({
+            requesterIdentityLocId,
+            legalOfficerAddress: requesterIdentityLoc.getOwner(),
+            challenge,
+            secretName,
+            userIdentity: userIdentity,
+            userPostalAddress: userPostalAddress,
+            createdOn: moment()
+        })
+        await this.secretRecoveryRequestService.add(recoveryRequest);
+        const userPrivateData: UserPrivateData = {
+            identityLocId: requesterIdentityLocId,
+            userIdentity,
+            userPostalAddress,
+        }
+        this.notify("WalletUser", "secret-recovery-requested-user", recoveryRequest.getDescription(), requesterIdentityLoc.getOwner(), userPrivateData);
+        this.notify("LegalOfficer", "secret-recovery-requested-legal-officer", recoveryRequest.getDescription(), requesterIdentityLoc.getOwner(), userPrivateData);
+        this.response.sendStatus(204);
+    }
+
+    private notify(recipient: NotificationRecipient, templateId: Template, secretRecoveryRequest: SecretRecoveryRequestDescription, legalOfficerAccount: ValidAccountId, userPrivateData: UserPrivateData): void {
+        this.getNotificationInfo(secretRecoveryRequest, legalOfficerAccount, userPrivateData)
+            .then(info => {
+                const to = recipient === "WalletUser" ? info.userEmail : info.legalOfficerEMail
+                return this.notificationService.notify(to, templateId, info.data)
+                    .catch(reason => logger.warn("Failed to send email '%s' to %s : %s", templateId, to, reason))
+            })
+            .catch(reason =>
+                logger.warn("Failed to retrieve notification info from directory: %s. Mail '%' not sent.", reason, templateId)
+            )
+    }
+
+    private async getNotificationInfo(secretRecoveryRequest: SecretRecoveryRequestDescription, legalOfficerAccount: ValidAccountId, userPrivateData: UserPrivateData):
+        Promise<{ legalOfficerEMail: string, userEmail: string | undefined, data: LocalsObject }> {
+
+        const legalOfficer = await this.directoryService.get(legalOfficerAccount)
+        const { userIdentity, userPostalAddress } = userPrivateData;
+        return {
+            legalOfficerEMail: legalOfficer.userIdentity.email,
+            userEmail: userIdentity?.email,
+            data: {
+                secretName: secretRecoveryRequest.secretName,
+                legalOfficer,
+                walletUser: userIdentity,
+                walletUserPostalAddress: userPostalAddress
+            }
+        }
+    }
+}

--- a/src/logion/migration/1715669632901-AddSecrets.ts
+++ b/src/logion/migration/1715669632901-AddSecrets.ts
@@ -4,7 +4,7 @@ export class AddSecrets1715669632901 implements MigrationInterface {
     name = 'AddSecrets1715669632901'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "loc_secret" ("request_id" uuid NOT NULL, "name" character varying(255) NOT NULL, "value" character varying(4096) NOT NULL, CONSTRAINT "UQ_loc_secret_request_id_name" UNIQUE ("request_id", "name"), CONSTRAINT "PK_loc_secret" PRIMARY KEY ("request_id", "name"))`);
+        await queryRunner.query(`CREATE TABLE "loc_secret" ("request_id" uuid NOT NULL, "name" character varying(255) NOT NULL, "value" character varying(4096) NOT NULL, CONSTRAINT "PK_loc_secret" PRIMARY KEY ("request_id", "name"))`);
         await queryRunner.query(`ALTER TABLE "loc_secret" ADD CONSTRAINT "FK_loc_secret_request_id" FOREIGN KEY ("request_id") REFERENCES "loc_request"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
 

--- a/src/logion/migration/1715933228153-AddSecretRecovery.ts
+++ b/src/logion/migration/1715933228153-AddSecretRecovery.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSecretRecovery1715933228153 implements MigrationInterface {
+    name = 'AddSecretRecovery1715933228153'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "secret_recovery_request" ("id" uuid NOT NULL, "requester_identity_loc_id" uuid NOT NULL, "legal_officer_address" character varying(255) NOT NULL, "secret_name" character varying(255) NOT NULL, "challenge" character varying(255) NOT NULL, "created_on" TIMESTAMP NOT NULL, "first_name" character varying(255), "last_name" character varying(255), "email" character varying(255), "phone_number" character varying(255), "line1" character varying(255), "line2" character varying(255), "postal_code" character varying(255), "city" character varying(255), "country" character varying(255), CONSTRAINT "PK_secret_recovery_request" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "secret_recovery_request"`);
+    }
+
+}

--- a/src/logion/model/locrequest.model.ts
+++ b/src/logion/model/locrequest.model.ts
@@ -1423,7 +1423,6 @@ export class LocLink extends Child implements HasIndex, Submitted {
 }
 
 @Entity("loc_secret")
-@Unique([ "requestId", "name" ])
 export class RecoverableSecretEntity extends Child {
 
     @PrimaryColumn({ type: "uuid", name: "request_id" })

--- a/src/logion/model/secret_recovery.model.ts
+++ b/src/logion/model/secret_recovery.model.ts
@@ -1,0 +1,93 @@
+import { Entity, PrimaryColumn, Column, Repository } from "typeorm";
+import { EmbeddableUserIdentity, UserIdentity, toUserIdentity } from "./useridentity.js";
+import { EmbeddablePostalAddress, PostalAddress, toPostalAddress } from "./postaladdress.js";
+import { injectable } from "inversify";
+import { appDataSource } from "@logion/rest-api-core";
+import { Moment } from "moment";
+import { ValidAccountId } from "@logion/node-api";
+import { v4 as uuid } from "uuid";
+import { DB_SS58_PREFIX } from "./supportedaccountid.model.js";
+import moment from "moment";
+
+@Entity("secret_recovery_request")
+export class SecretRecoveryRequestAggregateRoot {
+
+    @PrimaryColumn({ type: "uuid" })
+    id?: string;
+
+    @Column({ type: "uuid", name: "requester_identity_loc_id" })
+    requesterIdentityLocId?: string;
+
+    @Column({ length: 255, name: "legal_officer_address" })
+    legalOfficerAddress?: string;
+
+    @Column({ length: 255, name: "secret_name" })
+    secretName?: string;
+
+    @Column({ length: 255, name: "challenge" })
+    challenge?: string;
+
+    @Column(() => EmbeddableUserIdentity, { prefix: "" })
+    userIdentity?: EmbeddableUserIdentity;
+
+    @Column(() => EmbeddablePostalAddress, { prefix: "" })
+    userPostalAddress?: EmbeddablePostalAddress;
+
+    @Column("timestamp without time zone", { name: "created_on" })
+    createdOn?: Date;
+
+    getDescription(): SecretRecoveryRequestDescription {
+        return {
+            requesterIdentityLocId: this.requesterIdentityLocId || "",
+            secretName: this.secretName || "",
+            challenge: this.challenge || "",
+            createdOn: moment(this.createdOn),
+            userIdentity: toUserIdentity(this.userIdentity)!,
+            userPostalAddress: toPostalAddress(this.userPostalAddress)!,
+        }
+    }
+}
+
+export interface SecretRecoveryRequestDescription {
+    readonly requesterIdentityLocId: string,
+    readonly secretName: string;
+    readonly challenge: string;
+    readonly userIdentity: UserIdentity;
+    readonly userPostalAddress: PostalAddress;
+    readonly createdOn: Moment,
+}
+
+@injectable()
+export class SecretRecoveryRequestRepository {
+
+    constructor() {
+        this.repository = appDataSource.getRepository(SecretRecoveryRequestAggregateRoot);
+    }
+
+    readonly repository: Repository<SecretRecoveryRequestAggregateRoot>;
+
+    async save(setting: SecretRecoveryRequestAggregateRoot): Promise<void> {
+        await this.repository.save(setting);
+    }
+}
+
+export interface NewSecretRecoveryRequestParams extends SecretRecoveryRequestDescription {
+    legalOfficerAddress: ValidAccountId;
+}
+
+@injectable()
+export class SecretRecoveryRequestFactory {
+
+    newSecretRecoveryRequest(params: NewSecretRecoveryRequestParams): SecretRecoveryRequestAggregateRoot {
+        const root = new SecretRecoveryRequestAggregateRoot();
+        root.id = uuid();
+        root.requesterIdentityLocId = params.requesterIdentityLocId;
+        root.legalOfficerAddress = params.legalOfficerAddress.getAddress(DB_SS58_PREFIX);
+        root.secretName = params.secretName;
+        root.challenge = params.challenge;
+        root.userIdentity = EmbeddableUserIdentity.from(params.userIdentity);
+        root.userPostalAddress = EmbeddablePostalAddress.from(params.userPostalAddress);
+        root.createdOn = params.createdOn.toDate();
+        return root;
+    }
+}

--- a/src/logion/services/notification.service.ts
+++ b/src/logion/services/notification.service.ts
@@ -37,6 +37,8 @@ export const templateValues = [
     "review-requested",
     "data-reviewed",
     "recoverable-secret-added",
+    "secret-recovery-requested-legal-officer",
+    "secret-recovery-requested-user",
 ] as const;
 
 export type Template = typeof templateValues[number];

--- a/src/logion/services/secret_recovery.service.ts
+++ b/src/logion/services/secret_recovery.service.ts
@@ -1,0 +1,43 @@
+import {
+    SecretRecoveryRequestRepository,
+    SecretRecoveryRequestAggregateRoot
+} from "../model/secret_recovery.model.js";
+import { DefaultTransactional } from "@logion/rest-api-core";
+import { injectable } from "inversify";
+
+export abstract class SecretRecoveryRequestService {
+
+    protected constructor(
+        private secretRecoveryRequestRepository: SecretRecoveryRequestRepository,
+    ) {
+    }
+
+    async add(request: SecretRecoveryRequestAggregateRoot) {
+        await this.secretRecoveryRequestRepository.save(request);
+    }
+}
+
+@injectable()
+export class TransactionalSecretRecoveryRequestService extends SecretRecoveryRequestService {
+
+    constructor(
+        secretRecoveryRequestRepository: SecretRecoveryRequestRepository,
+    ) {
+        super(secretRecoveryRequestRepository);
+    }
+
+    @DefaultTransactional()
+    override async add(request: SecretRecoveryRequestAggregateRoot): Promise<void> {
+        return super.add(request);
+    }
+}
+
+@injectable()
+export class NonTransactionalSecretRecoveryRequestService extends SecretRecoveryRequestService {
+
+    constructor(
+        secretRecoveryRequestRepository: SecretRecoveryRequestRepository,
+    ) {
+        super(secretRecoveryRequestRepository);
+    }
+}

--- a/test/integration/migration/migration.spec.ts
+++ b/test/integration/migration/migration.spec.ts
@@ -3,7 +3,7 @@ const { connect, disconnect, queryRunner, runAllMigrations, revertAllMigrations 
 
 describe('Migration', () => {
 
-    const NUM_OF_TABLES = 23;
+    const NUM_OF_TABLES = 24;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
     beforeEach(async () => {

--- a/test/unit/controllers/secret_recovery.controller.spec.ts
+++ b/test/unit/controllers/secret_recovery.controller.spec.ts
@@ -1,0 +1,152 @@
+import { TestApp } from "@logion/rest-api-core";
+import { Container } from "inversify";
+import { SecretRecoveryController } from "../../../src/logion/controllers/secret_recovery.controller.js";
+import {
+    SecretRecoveryRequestFactory,
+    SecretRecoveryRequestDescription, SecretRecoveryRequestAggregateRoot
+} from "../../../src/logion/model/secret_recovery.model.js";
+import { SecretRecoveryRequestService } from "../../../src/logion/services/secret_recovery.service.js";
+import {
+    LocRequestRepository,
+    LocRequestAggregateRoot,
+    RecoverableSecretEntity
+} from "../../../src/logion/model/locrequest.model.js";
+import { Mock, It } from "moq.ts";
+import request from "supertest";
+import { ALICE_ACCOUNT, ALICE } from "../../helpers/addresses.js";
+import { DirectoryService } from "../../../src/logion/services/directory.service.js";
+import { NotificationService, Template } from "../../../src/logion/services/notification.service.js";
+import moment from "moment";
+import { notifiedLegalOfficer } from "../services/notification-test-data.js";
+import { ValidAccountId } from "@logion/node-api";
+import { LocalsObject } from "pug";
+
+const { setupApp } = TestApp;
+
+describe("SecretRecoveryController", () => {
+
+    it("creates secret recovery request", async () => {
+
+        const app = setupApp(SecretRecoveryController, mockDependencies);
+        await request(app)
+            .post('/api/secret-recovery')
+            .send({
+                ...recoveryRequest,
+                requesterIdentityLocId: IDENTITY_LOC_ID,
+                secretName: SECRET_NAME,
+            })
+            .expect(204);
+    })
+
+    it("fails to create secret recovery request with IDLOC not found", async () => {
+
+        const app = setupApp(SecretRecoveryController, mockDependencies);
+        const unknownLocId = "0a765ca1-f0a8-450a-b66a-5dfe9de7adc6";
+        await request(app)
+            .post('/api/secret-recovery')
+            .send({
+                ...recoveryRequest,
+                requesterIdentityLocId: unknownLocId,
+                secretName: SECRET_NAME,
+            })
+            .expect(400)
+            .expect(response => expect(response.body.errorMessage).toEqual("Identity LOC not found"));
+    })
+
+    it("fails to create secret recovery request with Secret not found", async () => {
+
+        const app = setupApp(SecretRecoveryController, mockDependencies);
+        await request(app)
+            .post('/api/secret-recovery')
+            .send({
+                ...recoveryRequest,
+                requesterIdentityLocId: IDENTITY_LOC_ID,
+                secretName: "unknown secret",
+            })
+            .expect(400)
+            .expect(response => expect(response.body.errorMessage).toEqual("Secret not found"));
+    })
+})
+
+function mockDependencies(container: Container) {
+    createAndBindMocks(container);
+
+    const identityLoc = new Mock<LocRequestAggregateRoot>();
+    const secret = new Mock<RecoverableSecretEntity>();
+    secret.setup(instance => instance.name)
+        .returns(SECRET_NAME);
+
+    identityLoc.setup(instance => instance.secrets)
+        .returns([ secret.object() ]);
+    identityLoc.setup(instance => instance.getOwner())
+        .returns(ALICE_ACCOUNT);
+
+    locRequestRepository.setup(instance => instance.findById(IDENTITY_LOC_ID))
+        .returns(Promise.resolve(identityLoc.object()));
+
+    const secretRecoveryRequest = new Mock<SecretRecoveryRequestAggregateRoot>();
+    secretRecoveryRequest.setup(instance => instance.getDescription())
+        .returns({
+            ...recoveryRequest,
+            requesterIdentityLocId: IDENTITY_LOC_ID,
+            secretName: SECRET_NAME,
+            createdOn: moment(),
+        })
+    secretRecoveryRequestFactory.setup(instance => instance.newSecretRecoveryRequest(It.IsAny<SecretRecoveryRequestDescription>()))
+        .returns(secretRecoveryRequest.object());
+
+    secretRecoveryRequestService.setup(instance => instance.add(secretRecoveryRequest.object()))
+        .returns(Promise.resolve())
+
+    mockNotifications();
+}
+
+function mockNotifications() {
+    directoryService.setup(instance => instance.get(It.IsAny<ValidAccountId>()))
+        .returns(Promise.resolve(notifiedLegalOfficer(ALICE)));
+    notificationService.setup(instance => instance.notify(
+        It.IsAny<string>(),
+        It.IsAny<Template>(),
+        It.IsAny<LocalsObject>(),
+    )).returns(Promise.resolve());
+}
+
+const IDENTITY_LOC_ID = "1f95f7e8-022a-4baf-bc90-4796c493dd69";
+const SECRET_NAME = "my-secret";
+const CHALLENGE = "my-challenge";
+
+const recoveryRequest = {
+    challenge: CHALLENGE,
+    userIdentity: {
+        email: "john.doe@logion.network",
+        firstName: "John",
+        lastName: "Doe",
+        phoneNumber: "+1234",
+    },
+    userPostalAddress: {
+        line1: "Rue de la Paix",
+        line2: "",
+        postalCode: "00000",
+        city: "Liège",
+        country: "Belgium",
+    },
+}
+
+let secretRecoveryRequestFactory: Mock<SecretRecoveryRequestFactory>;
+let secretRecoveryRequestService: Mock<SecretRecoveryRequestService>;
+let locRequestRepository: Mock<LocRequestRepository>;
+let directoryService: Mock<DirectoryService>;
+let notificationService: Mock<NotificationService>;
+
+function createAndBindMocks(container: Container) {
+    secretRecoveryRequestFactory = new Mock<SecretRecoveryRequestFactory>();
+    container.bind(SecretRecoveryRequestFactory).toConstantValue(secretRecoveryRequestFactory.object());
+    secretRecoveryRequestService = new Mock<SecretRecoveryRequestService>();
+    container.bind(SecretRecoveryRequestService).toConstantValue(secretRecoveryRequestService.object());
+    locRequestRepository = new Mock<LocRequestRepository>();
+    container.bind(LocRequestRepository).toConstantValue(locRequestRepository.object());
+    directoryService = new Mock<DirectoryService>();
+    container.bind(DirectoryService).toConstantValue(directoryService.object());
+    notificationService = new Mock<NotificationService>();
+    container.bind(NotificationService).toConstantValue(notificationService.object());
+}

--- a/test/unit/model/secret_recovery.model.spec.ts
+++ b/test/unit/model/secret_recovery.model.spec.ts
@@ -1,0 +1,41 @@
+import { SecretRecoveryRequestFactory } from "../../../src/logion/model/secret_recovery.model.js";
+import moment from "moment";
+import { ALICE_ACCOUNT } from "../../helpers/addresses.js";
+
+describe("SecretRecoveryRequestFactory", () => {
+
+    it("creates a request", () => {
+        const factory = new SecretRecoveryRequestFactory();
+
+        const userIdentity = {
+            email: "john.doe@logion.network",
+            firstName: "John",
+            lastName: "Doe",
+            phoneNumber: "+1234",
+        };
+        const userPostalAddress = {
+            line1: "Place de le République Française, 10",
+            line2: "boite 15",
+            postalCode: "4000",
+            city: "Liège",
+            country: "Belgium",
+        };
+
+        const params = {
+            requesterIdentityLocId: "fd61e638-4af0-4ced-b018-4f1c31a91e6e",
+            secretName: "my-secret",
+            challenge: "my-challenge",
+            createdOn: moment(),
+            userIdentity,
+            userPostalAddress,
+            legalOfficerAddress: ALICE_ACCOUNT,
+        }
+        const secretRecoveryRequest = factory.newSecretRecoveryRequest(params);
+        expect(secretRecoveryRequest.id).toBeDefined();
+        expect(secretRecoveryRequest.getDescription().userIdentity).toEqual(params.userIdentity);
+        expect(secretRecoveryRequest.getDescription().userPostalAddress).toEqual(params.userPostalAddress);
+        expect(secretRecoveryRequest.getDescription().challenge).toEqual(params.challenge);
+        expect(secretRecoveryRequest.getDescription().secretName).toEqual(params.secretName);
+        expect(secretRecoveryRequest.getDescription().requesterIdentityLocId).toEqual(params.requesterIdentityLocId);
+    })
+})


### PR DESCRIPTION
* Provides a public (no authentication) to request a secret recovery.
* 2 Notification are sent:
  * to the legal officer, as the usual notification of work.
  * to the requester, to confirm his/her request.

logion-network/logion-internal#1255