### PR TITLE
Enable secret recovery review and decision

### DIFF
--- a/resources/mail/recoverable-secret-added.pug
+++ b/resources/mail/recoverable-secret-added.pug
@@ -1,7 +1,7 @@
 | logion notification - Recoverable secret added
 | Dear #{walletUser.firstName} #{walletUser.lastName},
 |
-| You receive this message because you just added a recoverable secret with name #{secretName} to your Identity LOC #{loc.id}.
+| You receive this message because you just added a recoverable secret with name #{secret.secretName} to your Identity LOC #{loc.id}.
 |
 | Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
 |

--- a/resources/mail/secret-recovery-accepted.pug
+++ b/resources/mail/secret-recovery-accepted.pug
@@ -1,0 +1,9 @@
+| logion notification - Secret recovery accepted
+| Dear #{walletUser.firstName} #{walletUser.lastName},
+|
+| You receive this message because your request to recover the secret with name #{secret.secretName} linked to your Identity LOC #{loc.id} has been accepted
+| by the legal officer in charge.
+|
+| Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
+|
+include /footer.pug

--- a/resources/mail/secret-recovery-rejected.pug
+++ b/resources/mail/secret-recovery-rejected.pug
@@ -1,0 +1,10 @@
+| logion notification - Secret recovery rejected
+| Dear #{walletUser.firstName} #{walletUser.lastName},
+|
+| You receive this message because your request to recover the secret with name #{secret.secretName} linked to your Identity LOC #{loc.id} has been rejected
+| by the legal officer in charge for the following reason:
+| #{secret.decision.rejectReason}
+|
+| Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
+|
+include /footer.pug

--- a/resources/mail/secret-recovery-requested-user.pug
+++ b/resources/mail/secret-recovery-requested-user.pug
@@ -1,7 +1,7 @@
 | logion notification - Recoverable secret added
 | Dear #{walletUser.firstName} #{walletUser.lastName},
 |
-| You receive this message because you just requested to recover the secret with name #{secretName} linked to your Identity LOC #{loc.id}.
+| You receive this message because you just requested to recover the secret with name #{secret.secretName} linked to your Identity LOC #{loc.id}.
 |
 | Please note, you can't answer this email. The logion network will never ask you to provide any kind of information or access to a web address through its email notifications.
 |

--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -412,24 +412,51 @@
                 "title": "ProtectionRequestView",
                 "description": "Information about the created Protection Request"
             },
+            "RecoveryInfoIdentityView": {
+                "type": "object",
+                "properties": {
+                    "userIdentity": {
+                        "$ref": "#/components/schemas/UserIdentityView"
+                    },
+                    "userPostalAddress": {
+                        "$ref": "#/components/schemas/PostalAddressView"
+                    }
+                }
+            },
             "RecoveryInfoView": {
                 "type": "object",
                 "properties": {
-                    "addressToRecover": {
-                        "type": "string",
-                        "description": "The address to recover"
+                    "identity1": {
+                        "$ref": "#/components/schemas/RecoveryInfoIdentityView"
                     },
-                    "accountToRecover": {
-                        "$ref": "#/components/schemas/ProtectionRequestView"
+                    "identity2": {
+                        "$ref": "#/components/schemas/RecoveryInfoIdentityView"
                     },
-                    "recoveryAccount": {
-                        "$ref": "#/components/schemas/ProtectionRequestView"
+                    "type": {
+                        "$ref": "#/components/schemas/RecoveryRequestType"
+                    },
+                    "accountRecovery": {
+                        "type": "object",
+                        "properties": {
+                            "address1": {
+                                "type": "string",
+                                "description": "The address to recover"
+                            },
+                            "address2": {
+                                "type": "string",
+                                "description": "The recovering address"
+                            }
+                        }
                     }
                 },
                 "title": "RecoveryInfoView",
-                "description": "The new (recovery) and old (to recover) account data"
+                "description": "The new (recovery) and old (to recover) account data",
+                "required": [
+                    "identity2",
+                    "type"
+                ]
             },
-            "RejectProtectionRequestView": {
+            "RejectRecoveryRequestView": {
                 "type": "object",
                 "properties": {
                     "rejectReason": {
@@ -437,8 +464,8 @@
                         "description": "The rejection reason"
                     }
                 },
-                "title": "RejectProtectionRequestView",
-                "description": "The Protection Request to reject"
+                "title": "RejectRecoveryRequestView",
+                "description": "The Recovery Request to reject"
             },
             "RejectTokenRequestView": {
                 "type": "object",
@@ -1955,6 +1982,70 @@
                     "userIdentity",
                     "userPostalAddress"
                 ]
+            },
+            "RecoveryRequestType": {
+                "type": "string",
+                "description": "The recovery request type",
+                "enum": [
+                    "ACCOUNT",
+                    "SECRET"
+                ]
+            },
+            "RecoveryRequestView": {
+                "type": "object",
+                "properties": {
+                    "userIdentity": {
+                        "$ref": "#/components/schemas/UserIdentityView"
+                    },
+                    "userPostalAddress": {
+                        "$ref": "#/components/schemas/PostalAddressView"
+                    },
+                    "createdOn": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The creation timestamp"
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "A recovery request status",
+                        "enum": [
+                            "ACCEPTED",
+                            "PENDING",
+                            "REJECTED",
+                            "ACTIVATED",
+                            "CANCELLED",
+                            "REJECTED_CANCELLED",
+                            "ACCEPTED_CANCELLED"
+                        ]
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/RecoveryRequestType"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The ID of created Protection Request"
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdOn",
+                    "status",
+                    "type",
+                    "userIdentity",
+                    "userPostalAddress"
+                ]
+            },
+            "RecoveryRequestsView": {
+                "type": "object",
+                "properties": {
+                    "requests": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RecoveryRequestView"
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/logion/app.support.ts
+++ b/src/logion/app.support.ts
@@ -25,6 +25,7 @@ import { fillInSpec as fillInSpecVote, VoteController } from "./controllers/vote
 import { fillInSpec as fillInSpecTokensRecord, TokensRecordController } from "./controllers/records.controller.js";
 import { fillInSpec as fillInSpecWorkload, WorkloadController } from "./controllers/workload.controller.js";
 import { fillInSpec as fillInSpecSecretRecovery, SecretRecoveryController } from "./controllers/secret_recovery.controller.js";
+import { fillInSpec as fillInSpecRecovery, RecoveryController } from "./controllers/recovery.controller.js";
 
 const { logger } = Log;
 
@@ -64,6 +65,7 @@ export function predefinedSpec(spec: OpenAPIV3.Document): OpenAPIV3.Document {
     fillInSpecTokensRecord(spec);
     fillInSpecWorkload(spec);
     fillInSpecSecretRecovery(spec);
+    fillInSpecRecovery(spec);
 
     return spec;
 }
@@ -127,6 +129,7 @@ export function setupApp(expressConfig?: ExpressConfig): Express {
     dino.registerController(TokensRecordController);
     dino.registerController(WorkloadController);
     dino.registerController(SecretRecoveryController);
+    dino.registerController(RecoveryController);
 
     dino.dependencyResolver<Container>(AppContainer,
         (injector, type) => {

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -69,6 +69,7 @@ import {
     SecretRecoveryRequestService,
     TransactionalSecretRecoveryRequestService
 } from "../services/secret_recovery.service.js";
+import { RecoveryController } from "../controllers/recovery.controller.js";
 
 const container = new Container({ defaultScope: "Singleton", skipBaseClassChecks: true });
 configureContainer(container);
@@ -175,5 +176,6 @@ container.bind(VoteController).toSelf().inTransientScope();
 container.bind(TokensRecordController).toSelf().inTransientScope();
 container.bind(WorkloadController).toSelf().inTransientScope();
 container.bind(SecretRecoveryController).toSelf().inTransientScope();
+container.bind(RecoveryController).toSelf().inTransientScope();
 
 export { container as AppContainer };

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -236,21 +236,30 @@ export interface components {
       /** @description The postal address of the requester */
       userPostalAddress?: components["schemas"]["PostalAddressView"];
     };
+    RecoveryInfoIdentityView: {
+      userIdentity?: components["schemas"]["UserIdentityView"];
+      userPostalAddress?: components["schemas"]["PostalAddressView"];
+    };
     /**
      * RecoveryInfoView
      * @description The new (recovery) and old (to recover) account data
      */
     RecoveryInfoView: {
-      /** @description The address to recover */
-      addressToRecover?: string;
-      accountToRecover?: components["schemas"]["ProtectionRequestView"];
-      recoveryAccount?: components["schemas"]["ProtectionRequestView"];
+      identity1?: components["schemas"]["RecoveryInfoIdentityView"];
+      identity2: components["schemas"]["RecoveryInfoIdentityView"];
+      type: components["schemas"]["RecoveryRequestType"];
+      accountRecovery?: {
+        /** @description The address to recover */
+        address1?: string;
+        /** @description The recovering address */
+        address2?: string;
+      };
     };
     /**
-     * RejectProtectionRequestView
-     * @description The Protection Request to reject
+     * RejectRecoveryRequestView
+     * @description The Recovery Request to reject
      */
-    RejectProtectionRequestView: {
+    RejectRecoveryRequestView: {
       /** @description The rejection reason */
       rejectReason?: string;
     };
@@ -1051,6 +1060,34 @@ export interface components {
       challenge: string;
       userIdentity: components["schemas"]["UserIdentityView"];
       userPostalAddress: components["schemas"]["PostalAddressView"];
+    };
+    /**
+     * @description The recovery request type
+     * @enum {string}
+     */
+    RecoveryRequestType: "ACCOUNT" | "SECRET";
+    RecoveryRequestView: {
+      userIdentity: components["schemas"]["UserIdentityView"];
+      userPostalAddress: components["schemas"]["PostalAddressView"];
+      /**
+       * Format: date-time
+       * @description The creation timestamp
+       */
+      createdOn: string;
+      /**
+       * @description A recovery request status
+       * @enum {string}
+       */
+      status: "ACCEPTED" | "PENDING" | "REJECTED" | "ACTIVATED" | "CANCELLED" | "REJECTED_CANCELLED" | "ACCEPTED_CANCELLED";
+      type: components["schemas"]["RecoveryRequestType"];
+      /**
+       * Format: uuid
+       * @description The ID of created Protection Request
+       */
+      id: string;
+    };
+    RecoveryRequestsView: {
+      requests?: components["schemas"]["RecoveryRequestView"][];
     };
   };
   responses: never;

--- a/src/logion/controllers/recovery.controller.ts
+++ b/src/logion/controllers/recovery.controller.ts
@@ -1,0 +1,100 @@
+import { OpenAPIV3 } from "express-oas-generator";
+import {
+    addTag,
+    setControllerTag,
+    requireDefined,
+    getDefaultResponses,
+    AuthenticationService,
+} from "@logion/rest-api-core";
+import { injectable } from "inversify";
+import { Controller, HttpPut, ApiController, Async } from "dinoloop";
+import { components } from "./components.js";
+import { SecretRecoveryRequestRepository, SecretRecoveryRequestAggregateRoot } from "../model/secret_recovery.model.js";
+import { LocRequestAdapter } from "./adapters/locrequestadapter.js";
+import { FetchProtectionRequestsSpecification, ProtectionRequestAggregateRoot, ProtectionRequestRepository } from "../model/protectionrequest.model.js";
+
+type RecoveryRequestView = components["schemas"]["RecoveryRequestView"];
+type RecoveryRequestsView = components["schemas"]["RecoveryRequestsView"];
+
+export function fillInSpec(spec: OpenAPIV3.Document): void {
+    const tagName = 'Recovery';
+    addTag(spec, {
+        name: tagName,
+        description: "Handling of Recovery Requests"
+    });
+    setControllerTag(spec, /^\/api\/recovery-requests.*/, tagName);
+
+    RecoveryController.fetchRecoveryRequests(spec);
+}
+
+@injectable()
+@Controller('/recovery-requests')
+export class RecoveryController extends ApiController {
+
+    constructor(
+        private authenticationService: AuthenticationService,
+        private secretRecoveryRequestRepository: SecretRecoveryRequestRepository,
+        private accountRecoveryRequestRepository: ProtectionRequestRepository,
+        private locRequestAdapter: LocRequestAdapter,
+    ) {
+        super();
+    }
+
+    static fetchRecoveryRequests(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/recovery-requests"].put!;
+        operationObject.summary = "Fetches recovery request";
+        operationObject.description = "Only for LLOs on current node";
+        operationObject.responses = getDefaultResponses("RecoveryRequestsView");
+    }
+
+    @Async()
+    @HttpPut('')
+    async fetchRecoveryRequests(): Promise<RecoveryRequestsView> {
+        const authenticatedUser = await this.authenticationService.authenticatedUserIsLegalOfficerOnNode(this.request);
+        const legalOfficer = authenticatedUser.validAccountId;
+
+        const accountRecoveryRequests = await this.accountRecoveryRequestRepository.findBy(
+            new FetchProtectionRequestsSpecification({
+                expectedLegalOfficerAddress: [ legalOfficer ],
+            })
+        );
+        const secretRecoveryRequests = await this.secretRecoveryRequestRepository.findByLegalOfficer(legalOfficer);
+        const view: RecoveryRequestsView = {
+            requests: [],
+        };
+        for(const request of accountRecoveryRequests) {
+            view.requests?.push(await this.toAccountRecoveryRequestView(request));
+        }
+        for(const request of secretRecoveryRequests) {
+            view.requests?.push(this.toSecretRecoveryRequestView(request));
+        }
+        return view;
+    }
+
+    private async toAccountRecoveryRequestView(accountRecoveryRequest: ProtectionRequestAggregateRoot): Promise<RecoveryRequestView> {
+        const description = accountRecoveryRequest.getDescription();
+        const { userIdentity, userPostalAddress } = requireDefined(
+            await this.locRequestAdapter.getUserPrivateData(description.requesterIdentityLocId)
+        );
+        return {
+            createdOn: description.createdOn,
+            id: description.id,
+            status: description.status,
+            type: "ACCOUNT",
+            userIdentity: requireDefined(userIdentity),
+            userPostalAddress: requireDefined(userPostalAddress),
+        };
+    }
+
+    private toSecretRecoveryRequestView(secretRecoveryRequest: SecretRecoveryRequestAggregateRoot): RecoveryRequestView {
+        const description = secretRecoveryRequest.getDescription();
+        return {
+            createdOn: description.createdOn.toISOString(),
+            id: description.id,
+            status: description.status,
+            type: "SECRET",
+            userIdentity: description.userIdentity,
+            userPostalAddress: description.userPostalAddress,
+        };
+    }
+}

--- a/src/logion/migration/1716302125635-AddSecretStatus.ts
+++ b/src/logion/migration/1716302125635-AddSecretStatus.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSecretStatus1716302125635 implements MigrationInterface {
+    name = 'AddSecretStatus1716302125635'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "secret_recovery_request" ADD "status" character varying(255) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "secret_recovery_request" ADD "decision_on" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "secret_recovery_request" ADD "reject_reason" character varying(255)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "secret_recovery_request" DROP COLUMN "reject_reason"`);
+        await queryRunner.query(`ALTER TABLE "secret_recovery_request" DROP COLUMN "decision_on"`);
+        await queryRunner.query(`ALTER TABLE "secret_recovery_request" DROP COLUMN "status"`);
+    }
+
+}

--- a/src/logion/model/decision.ts
+++ b/src/logion/model/decision.ts
@@ -1,0 +1,25 @@
+import { Column } from "typeorm";
+import { Moment } from 'moment';
+
+export class LegalOfficerDecision {
+
+    reject(reason: string, decisionOn: Moment): void {
+        this.decisionOn = decisionOn.toISOString();
+        this.rejectReason = reason;
+    }
+
+    accept(decisionOn: Moment): void {
+        this.decisionOn = decisionOn.toISOString();
+    }
+
+    clear() {
+        this.decisionOn = undefined;
+        this.rejectReason = undefined;
+    }
+
+    @Column("timestamp without time zone", { name: "decision_on", nullable: true })
+    decisionOn?: string;
+
+    @Column({ length: 255, name: "reject_reason", nullable: true })
+    rejectReason?: string;
+}

--- a/src/logion/services/notification.service.ts
+++ b/src/logion/services/notification.service.ts
@@ -39,6 +39,8 @@ export const templateValues = [
     "recoverable-secret-added",
     "secret-recovery-requested-legal-officer",
     "secret-recovery-requested-user",
+    "secret-recovery-rejected",
+    "secret-recovery-accepted",
 ] as const;
 
 export type Template = typeof templateValues[number];

--- a/src/logion/services/secret_recovery.service.ts
+++ b/src/logion/services/secret_recovery.service.ts
@@ -2,7 +2,7 @@ import {
     SecretRecoveryRequestRepository,
     SecretRecoveryRequestAggregateRoot
 } from "../model/secret_recovery.model.js";
-import { DefaultTransactional } from "@logion/rest-api-core";
+import { DefaultTransactional, requireDefined } from "@logion/rest-api-core";
 import { injectable } from "inversify";
 
 export abstract class SecretRecoveryRequestService {
@@ -14,6 +14,13 @@ export abstract class SecretRecoveryRequestService {
 
     async add(request: SecretRecoveryRequestAggregateRoot) {
         await this.secretRecoveryRequestRepository.save(request);
+    }
+
+    async update(id: string, mutator: (item: SecretRecoveryRequestAggregateRoot) => Promise<void>): Promise<SecretRecoveryRequestAggregateRoot> {
+        const item = requireDefined(await this.secretRecoveryRequestRepository.findById(id));
+        await mutator(item);
+        await this.secretRecoveryRequestRepository.save(item);
+        return item;
     }
 }
 
@@ -29,6 +36,11 @@ export class TransactionalSecretRecoveryRequestService extends SecretRecoveryReq
     @DefaultTransactional()
     override async add(request: SecretRecoveryRequestAggregateRoot): Promise<void> {
         return super.add(request);
+    }
+
+    @DefaultTransactional()
+    override update(id: string, mutator: (item: SecretRecoveryRequestAggregateRoot) => Promise<void>): Promise<SecretRecoveryRequestAggregateRoot> {
+        return super.update(id, mutator);
     }
 }
 

--- a/test/unit/controllers/recovery.controller.spec.ts
+++ b/test/unit/controllers/recovery.controller.spec.ts
@@ -1,0 +1,146 @@
+import { Container } from 'inversify';
+import { Mock } from 'moq.ts';
+import request from 'supertest';
+
+import { TestApp } from '@logion/rest-api-core';
+
+import {
+    ProtectionRequestRepository,
+    ProtectionRequestAggregateRoot,
+    ProtectionRequestDescription,
+} from '../../../src/logion/model/protectionrequest.model.js';
+import { BOB_ACCOUNT, ALICE_ACCOUNT } from '../../helpers/addresses.js';
+import { UserIdentity } from '../../../src/logion/model/useridentity.js';
+import { PostalAddress } from '../../../src/logion/model/postaladdress.js';
+import { LocRequestAdapter } from "../../../src/logion/controllers/adapters/locrequestadapter.js";
+import { ValidAccountId } from "@logion/node-api";
+import { RecoveryController } from '../../../src/logion/controllers/recovery.controller.js';
+import { SecretRecoveryRequestAggregateRoot, SecretRecoveryRequestDescription, SecretRecoveryRequestRepository } from '../../../src/logion/model/secret_recovery.model.js';
+import { ItIsAccount } from '../../helpers/Mock.js';
+import moment from 'moment';
+
+const { setupApp, mockLegalOfficerOnNode, mockAuthenticationWithAuthenticatedUser } = TestApp;
+
+describe('RecoveryController', () => {
+
+    it('fetchRecoveryRequests', async () => {
+        const userMock = mockAuthenticationWithAuthenticatedUser(mockLegalOfficerOnNode(ALICE_ACCOUNT));
+        const app = setupApp(RecoveryController, mockModelForFetch, userMock);
+
+        await request(app)
+            .put('/api/recovery-requests')
+            .expect(200)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.requests).toBeDefined();
+                expect(response.body.requests.length).toBe(2);
+
+                expect(response.body.requests[0].userIdentity).toEqual(IDENTITY);
+                expect(response.body.requests[0].userPostalAddress).toEqual(POSTAL_ADDRESS);
+                expect(response.body.requests[0].createdOn).toBe(ACCOUNT_CREATED_ON);
+                expect(response.body.requests[0].status).toBe("ACCEPTED");
+                expect(response.body.requests[0].id).toBe(ACCOUNT_RECOVERY_REQUEST_ID);
+                expect(response.body.requests[0].type).toBe("ACCOUNT");
+
+                expect(response.body.requests[1].userIdentity).toEqual(IDENTITY);
+                expect(response.body.requests[1].userPostalAddress).toEqual(POSTAL_ADDRESS);
+                expect(response.body.requests[1].createdOn).toBe(SECRET_CREATED_ON.toISOString());
+                expect(response.body.requests[1].status).toBe("ACCEPTED");
+                expect(response.body.requests[1].id).toBe(SECRET_RECOVERY_REQUEST_ID);
+                expect(response.body.requests[1].type).toBe("SECRET");
+            });
+    });
+});
+
+function mockModelForFetch(container: Container): void {
+    const accountRecoveryRequestRepository = new Mock<ProtectionRequestRepository>();
+
+    const protectionRequest = mockProtectionRequest();
+
+    const requests: ProtectionRequestAggregateRoot[] = [ protectionRequest.object() ];
+    accountRecoveryRequestRepository.setup(instance => instance.findBy)
+        .returns(() => Promise.resolve(requests));
+    container.bind(ProtectionRequestRepository).toConstantValue(accountRecoveryRequestRepository.object());
+
+    container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
+
+    const secretRecoveryRequest = mockSecretRecoveryRequest();
+    const secretRecoveryRequestRepository = new Mock<SecretRecoveryRequestRepository>();
+    secretRecoveryRequestRepository.setup(instance => instance.findByLegalOfficer(ItIsAccount(ALICE_ACCOUNT)))
+        .returns(Promise.resolve([ secretRecoveryRequest.object() ]));
+    container.bind(SecretRecoveryRequestRepository).toConstantValue(secretRecoveryRequestRepository.object());
+}
+
+function mockProtectionRequest(): Mock<ProtectionRequestAggregateRoot> {
+    const description: ProtectionRequestDescription = {
+        id: ACCOUNT_RECOVERY_REQUEST_ID,
+        status: "ACCEPTED",
+        requesterAddress: REQUESTER,
+        requesterIdentityLocId: REQUESTER_IDENTITY_LOC_ID,
+        legalOfficerAddress: ALICE_ACCOUNT,
+        isRecovery: false,
+        otherLegalOfficerAddress: BOB_ACCOUNT,
+        createdOn: ACCOUNT_CREATED_ON,
+        addressToRecover: null,
+    }
+    const protectionRequest = new Mock<ProtectionRequestAggregateRoot>()
+    protectionRequest.setup(instance => instance.getDescription()).returns(description)
+    protectionRequest.setup(instance => instance.getLegalOfficer()).returns(ALICE_ACCOUNT)
+    protectionRequest.setup(instance => instance.getOtherLegalOfficer()).returns(BOB_ACCOUNT)
+    protectionRequest.setup(instance => instance.getRequester()).returns(REQUESTER)
+    protectionRequest.setup(instance => instance.getAddressToRecover()).returns(null)
+    return protectionRequest
+}
+
+const REQUESTER = ValidAccountId.polkadot("5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY");
+
+const ACCOUNT_CREATED_ON = "2021-06-10T16:25:23.668294";
+
+const IDENTITY: UserIdentity = {
+    email: "john.doe@logion.network",
+    firstName: "John",
+    lastName: "Doe",
+    phoneNumber: "+1234",
+};
+
+const POSTAL_ADDRESS: PostalAddress = {
+    line1: "Place de le République Française, 10",
+    line2: "boite 15",
+    postalCode: "4000",
+    city: "Liège",
+    country: "Belgium"
+};
+
+const REQUESTER_IDENTITY_LOC_ID = "77c2fef4-6f1d-44a1-a49d-3485c2eb06ee";
+
+const ACCOUNT_RECOVERY_REQUEST_ID = "a7ff4ab6-5bef-4310-9c28-bcbd653565c3";
+
+function mockLocRequestAdapter(): LocRequestAdapter {
+    const locRequestAdapter = new Mock<LocRequestAdapter>();
+    locRequestAdapter.setup(instance => instance.getUserPrivateData(REQUESTER_IDENTITY_LOC_ID))
+        .returns(Promise.resolve({
+            userIdentity: IDENTITY,
+            userPostalAddress: POSTAL_ADDRESS,
+            identityLocId: REQUESTER_IDENTITY_LOC_ID
+        }))
+    return locRequestAdapter.object();
+}
+
+function mockSecretRecoveryRequest(): Mock<SecretRecoveryRequestAggregateRoot> {
+    const description: SecretRecoveryRequestDescription = {
+        id: SECRET_RECOVERY_REQUEST_ID,
+        status: "ACCEPTED",
+        requesterIdentityLocId: REQUESTER_IDENTITY_LOC_ID,
+        createdOn: SECRET_CREATED_ON,
+        challenge: "Challenge",
+        secretName: "Key",
+        userIdentity: IDENTITY,
+        userPostalAddress: POSTAL_ADDRESS,
+    }
+    const protectionRequest = new Mock<SecretRecoveryRequestAggregateRoot>()
+    protectionRequest.setup(instance => instance.getDescription()).returns(description)
+    return protectionRequest
+}
+
+const SECRET_RECOVERY_REQUEST_ID = "f293127e-8356-47a7-a6b7-480cdd1daabd";
+const SECRET_CREATED_ON = moment();

--- a/test/unit/controllers/secret_recovery.controller.spec.ts
+++ b/test/unit/controllers/secret_recovery.controller.spec.ts
@@ -1,11 +1,12 @@
-import { TestApp } from "@logion/rest-api-core";
+import { AuthenticationService, TestApp } from "@logion/rest-api-core";
 import { Container } from "inversify";
 import { SecretRecoveryController } from "../../../src/logion/controllers/secret_recovery.controller.js";
 import {
     SecretRecoveryRequestFactory,
-    SecretRecoveryRequestDescription, SecretRecoveryRequestAggregateRoot
+    SecretRecoveryRequestDescription, SecretRecoveryRequestAggregateRoot,
+    SecretRecoveryRequestRepository
 } from "../../../src/logion/model/secret_recovery.model.js";
-import { SecretRecoveryRequestService } from "../../../src/logion/services/secret_recovery.service.js";
+import { NonTransactionalSecretRecoveryRequestService, SecretRecoveryRequestService } from "../../../src/logion/services/secret_recovery.service.js";
 import {
     LocRequestRepository,
     LocRequestAggregateRoot,
@@ -20,14 +21,17 @@ import moment from "moment";
 import { notifiedLegalOfficer } from "../services/notification-test-data.js";
 import { ValidAccountId } from "@logion/node-api";
 import { LocalsObject } from "pug";
+import { mockAuthenticationWithAuthenticatedUser } from "@logion/rest-api-core/dist/TestApp.js";
+import { UserIdentity } from "src/logion/model/useridentity.js";
+import { PostalAddress } from "src/logion/model/postaladdress.js";
 
-const { setupApp } = TestApp;
+const { setupApp, mockLegalOfficerOnNode } = TestApp;
 
 describe("SecretRecoveryController", () => {
 
     it("creates secret recovery request", async () => {
 
-        const app = setupApp(SecretRecoveryController, mockDependencies);
+        const app = setupApp(SecretRecoveryController, mockForCreate);
         await request(app)
             .post('/api/secret-recovery')
             .send({
@@ -36,11 +40,12 @@ describe("SecretRecoveryController", () => {
                 secretName: SECRET_NAME,
             })
             .expect(204);
+        secretRecoveryRequestRepository.verify(instance => instance.save(secretRecoveryRequest.object()));
     })
 
     it("fails to create secret recovery request with IDLOC not found", async () => {
 
-        const app = setupApp(SecretRecoveryController, mockDependencies);
+        const app = setupApp(SecretRecoveryController, mockForCreate);
         const unknownLocId = "0a765ca1-f0a8-450a-b66a-5dfe9de7adc6";
         await request(app)
             .post('/api/secret-recovery')
@@ -55,7 +60,7 @@ describe("SecretRecoveryController", () => {
 
     it("fails to create secret recovery request with Secret not found", async () => {
 
-        const app = setupApp(SecretRecoveryController, mockDependencies);
+        const app = setupApp(SecretRecoveryController, mockForCreate);
         await request(app)
             .post('/api/secret-recovery')
             .send({
@@ -66,12 +71,68 @@ describe("SecretRecoveryController", () => {
             .expect(400)
             .expect(response => expect(response.body.errorMessage).toEqual("Secret not found"));
     })
+
+    it("accepts existing secret recovery request", async () => {
+        const userMock = mockAuthenticationWithAuthenticatedUser(mockLegalOfficerOnNode(ALICE_ACCOUNT));
+        const app = setupApp(SecretRecoveryController, mockForUpdate, userMock);
+        await request(app)
+            .post(`/api/secret-recovery/${ REQUEST_ID }/accept`)
+            .expect(204);
+        secretRecoveryRequest.verify(instance => instance.accept(It.IsAny()));
+        secretRecoveryRequestRepository.verify(instance => instance.save(secretRecoveryRequest.object()));
+    })
+
+    it("rejects existing secret recovery request", async () => {
+        const userMock = mockAuthenticationWithAuthenticatedUser(mockLegalOfficerOnNode(ALICE_ACCOUNT));
+        const app = setupApp(SecretRecoveryController, mockForUpdate, userMock);
+        await request(app)
+            .post(`/api/secret-recovery/${ REQUEST_ID }/reject`)
+            .send({ rejectReason: "Because." })
+            .expect(204);
+        secretRecoveryRequest.verify(instance => instance.reject("Because.", It.IsAny()));
+        secretRecoveryRequestRepository.verify(instance => instance.save(secretRecoveryRequest.object()));
+    })
+
+    it("fetches recovery information", async () => {
+        const userMock = mockAuthenticationWithAuthenticatedUser(mockLegalOfficerOnNode(ALICE_ACCOUNT));
+        const app = setupApp(SecretRecoveryController, mockForFetch, userMock);
+        await request(app)
+            .put(`/api/secret-recovery/${ REQUEST_ID }/recovery-info`)
+            .expect(200)
+            .then(response => {
+                expect(response.body.identity1).toBeDefined();
+                expect(response.body.identity1.userIdentity).toEqual(USER_IDENTITY);
+                expect(response.body.identity1.userPostalAddress).toEqual(USER_POSTAL_ADDRESS);
+
+                expect(response.body.identity2).toBeDefined();
+                expect(response.body.identity2.userIdentity).toEqual(USER_IDENTITY);
+                expect(response.body.identity2.userPostalAddress).toEqual(USER_POSTAL_ADDRESS);
+
+                expect(response.body.type).toBe("SECRET");
+            });
+    })
 })
 
-function mockDependencies(container: Container) {
+function mockForCreate(container: Container) {
+    mockForAll(container);
+
+    secretRecoveryRequest.setup(instance => instance.getDescription())
+        .returns({
+            ...recoveryRequest,
+            requesterIdentityLocId: IDENTITY_LOC_ID,
+            secretName: SECRET_NAME,
+            createdOn: moment(),
+            id: REQUEST_ID,
+            status: "PENDING",
+        });
+    secretRecoveryRequestFactory.setup(instance => instance.newSecretRecoveryRequest(It.IsAny<SecretRecoveryRequestDescription>()))
+        .returns(secretRecoveryRequest.object());
+}
+
+function mockForAll(container: Container) {
     createAndBindMocks(container);
 
-    const identityLoc = new Mock<LocRequestAggregateRoot>();
+    identityLoc = new Mock<LocRequestAggregateRoot>();
     const secret = new Mock<RecoverableSecretEntity>();
     secret.setup(instance => instance.name)
         .returns(SECRET_NAME);
@@ -84,19 +145,20 @@ function mockDependencies(container: Container) {
     locRequestRepository.setup(instance => instance.findById(IDENTITY_LOC_ID))
         .returns(Promise.resolve(identityLoc.object()));
 
-    const secretRecoveryRequest = new Mock<SecretRecoveryRequestAggregateRoot>();
     secretRecoveryRequest.setup(instance => instance.getDescription())
         .returns({
             ...recoveryRequest,
             requesterIdentityLocId: IDENTITY_LOC_ID,
             secretName: SECRET_NAME,
             createdOn: moment(),
+            id: REQUEST_ID,
+            status: "PENDING",
         })
     secretRecoveryRequestFactory.setup(instance => instance.newSecretRecoveryRequest(It.IsAny<SecretRecoveryRequestDescription>()))
         .returns(secretRecoveryRequest.object());
 
-    secretRecoveryRequestService.setup(instance => instance.add(secretRecoveryRequest.object()))
-        .returns(Promise.resolve())
+    secretRecoveryRequestRepository.setup(instance => instance.save(It.IsAny()))
+        .returns(Promise.resolve());
 
     mockNotifications();
 }
@@ -114,39 +176,95 @@ function mockNotifications() {
 const IDENTITY_LOC_ID = "1f95f7e8-022a-4baf-bc90-4796c493dd69";
 const SECRET_NAME = "my-secret";
 const CHALLENGE = "my-challenge";
-
-const recoveryRequest = {
-    challenge: CHALLENGE,
-    userIdentity: {
-        email: "john.doe@logion.network",
-        firstName: "John",
-        lastName: "Doe",
-        phoneNumber: "+1234",
-    },
-    userPostalAddress: {
-        line1: "Rue de la Paix",
+const REQUEST_ID = "a7ff4ab6-5bef-4310-9c28-bcbd653565c3";
+const USER_IDENTITY: UserIdentity = {
+    email: "john.doe@logion.network",
+    firstName: "John",
+    lastName: "Doe",
+    phoneNumber: "+1234",
+};
+const USER_POSTAL_ADDRESS: PostalAddress = {
+    line1: "Rue de la Paix",
         line2: "",
         postalCode: "00000",
         city: "Liège",
         country: "Belgium",
-    },
+};
+
+const recoveryRequest = {
+    challenge: CHALLENGE,
+    userIdentity: USER_IDENTITY,
+    userPostalAddress: USER_POSTAL_ADDRESS,
 }
 
+let identityLoc: Mock<LocRequestAggregateRoot>;
 let secretRecoveryRequestFactory: Mock<SecretRecoveryRequestFactory>;
-let secretRecoveryRequestService: Mock<SecretRecoveryRequestService>;
+let secretRecoveryRequestRepository: Mock<SecretRecoveryRequestRepository>;
 let locRequestRepository: Mock<LocRequestRepository>;
 let directoryService: Mock<DirectoryService>;
 let notificationService: Mock<NotificationService>;
+let secretRecoveryRequest: Mock<SecretRecoveryRequestAggregateRoot>;
 
 function createAndBindMocks(container: Container) {
+    secretRecoveryRequest = new Mock<SecretRecoveryRequestAggregateRoot>();
     secretRecoveryRequestFactory = new Mock<SecretRecoveryRequestFactory>();
     container.bind(SecretRecoveryRequestFactory).toConstantValue(secretRecoveryRequestFactory.object());
-    secretRecoveryRequestService = new Mock<SecretRecoveryRequestService>();
-    container.bind(SecretRecoveryRequestService).toConstantValue(secretRecoveryRequestService.object());
+    secretRecoveryRequestRepository = new Mock<SecretRecoveryRequestRepository>();
+    container.bind(SecretRecoveryRequestRepository).toConstantValue(secretRecoveryRequestRepository.object());
+    container.bind(SecretRecoveryRequestService).toConstantValue(new NonTransactionalSecretRecoveryRequestService(secretRecoveryRequestRepository.object()));
     locRequestRepository = new Mock<LocRequestRepository>();
     container.bind(LocRequestRepository).toConstantValue(locRequestRepository.object());
     directoryService = new Mock<DirectoryService>();
     container.bind(DirectoryService).toConstantValue(directoryService.object());
     notificationService = new Mock<NotificationService>();
     container.bind(NotificationService).toConstantValue(notificationService.object());
+}
+
+function mockForUpdate(container: Container) {
+    mockForAll(container);
+
+    secretRecoveryRequest = new Mock<SecretRecoveryRequestAggregateRoot>();
+    secretRecoveryRequest.setup(instance => instance.getDescription())
+        .returns({
+            ...recoveryRequest,
+            requesterIdentityLocId: IDENTITY_LOC_ID,
+            secretName: SECRET_NAME,
+            createdOn: moment(),
+            id: REQUEST_ID,
+            status: "PENDING",
+        });
+    secretRecoveryRequest.setup(instance => instance.accept(It.IsAny())).returns();
+    secretRecoveryRequest.setup(instance => instance.reject(It.IsAny(), It.IsAny())).returns();
+
+    secretRecoveryRequestRepository.setup(instance => instance.findById(REQUEST_ID))
+        .returns(Promise.resolve(secretRecoveryRequest.object()));
+}
+
+function mockForFetch(container: Container) {
+    mockForAll(container);
+
+    secretRecoveryRequest = new Mock<SecretRecoveryRequestAggregateRoot>();
+    secretRecoveryRequest.setup(instance => instance.getDescription())
+        .returns({
+            ...recoveryRequest,
+            requesterIdentityLocId: IDENTITY_LOC_ID,
+            secretName: SECRET_NAME,
+            createdOn: moment(),
+            id: REQUEST_ID,
+            status: "PENDING",
+        });
+    secretRecoveryRequestRepository.setup(instance => instance.findById(REQUEST_ID))
+        .returns(Promise.resolve(secretRecoveryRequest.object()));
+
+    identityLoc.setup(instance => instance.getDescription()).returns({
+        createdOn: moment().toISOString(),
+        description: "",
+        fees: {
+
+        },
+        locType: "Identity",
+        ownerAddress: ALICE_ACCOUNT,
+        userIdentity: USER_IDENTITY,
+        userPostalAddress: USER_POSTAL_ADDRESS,
+    });
 }

--- a/test/unit/controllers/vaulttransferrequest.controller.spec.ts
+++ b/test/unit/controllers/vaulttransferrequest.controller.spec.ts
@@ -347,6 +347,8 @@ const POSTAL_ADDRESS: PostalAddress = {
 const REQUESTER_IDENTITY_LOC_ID = "77c2fef4-6f1d-44a1-a49d-3485c2eb06ee";
 
 const protectionRequestDescription: ProtectionRequestDescription = {
+    id: "a7ff4ab6-5bef-4310-9c28-bcbd653565c3",
+    status: "ACTIVATED",
     addressToRecover: null,
     requesterIdentityLocId: REQUESTER_IDENTITY_LOC_ID,
     legalOfficerAddress: ALICE_ACCOUNT,

--- a/test/unit/model/protectionrequest.model.spec.ts
+++ b/test/unit/model/protectionrequest.model.spec.ts
@@ -36,7 +36,6 @@ describe('ProtectionRequestFactoryTest', () => {
         const factory = new ProtectionRequestFactory(locRequestRepository.object());
         await expectAsyncToThrow(
             () => factory.newProtectionRequest({
-                id,
                 requesterIdentityLoc: "missing",
                 ...description,
             }),
@@ -140,6 +139,8 @@ const userPostalAddress = {
     country: "Belgium",
 };
 const description: ProtectionRequestDescription = {
+    id,
+    status: "PENDING",
     requesterAddress: ValidAccountId.polkadot("5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW"),
     requesterIdentityLocId: "80124e8a-a7d8-456f-a7be-deb4e0983e87",
     legalOfficerAddress: ALICE_ACCOUNT,
@@ -170,7 +171,6 @@ async function newProtectionRequestUsingFactory(status?: ProtectionRequestStatus
 
     const factory = new ProtectionRequestFactory(locRequestRepository.object());
     const protectionRequest = await factory.newProtectionRequest({
-        id,
         requesterIdentityLoc: identityLoc.id!,
         ...description,
     });

--- a/test/unit/services/notification-test-data.ts
+++ b/test/unit/services/notification-test-data.ts
@@ -7,8 +7,12 @@ import { LegalOfficer } from "../../../src/logion/model/legalofficer.model.js";
 import { VaultTransferRequestDescription } from "src/logion/model/vaulttransferrequest.model.js";
 import { ValidAccountId } from "@logion/node-api";
 import { LocRequestDecision, LocRequestDescription } from "src/logion/model/loc_vos.js";
+import { SecretRecoveryRequestDescription } from "src/logion/model/secret_recovery.model.js";
+import moment from "moment";
 
 export const notifiedProtection: ProtectionRequestDescription & { decision: LegalOfficerDecisionDescription } = {
+    id: "a7ff4ab6-5bef-4310-9c28-bcbd653565c3",
+    status: "PENDING",
     requesterAddress: ValidAccountId.polkadot("5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY"),
     requesterIdentityLocId: "7a6ca6b7-87ca-4e55-9c5f-422c9f799b74",
     legalOfficerAddress: ALICE_ACCOUNT,
@@ -80,6 +84,28 @@ const vaultTransfer: VaultTransferRequestDescription = {
     },
 };
 
+const secret: SecretRecoveryRequestDescription = {
+    id: "id",
+    challenge: "00475b3e-cf23-4fdc-a057-80372dc44f9e",
+    createdOn: moment("2021-06-10T16:25:23.668294"),
+    requesterIdentityLocId: "0f9ce42d-e020-4168-a5aa-e72618a8a882",
+    secretName: "Key",
+    status: "REJECTED",
+    userIdentity: {
+        firstName: "John",
+        lastName: "Doe",
+        email: "john@doe.com",
+        phoneNumber: "123465",
+    },
+    userPostalAddress: {
+        line1: "Rue de la Paix",
+        line2: "",
+        postalCode: "4000",
+        city: "Liège",
+        country: "Belgium"
+    }
+};
+
 export function notificationData() {
     const lo = notifiedLegalOfficer(ALICE_ACCOUNT.address);
     const otherLo = notifiedLegalOfficer(BOB_ACCOUNT.address);
@@ -107,7 +133,13 @@ export function notificationData() {
                 decisionOn: "2021-06-10T16:25:23.668294",
                 rejectReason: "Failed to provide some data",
             }
+        },
+        secret: {
+            ...secret,
+            decision: {
+                decisionOn: "2021-06-10T16:25:23.668294",
+                rejectReason: "Failed to provide some data",
+            }
         }
     }
 }
-


### PR DESCRIPTION
* Adds a resource to retrieve all recovery requests (account and secret) in a single HTTP request.
* Enriches model to enable acceptance/rejection of a secret recovery request.
* Standardizes recovery request review (same view for account and secret recovery).

logion-network/logion-internal#1263