### PR TITLE
Decentralize directory

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,7 +6,6 @@ JWT_ISSUER=12D3KooWDCuGU7WY3VaWjBS1E44x4EnmTgK3HRxWFqYG3dqXDfP1 # Replace this v
 JWT_TTL_SEC=3600 # TTL of issued JWT tokens
 OWNER=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
 HEALTH_TOKEN="change-me-please"
-DIRECTORY_URL=http://localhost:8090
 BASE_URL=http://localhost:8080
 
 # E-mail

--- a/resources/mail/README.md
+++ b/resources/mail/README.md
@@ -9,9 +9,8 @@ contain only variables, which are replaced at runtime with their respective valu
 All possible variables are available (for copy/paste) in this template: [all-documented-vars.pug](all-documented-vars.pug)
 
 ### Legal Officer
-    legalOfficer.address
+    legalOfficer.account.address
     legalOfficer.additionalDetails
-    legalOfficer.node
 
     legalOfficer.userIdentity.firstName
     legalOfficer.userIdentity.lastName

--- a/resources/mail/all-documented-vars.pug
+++ b/resources/mail/all-documented-vars.pug
@@ -3,7 +3,6 @@
 | === Legal Officer ===
 | #{legalOfficer.address};
 | #{legalOfficer.additionalDetails};
-| #{legalOfficer.node};
 |
 | #{legalOfficer.userIdentity.firstName};
 | #{legalOfficer.userIdentity.lastName};
@@ -17,26 +16,8 @@
 | #{legalOfficer.postalAddress.city};
 | #{legalOfficer.postalAddress.country};
 |
-| === Other Legal Officer ===
-| #{otherLegalOfficer.address};
-| #{otherLegalOfficer.additionalDetails};
-| #{otherLegalOfficer.node};
-|
-| #{otherLegalOfficer.userIdentity.firstName};
-| #{otherLegalOfficer.userIdentity.lastName};
-| #{otherLegalOfficer.userIdentity.email};
-| #{otherLegalOfficer.userIdentity.phoneNumber};
-|
-| #{otherLegalOfficer.postalAddress.company};
-| #{otherLegalOfficer.postalAddress.line1};
-| #{otherLegalOfficer.postalAddress.line2};
-| #{otherLegalOfficer.postalAddress.postalCode};
-| #{otherLegalOfficer.postalAddress.city};
-| #{otherLegalOfficer.postalAddress.country};
-|
 | === Account Recovery ===
 | #{recovery.requesterAddress.address};
-| #{recovery.otherLegalOfficerAddress};
 | #{recovery.addressToRecover};
 | #{recovery.createdOn};
 |

--- a/resources/mail/legal-officer-details.pug
+++ b/resources/mail/legal-officer-details.pug
@@ -8,7 +8,7 @@
 |
 | Identification key:
 | ********************
-| #{legalOfficer.address}
+| #{legalOfficer.account.address}
 |
 | Email:
 | *******

--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -2049,6 +2049,70 @@
                         "description": "The ID of the Secret Recovery"
                     }
                 }
+            },
+            "FetchLegalOfficersView": {
+                "type": "object",
+                "properties": {
+                    "legalOfficers": {
+                        "type": "array",
+                        "description": "All the legal officers",
+                        "items": {
+                            "$ref": "#/components/schemas/LegalOfficerView"
+                        }
+                    }
+                },
+                "title": "FetchLegalOfficersView",
+                "description": "The fetched Legal Officers"
+            },
+            "LegalOfficerView": {
+                "type": "object",
+                "properties": {
+                    "address": {
+                        "type": "string",
+                        "description": "The SS58 address of the legal officer"
+                    },
+                    "userIdentity": {
+                        "$ref": "#/components/schemas/UserIdentityView"
+                    },
+                    "postalAddress": {
+                        "$ref": "#/components/schemas/LegalOfficerPostalAddressView"
+                    },
+                    "additionalDetails": {
+                        "type": "string",
+                        "description": "Any additional public info"
+                    }
+                },
+                "title": "LegalOfficerView",
+                "description": "The Legal Officer"
+            },
+            "CreateOrUpdateLegalOfficerView": {
+                "type": "object",
+                "properties": {
+                    "userIdentity": {
+                        "$ref": "#/components/schemas/UserIdentityView"
+                    },
+                    "postalAddress": {
+                        "$ref": "#/components/schemas/LegalOfficerPostalAddressView"
+                    },
+                    "additionalDetails": {
+                        "type": "string",
+                        "description": "Any additional public info"
+                    }
+                },
+                "title": "CreateOrUpdateLegalOfficerView",
+                "description": "The Legal Officer info to created or updated"
+            },
+            "LegalOfficerPostalAddressView": {
+                "type": "object",
+                "allOf": [{
+                    "$ref": "#/components/schemas/PostalAddressView"
+                }],
+                "properties": {
+                    "company": {
+                        "type": "string",
+                        "description": "The company of the Legal Officer"
+                    }
+                }
             }
         }
     }

--- a/src/logion/app.support.ts
+++ b/src/logion/app.support.ts
@@ -26,6 +26,7 @@ import { fillInSpec as fillInSpecTokensRecord, TokensRecordController } from "./
 import { fillInSpec as fillInSpecWorkload, WorkloadController } from "./controllers/workload.controller.js";
 import { fillInSpec as fillInSpecSecretRecovery, SecretRecoveryController } from "./controllers/secret_recovery.controller.js";
 import { fillInSpec as fillInSpecRecovery, RecoveryController } from "./controllers/recovery.controller.js";
+import { fillInSpec as fillInSpecLegalOfficer, LegalOfficerController } from "./controllers/legalofficer.controller.js";
 
 const { logger } = Log;
 
@@ -66,6 +67,7 @@ export function predefinedSpec(spec: OpenAPIV3.Document): OpenAPIV3.Document {
     fillInSpecWorkload(spec);
     fillInSpecSecretRecovery(spec);
     fillInSpecRecovery(spec);
+    fillInSpecLegalOfficer(spec);
 
     return spec;
 }
@@ -130,6 +132,7 @@ export function setupApp(expressConfig?: ExpressConfig): Express {
     dino.registerController(WorkloadController);
     dino.registerController(SecretRecoveryController);
     dino.registerController(RecoveryController);
+    dino.registerController(LegalOfficerController);
 
     dino.dependencyResolver<Container>(AppContainer,
         (injector, type) => {

--- a/src/logion/container/app.container.ts
+++ b/src/logion/container/app.container.ts
@@ -20,7 +20,9 @@ import { TransactionController } from '../controllers/transaction.controller.js'
 import { CollectionRepository, CollectionFactory } from "../model/collection.model.js";
 import { NotificationService } from "../services/notification.service.js";
 import { MailService } from "../services/mail.service.js";
-import { DirectoryService } from "../services/directory.service.js";
+import { LegalOfficerService, TransactionalLegalOfficerService } from "../services/legalOfficerService.js";
+import { LegalOfficerController } from "../controllers/legalofficer.controller.js";
+import { LegalOfficerRepository, LegalOfficerFactory } from "../model/legalofficer.model.js";
 import { VaultTransferRequestController } from '../controllers/vaulttransferrequest.controller.js';
 import { VaultTransferRequestFactory, VaultTransferRequestRepository } from '../model/vaulttransferrequest.model.js';
 import { LoFileFactory, LoFileRepository } from "../model/lofile.model.js";
@@ -96,7 +98,10 @@ container.bind(CollectionFactory).toSelf()
 container.bind(LogionNodeCollectionService).toSelf();
 container.bind(NotificationService).toSelf()
 container.bind(MailService).toSelf()
-container.bind(DirectoryService).toSelf()
+container.bind(LegalOfficerService).toService(TransactionalLegalOfficerService);
+container.bind(TransactionalLegalOfficerService).toSelf();
+container.bind(LegalOfficerFactory).toSelf();
+container.bind(LegalOfficerRepository).toSelf();
 container.bind(VaultTransferRequestRepository).toSelf();
 container.bind(VaultTransferRequestFactory).toSelf();
 container.bind(LoFileFactory).toSelf();
@@ -177,5 +182,6 @@ container.bind(TokensRecordController).toSelf().inTransientScope();
 container.bind(WorkloadController).toSelf().inTransientScope();
 container.bind(SecretRecoveryController).toSelf().inTransientScope();
 container.bind(RecoveryController).toSelf().inTransientScope();
+container.bind(LegalOfficerController).toSelf().inTransientScope();
 
 export { container as AppContainer };

--- a/src/logion/controllers/account_recovery.controller.ts
+++ b/src/logion/controllers/account_recovery.controller.ts
@@ -315,7 +315,6 @@ export class AccountRecoveryController extends ApiController {
         Promise<{ legalOfficerEMail: string, userEmail: string | undefined, data: LocalsObject }> {
 
         const legalOfficer = await this.directoryService.get(request.legalOfficerAddress)
-        const otherLegalOfficer = await this.directoryService.get(request.otherLegalOfficerAddress)
         const { userIdentity, userPostalAddress } = userPrivateData ? userPrivateData : await this.locRequestAdapter.getUserPrivateData(request.requesterIdentityLocId)
         return {
             legalOfficerEMail: legalOfficer.userIdentity.email,
@@ -323,7 +322,6 @@ export class AccountRecoveryController extends ApiController {
             data: {
                 recovery: { ...request, decision },
                 legalOfficer,
-                otherLegalOfficer,
                 walletUser: userIdentity,
                 walletUserPostalAddress: userPostalAddress
             }

--- a/src/logion/controllers/account_recovery.controller.ts
+++ b/src/logion/controllers/account_recovery.controller.ts
@@ -25,7 +25,7 @@ import {
 } from '../model/account_recovery.model.js';
 import { components } from './components.js';
 import { NotificationService, Template, NotificationRecipient } from "../services/notification.service.js";
-import { DirectoryService } from "../services/directory.service.js";
+import { LegalOfficerService } from "../services/legalOfficerService.js";
 import { AccountRecoveryRequestService } from '../services/accountrecoveryrequest.service.js';
 import { LocalsObject } from 'pug';
 import { LocRequestAdapter, UserPrivateData } from "./adapters/locrequestadapter.js";
@@ -91,7 +91,7 @@ export class AccountRecoveryController extends ApiController {
         private accountRecoveryRequestFactory: AccountRecoveryRequestFactory,
         private authenticationService: AuthenticationService,
         private notificationService: NotificationService,
-        private directoryService: DirectoryService,
+        private directoryService: LegalOfficerService,
         private accountRecoveryRequestService: AccountRecoveryRequestService,
         private locRequestAdapter: LocRequestAdapter,
         private locRequestRepository: LocRequestRepository,

--- a/src/logion/controllers/account_recovery.controller.ts
+++ b/src/logion/controllers/account_recovery.controller.ts
@@ -91,7 +91,7 @@ export class AccountRecoveryController extends ApiController {
         private accountRecoveryRequestFactory: AccountRecoveryRequestFactory,
         private authenticationService: AuthenticationService,
         private notificationService: NotificationService,
-        private directoryService: LegalOfficerService,
+        private legalOfficerService: LegalOfficerService,
         private accountRecoveryRequestService: AccountRecoveryRequestService,
         private locRequestAdapter: LocRequestAdapter,
         private locRequestRepository: LocRequestRepository,
@@ -114,7 +114,7 @@ export class AccountRecoveryController extends ApiController {
     @HttpPost('')
     async createRequest(body: CreateAccountRecoveryRequestView): Promise<AccountRecoveryRequestView> {
         const requester = await this.authenticationService.authenticatedUser(this.request);
-        const legalOfficerAddress = await this.directoryService.requireLegalOfficerAddressOnNode(body.legalOfficerAddress);
+        const legalOfficerAddress = await this.legalOfficerService.requireLegalOfficerAddressOnNode(body.legalOfficerAddress);
         const requesterIdentityLoc = requireDefined(body.requesterIdentityLoc);
         const request = await this.accountRecoveryRequestFactory.newAccountRecoveryRequest({
             id: uuid(),
@@ -314,7 +314,7 @@ export class AccountRecoveryController extends ApiController {
     private async getNotificationInfo(request: AccountRecoveryRequestDescription, userPrivateData?: UserPrivateData, decision?: LegalOfficerDecisionDescription):
         Promise<{ legalOfficerEMail: string, userEmail: string | undefined, data: LocalsObject }> {
 
-        const legalOfficer = await this.directoryService.get(request.legalOfficerAddress)
+        const legalOfficer = await this.legalOfficerService.get(request.legalOfficerAddress)
         const { userIdentity, userPostalAddress } = userPrivateData ? userPrivateData : await this.locRequestAdapter.getUserPrivateData(request.requesterIdentityLocId)
         return {
             legalOfficerEMail: legalOfficer.userIdentity.email,

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -1086,6 +1086,40 @@ export interface components {
       /** @description The ID of the Secret Recovery */
       id?: string;
     };
+    /**
+     * FetchLegalOfficersView
+     * @description The fetched Legal Officers
+     */
+    FetchLegalOfficersView: {
+      /** @description All the legal officers */
+      legalOfficers?: components["schemas"]["LegalOfficerView"][];
+    };
+    /**
+     * LegalOfficerView
+     * @description The Legal Officer
+     */
+    LegalOfficerView: {
+      /** @description The SS58 address of the legal officer */
+      address?: string;
+      userIdentity?: components["schemas"]["UserIdentityView"];
+      postalAddress?: components["schemas"]["LegalOfficerPostalAddressView"];
+      /** @description Any additional public info */
+      additionalDetails?: string;
+    };
+    /**
+     * CreateOrUpdateLegalOfficerView
+     * @description The Legal Officer info to created or updated
+     */
+    CreateOrUpdateLegalOfficerView: {
+      userIdentity?: components["schemas"]["UserIdentityView"];
+      postalAddress?: components["schemas"]["LegalOfficerPostalAddressView"];
+      /** @description Any additional public info */
+      additionalDetails?: string;
+    };
+    LegalOfficerPostalAddressView: {
+      /** @description The company of the Legal Officer */
+      company?: string;
+    } & components["schemas"]["PostalAddressView"];
   };
   responses: never;
   parameters: never;

--- a/src/logion/controllers/legalofficer.controller.ts
+++ b/src/logion/controllers/legalofficer.controller.ts
@@ -9,7 +9,7 @@ import {
     LegalOfficerFactory,
 } from "../model/legalofficer.model.js";
 import { ValidAccountId } from "@logion/node-api";
-import { DirectoryService } from "../services/directory.service.js";
+import { LegalOfficerService } from "../services/legalOfficerService.js";
 
 export function fillInSpec(spec: OpenAPIV3.Document): void {
     const tagName = 'Legal Officers';
@@ -36,7 +36,7 @@ export class LegalOfficerController extends ApiController {
         private legalOfficerRepository: LegalOfficerRepository,
         private legalOfficerFactory: LegalOfficerFactory,
         private authenticationService: AuthenticationService,
-        private directoryService: DirectoryService,
+        private directoryService: LegalOfficerService,
         ) {
         super();
     }

--- a/src/logion/controllers/legalofficer.controller.ts
+++ b/src/logion/controllers/legalofficer.controller.ts
@@ -36,7 +36,7 @@ export class LegalOfficerController extends ApiController {
         private legalOfficerRepository: LegalOfficerRepository,
         private legalOfficerFactory: LegalOfficerFactory,
         private authenticationService: AuthenticationService,
-        private directoryService: LegalOfficerService,
+        private legalOfficerService: LegalOfficerService,
         ) {
         super();
     }
@@ -140,7 +140,7 @@ export class LegalOfficerController extends ApiController {
             additionalDetails: createOrUpdate.additionalDetails || "",
         }
         const legalOfficer = this.legalOfficerFactory.newLegalOfficer(description);
-        await this.directoryService.createOrUpdateLegalOfficer(legalOfficer);
+        await this.legalOfficerService.createOrUpdateLegalOfficer(legalOfficer);
 
         return this.toView(legalOfficer.getDescription());
     }

--- a/src/logion/controllers/legalofficer.controller.ts
+++ b/src/logion/controllers/legalofficer.controller.ts
@@ -1,0 +1,147 @@
+import { addTag, setControllerTag, getDefaultResponses, setPathParameters, getRequestBody, AuthenticationService, requireDefined } from "@logion/rest-api-core";
+import { OpenAPIV3 } from "openapi-types";
+import { injectable } from "inversify";
+import { Controller, ApiController, HttpGet, Async, HttpPut } from "dinoloop";
+import { components } from "./components.js";
+import {
+    LegalOfficerRepository,
+    LegalOfficerDescription,
+    LegalOfficerFactory,
+} from "../model/legalofficer.model.js";
+import { ValidAccountId } from "@logion/node-api";
+import { DirectoryService } from "../services/directory.service.js";
+
+export function fillInSpec(spec: OpenAPIV3.Document): void {
+    const tagName = 'Legal Officers';
+    addTag(spec, {
+        name: tagName,
+        description: "Retrieval and Management of Legal Officers details"
+    });
+    setControllerTag(spec, /^\/api\/legal-officer.*/, tagName);
+
+    LegalOfficerController.fetchLegalOfficers(spec);
+    LegalOfficerController.getLegalOfficer(spec);
+    LegalOfficerController.createOrUpdateLegalOfficer(spec);
+}
+
+type LegalOfficerView = components["schemas"]["LegalOfficerView"]
+type FetchLegalOfficersView = components["schemas"]["FetchLegalOfficersView"]
+type CreateOrUpdateLegalOfficerView = components["schemas"]["CreateOrUpdateLegalOfficerView"]
+
+@injectable()
+@Controller('/legal-officer')
+export class LegalOfficerController extends ApiController {
+
+    constructor(
+        private legalOfficerRepository: LegalOfficerRepository,
+        private legalOfficerFactory: LegalOfficerFactory,
+        private authenticationService: AuthenticationService,
+        private directoryService: DirectoryService,
+        ) {
+        super();
+    }
+
+    static fetchLegalOfficers(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/legal-officer"].get!;
+        operationObject.summary = "Gets the list of all legal officers";
+        operationObject.description = "No authentication required.";
+        operationObject.responses = getDefaultResponses("FetchLegalOfficersView");
+    }
+
+    @HttpGet('')
+    @Async()
+    async fetchLegalOfficers(): Promise<FetchLegalOfficersView> {
+        const legalOfficers = await this.legalOfficerRepository.findAll();
+        return { legalOfficers: legalOfficers.map(legalOfficer => legalOfficer.getDescription()).map(this.toView) }
+    }
+
+    static getLegalOfficer(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/legal-officer/{address}"].get!;
+        operationObject.summary = "Gets the details of one legal officer";
+        operationObject.description = "No authentication required.";
+        operationObject.responses = getDefaultResponses("LegalOfficerView");
+        setPathParameters(operationObject, {
+            address: "The Polkadot address of the expected Legal Officer"
+        })
+    }
+
+    @HttpGet('/:address')
+    @Async()
+    async getLegalOfficer(address: string): Promise<LegalOfficerView> {
+        const account = ValidAccountId.polkadot(address);
+        const legalOfficer = await this.legalOfficerRepository.findByAccount(account);
+        if (legalOfficer) {
+            return this.toView(legalOfficer.getDescription());
+        } else {
+            throw new Error("No legal officer with given address");
+        }
+    }
+
+    private toView(description: LegalOfficerDescription): LegalOfficerView {
+        const userIdentity = description.userIdentity;
+        const postalAddress = description.postalAddress;
+        return {
+            address: description.account.address,
+            userIdentity: {
+                firstName: userIdentity.firstName,
+                lastName: userIdentity.lastName,
+                email: userIdentity.email,
+                phoneNumber: userIdentity.phoneNumber,
+            },
+            postalAddress: {
+                company: postalAddress.company,
+                line1: postalAddress.line1,
+                line2: postalAddress.line2,
+                postalCode: postalAddress.postalCode,
+                city: postalAddress.city,
+                country: postalAddress.country,
+            },
+            additionalDetails: description.additionalDetails,
+        }
+    }
+
+    static createOrUpdateLegalOfficer(spec: OpenAPIV3.Document) {
+        const operationObject = spec.paths["/api/legal-officer"].put!;
+        operationObject.summary = "Creates or updates the details of a legal officer";
+        operationObject.description = ".";
+        operationObject.requestBody = getRequestBody({
+            description: "Legal Officer details to be created/updated",
+            view: "CreateOrUpdateLegalOfficerView"
+        })
+        operationObject.responses = getDefaultResponses("LegalOfficerView");
+        setPathParameters(operationObject, {
+            address: "The Polkadot address of the expected Legal Officer"
+        })
+    }
+
+    @HttpPut('')
+    @Async()
+    async createOrUpdateLegalOfficer(createOrUpdate: CreateOrUpdateLegalOfficerView): Promise<LegalOfficerView> {
+        const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
+        const account = (await authenticatedUser.requireLegalOfficerOnNode()).validAccountId;
+        const userIdentity = requireDefined(createOrUpdate.userIdentity);
+        const postalAddress = requireDefined(createOrUpdate.postalAddress);
+        const description: LegalOfficerDescription = {
+            account,
+            userIdentity: {
+                firstName: userIdentity.firstName || "",
+                lastName: userIdentity.lastName || "",
+                email: userIdentity.email || "",
+                phoneNumber: userIdentity.phoneNumber || "",
+            },
+            postalAddress: {
+                company: postalAddress.company || "",
+                line1: postalAddress.line1 || "",
+                line2: postalAddress.line2 || "",
+                postalCode: postalAddress.postalCode || "",
+                city: postalAddress.city || "",
+                country: postalAddress.country || "",
+            },
+            additionalDetails: createOrUpdate.additionalDetails || "",
+        }
+        const legalOfficer = this.legalOfficerFactory.newLegalOfficer(description);
+        await this.directoryService.createOrUpdateLegalOfficer(legalOfficer);
+
+        return this.toView(legalOfficer.getDescription());
+    }
+}

--- a/src/logion/controllers/legalofficer.controller.ts
+++ b/src/logion/controllers/legalofficer.controller.ts
@@ -1,4 +1,13 @@
-import { addTag, setControllerTag, getDefaultResponses, setPathParameters, getRequestBody, AuthenticationService, requireDefined } from "@logion/rest-api-core";
+import {
+    addTag,
+    setControllerTag,
+    getDefaultResponses,
+    setPathParameters,
+    getRequestBody,
+    AuthenticationService,
+    requireDefined,
+    badRequest
+} from "@logion/rest-api-core";
 import { OpenAPIV3 } from "openapi-types";
 import { injectable } from "inversify";
 import { Controller, ApiController, HttpGet, Async, HttpPut } from "dinoloop";
@@ -43,7 +52,7 @@ export class LegalOfficerController extends ApiController {
 
     static fetchLegalOfficers(spec: OpenAPIV3.Document) {
         const operationObject = spec.paths["/api/legal-officer"].get!;
-        operationObject.summary = "Gets the list of all legal officers";
+        operationObject.summary = "Gets the list of all legal officers hosted on this node";
         operationObject.description = "No authentication required.";
         operationObject.responses = getDefaultResponses("FetchLegalOfficersView");
     }
@@ -73,7 +82,7 @@ export class LegalOfficerController extends ApiController {
         if (legalOfficer) {
             return this.toView(legalOfficer.getDescription());
         } else {
-            throw new Error("No legal officer with given address");
+            throw badRequest("No legal officer with given address");
         }
     }
 
@@ -103,7 +112,7 @@ export class LegalOfficerController extends ApiController {
     static createOrUpdateLegalOfficer(spec: OpenAPIV3.Document) {
         const operationObject = spec.paths["/api/legal-officer"].put!;
         operationObject.summary = "Creates or updates the details of a legal officer";
-        operationObject.description = ".";
+        operationObject.description = "The authenticated user must be Legal Officer hosted on this node";
         operationObject.requestBody = getRequestBody({
             description: "Legal Officer details to be created/updated",
             view: "CreateOrUpdateLegalOfficerView"

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -140,7 +140,7 @@ export class LocRequestController extends ApiController {
         private collectionRepository: CollectionRepository,
         private fileStorageService: FileStorageService,
         private notificationService: NotificationService,
-        private directoryService: LegalOfficerService,
+        private legalOfficerService: LegalOfficerService,
         private locRequestAdapter: LocRequestAdapter,
         private locRequestService: LocRequestService,
         private locAuthorizationService: LocAuthorizationService,
@@ -164,7 +164,7 @@ export class LocRequestController extends ApiController {
     @Async()
     async createLocRequest(createLocRequestView: CreateLocRequestView): Promise<LocRequestView> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
-        const ownerAddress = await this.directoryService.requireLegalOfficerAddressOnNode(createLocRequestView.ownerAddress);
+        const ownerAddress = await this.legalOfficerService.requireLegalOfficerAddressOnNode(createLocRequestView.ownerAddress);
         const locType = requireDefined(createLocRequestView.locType);
         const requesterAddress = !authenticatedUser.validAccountId.equals(ownerAddress) ?
             authenticatedUser.validAccountId :
@@ -276,7 +276,7 @@ export class LocRequestController extends ApiController {
     @Async()
     async createOpenLoc(openLocView: OpenLocView): Promise<LocRequestView> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
-        const ownerAddress = await this.directoryService.requireLegalOfficerAddressOnNode(openLocView.ownerAddress);
+        const ownerAddress = await this.legalOfficerService.requireLegalOfficerAddressOnNode(openLocView.ownerAddress);
         const locType = requireDefined(openLocView.locType);
         const requesterAddress = authenticatedUser.validAccountId;
         const requesterIdentityLoc = await this.locRequestRepository.getValidPolkadotIdentityLoc(requesterAddress, ownerAddress);
@@ -1555,7 +1555,7 @@ export class LocRequestController extends ApiController {
     private async getNotificationInfo(loc: LocRequestDescription, userIdentity: UserIdentity, decision?: LocRequestDecision):
         Promise<{ legalOfficerEMail: string, data: LocalsObject }> {
 
-        const legalOfficer = await this.directoryService.get(loc.ownerAddress);
+        const legalOfficer = await this.legalOfficerService.get(loc.ownerAddress);
         return {
             legalOfficerEMail: legalOfficer.userIdentity.email,
             data: {

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -33,7 +33,7 @@ import { UserIdentity } from "../model/useridentity.js";
 import { FileStorageService } from "../services/file.storage.service.js";
 import { ForbiddenException } from "dinoloop/modules/builtin/exceptions/exceptions.js";
 import { NotificationService, Template, NotificationRecipient } from "../services/notification.service.js";
-import { DirectoryService } from "../services/directory.service.js";
+import { LegalOfficerService } from "../services/legalOfficerService.js";
 import { CollectionRepository } from "../model/collection.model.js";
 import { getUploadedFile } from "./fileupload.js";
 import { PostalAddress } from "../model/postaladdress.js";
@@ -140,7 +140,7 @@ export class LocRequestController extends ApiController {
         private collectionRepository: CollectionRepository,
         private fileStorageService: FileStorageService,
         private notificationService: NotificationService,
-        private directoryService: DirectoryService,
+        private directoryService: LegalOfficerService,
         private locRequestAdapter: LocRequestAdapter,
         private locRequestService: LocRequestService,
         private locAuthorizationService: LocAuthorizationService,

--- a/src/logion/controllers/secret_recovery.controller.ts
+++ b/src/logion/controllers/secret_recovery.controller.ts
@@ -62,7 +62,7 @@ export class SecretRecoveryController extends ApiController {
         private secretRecoveryRequestService: SecretRecoveryRequestService,
         private secretRecoveryRequestRepository: SecretRecoveryRequestRepository,
         private locRequestRepository: LocRequestRepository,
-        private directoryService: LegalOfficerService,
+        private legalOfficerService: LegalOfficerService,
         private notificationService: NotificationService,
         private authenticationService: AuthenticationService,
     ) {
@@ -142,7 +142,7 @@ export class SecretRecoveryController extends ApiController {
     private async getNotificationInfo(secretRecoveryRequest: SecretRecoveryRequestDescription, legalOfficerAccount: ValidAccountId, userPrivateData: UserPrivateData, decision?: LegalOfficerDecisionDescription):
         Promise<{ legalOfficerEMail: string, userEmail: string | undefined, data: LocalsObject }> {
 
-        const legalOfficer = await this.directoryService.get(legalOfficerAccount)
+        const legalOfficer = await this.legalOfficerService.get(legalOfficerAccount)
         const { userIdentity, userPostalAddress } = userPrivateData;
         return {
             legalOfficerEMail: legalOfficer.userIdentity.email,

--- a/src/logion/controllers/secret_recovery.controller.ts
+++ b/src/logion/controllers/secret_recovery.controller.ts
@@ -22,7 +22,7 @@ import moment from "moment";
 import { NotificationRecipient, Template, NotificationService } from "../services/notification.service.js";
 import { UserPrivateData } from "./adapters/locrequestadapter.js";
 import { LocalsObject } from "pug";
-import { DirectoryService } from "../services/directory.service.js";
+import { LegalOfficerService } from "../services/legalOfficerService.js";
 import { UUID, ValidAccountId } from "@logion/node-api";
 import { LegalOfficerDecisionDescription } from "../model/decision.js";
 import { EMPTY_POSTAL_ADDRESS } from "../model/postaladdress.js";
@@ -62,7 +62,7 @@ export class SecretRecoveryController extends ApiController {
         private secretRecoveryRequestService: SecretRecoveryRequestService,
         private secretRecoveryRequestRepository: SecretRecoveryRequestRepository,
         private locRequestRepository: LocRequestRepository,
-        private directoryService: DirectoryService,
+        private directoryService: LegalOfficerService,
         private notificationService: NotificationService,
         private authenticationService: AuthenticationService,
     ) {

--- a/src/logion/controllers/vaulttransferrequest.controller.ts
+++ b/src/logion/controllers/vaulttransferrequest.controller.ts
@@ -71,7 +71,7 @@ export class VaultTransferRequestController extends ApiController {
         private vaultTransferRequestFactory: VaultTransferRequestFactory,
         private authenticationService: AuthenticationService,
         private notificationService: NotificationService,
-        private directoryService: LegalOfficerService,
+        private legalOfficerService: LegalOfficerService,
         private accountRecoveryRepository: AccountRecoveryRepository,
         private vaultTransferRequestService: VaultTransferRequestService,
         private polkadotService: PolkadotService,
@@ -96,7 +96,7 @@ export class VaultTransferRequestController extends ApiController {
     async createVaultTransferRequest(body: CreateVaultTransferRequestView): Promise<VaultTransferRequestView> {
         const origin = ValidAccountId.polkadot(requireDefined(body.origin, () => badRequest("Missing origin")));
         const destination = ValidAccountId.polkadot(requireDefined(body.destination, () => badRequest("Missing destination")));
-        const legalOfficerAddress = await this.directoryService.requireLegalOfficerAddressOnNode(body.legalOfficerAddress);
+        const legalOfficerAddress = await this.legalOfficerService.requireLegalOfficerAddressOnNode(body.legalOfficerAddress);
         const userData = await this.userAuthorizedAndProtected(origin, legalOfficerAddress);
 
         const request = this.vaultTransferRequestFactory.newVaultTransferRequest({
@@ -204,7 +204,7 @@ export class VaultTransferRequestController extends ApiController {
         decision?: VaultTransferRequestDecision
     ): Promise<{ legalOfficerEmail: string, userEmail: string | undefined, data: LocalsObject }> {
 
-        const legalOfficer = await this.directoryService.get(vaultTransfer.legalOfficerAddress);
+        const legalOfficer = await this.legalOfficerService.get(vaultTransfer.legalOfficerAddress);
         const { userIdentity, userPostalAddress } = userPrivateData;
         return {
             legalOfficerEmail: legalOfficer.userIdentity.email,

--- a/src/logion/controllers/vaulttransferrequest.controller.ts
+++ b/src/logion/controllers/vaulttransferrequest.controller.ts
@@ -25,7 +25,7 @@ import {
 } from '../model/vaulttransferrequest.model.js';
 import { components } from './components.js';
 import { NotificationService } from "../services/notification.service.js";
-import { DirectoryService } from "../services/directory.service.js";
+import { LegalOfficerService } from "../services/legalOfficerService.js";
 import { AccountRecoveryRequestDescription, AccountRecoveryRepository } from '../model/account_recovery.model.js';
 import { VaultTransferRequestService } from '../services/vaulttransferrequest.service.js';
 import { LocalsObject } from 'pug';
@@ -71,7 +71,7 @@ export class VaultTransferRequestController extends ApiController {
         private vaultTransferRequestFactory: VaultTransferRequestFactory,
         private authenticationService: AuthenticationService,
         private notificationService: NotificationService,
-        private directoryService: DirectoryService,
+        private directoryService: LegalOfficerService,
         private accountRecoveryRepository: AccountRecoveryRepository,
         private vaultTransferRequestService: VaultTransferRequestService,
         private polkadotService: PolkadotService,

--- a/src/logion/migration/1718188396630-AddLegalOfficers.ts
+++ b/src/logion/migration/1718188396630-AddLegalOfficers.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddLegalOfficers1718188396630 implements MigrationInterface {
+    name = 'AddLegalOfficers1718188396630'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "legal_officer" ("address" character varying NOT NULL, "first_name" character varying(255) NOT NULL, "last_name" character varying(255) NOT NULL, "email" character varying(255) NOT NULL, "phone_number" character varying(255) NOT NULL, "company" character varying(255), "line1" character varying(255) NOT NULL, "line2" character varying(255), "postal_code" character varying(255) NOT NULL, "city" character varying(255) NOT NULL, "country" character varying(255) NOT NULL, "additional_details" character varying(255), CONSTRAINT "PK_legal_officer" PRIMARY KEY ("address"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "legal_officer"`);
+    }
+
+}

--- a/src/logion/model/legalofficer.model.ts
+++ b/src/logion/model/legalofficer.model.ts
@@ -1,21 +1,136 @@
 import { PostalAddress } from "./postaladdress.js";
 import { UserIdentity } from "./useridentity.js";
 import { ValidAccountId } from "@logion/node-api";
+import { appDataSource } from "@logion/rest-api-core";
+import { Entity, Column, PrimaryColumn, Repository } from "typeorm";
+import { injectable } from "inversify";
+import { DB_SS58_PREFIX } from "./supportedaccountid.model.js";
 
 interface LegalOfficerPostalAddress extends PostalAddress {
     readonly company: string
-}
-
-export interface LegalOfficer {
-    readonly address: string;
-    readonly userIdentity: UserIdentity
-    readonly postalAddress: LegalOfficerPostalAddress
-    readonly additionalDetails: string
-    readonly node: string
 }
 
 export interface LegalOfficerSettingId {
     id: string,
     legalOfficer: ValidAccountId,
 }
+
+@Entity("legal_officer")
+export class LegalOfficerAggregateRoot {
+
+    @PrimaryColumn()
+    address?: string;
+
+    @Column({ length: 255, name: "first_name" })
+    firstName?: string;
+
+    @Column({ length: 255, name: "last_name" })
+    lastName?: string;
+
+    @Column({ length: 255 })
+    email?: string;
+
+    @Column({ length: 255, name: "phone_number" })
+    phoneNumber?: string;
+
+    @Column({ length: 255, nullable: true })
+    company?: string;
+
+    @Column({ length: 255 })
+    line1?: string;
+
+    @Column({ length: 255, nullable: true })
+    line2?: string;
+
+    @Column({ length: 255, name: "postal_code" })
+    postalCode?: string;
+
+    @Column({ length: 255 })
+    city?: string;
+
+    @Column({ length: 255 })
+    country?: string;
+
+    @Column({ length: 255, name: "additional_details", nullable: true })
+    additionalDetails?: string;
+
+    getDescription(): LegalOfficerDescription {
+        return {
+            account: ValidAccountId.polkadot(this.address!),
+            userIdentity: {
+                firstName: this.firstName || "",
+                lastName: this.lastName || "",
+                email: this.email || "",
+                phoneNumber: this.phoneNumber || "",
+            },
+            postalAddress: {
+                company: this.company || "",
+                line1: this.line1 || "",
+                line2: this.line2 || "",
+                postalCode: this.postalCode || "",
+                city: this.city || "",
+                country: this.country || "",
+            },
+            additionalDetails: this.additionalDetails || "",
+        }
+    }
+}
+
+export interface LegalOfficerDescription {
+    readonly account: ValidAccountId;
+    readonly userIdentity: UserIdentity;
+    readonly postalAddress: LegalOfficerPostalAddress;
+    readonly additionalDetails: string;
+}
+
+@injectable()
+export class LegalOfficerFactory {
+
+    newLegalOfficer(description: LegalOfficerDescription): LegalOfficerAggregateRoot {
+        const legalOfficer = new LegalOfficerAggregateRoot();
+        legalOfficer.address = description.account.getAddress(DB_SS58_PREFIX);
+
+        const userIdentity = description.userIdentity;
+        legalOfficer.firstName = userIdentity.firstName;
+        legalOfficer.lastName = userIdentity.lastName;
+        legalOfficer.email = userIdentity.email;
+        legalOfficer.phoneNumber = userIdentity.phoneNumber;
+
+        const postalAddress = description.postalAddress
+        legalOfficer.company = postalAddress.company;
+        legalOfficer.line1 = postalAddress.line1;
+        legalOfficer.line2 = postalAddress.line2;
+        legalOfficer.postalCode = postalAddress.postalCode;
+        legalOfficer.city = postalAddress.city;
+        legalOfficer.country = postalAddress.country;
+
+        legalOfficer.additionalDetails = description.additionalDetails;
+
+        return legalOfficer;
+    }
+}
+
+@injectable()
+export class LegalOfficerRepository {
+
+    constructor() {
+        this.repository = appDataSource.getRepository(LegalOfficerAggregateRoot);
+    }
+
+    readonly repository: Repository<LegalOfficerAggregateRoot>
+
+    public findByAccount(address: ValidAccountId): Promise<LegalOfficerAggregateRoot | null> {
+        return this.repository.findOneBy({ address: address.getAddress(DB_SS58_PREFIX) });
+    }
+
+    public findAll(): Promise<LegalOfficerAggregateRoot []> {
+        return this.repository.find();
+    }
+
+    public async save(root: LegalOfficerAggregateRoot): Promise<void> {
+        await this.repository.save(root);
+    }
+
+}
+
 

--- a/src/logion/services/accountrecoverysynchronization.service.ts
+++ b/src/logion/services/accountrecoverysynchronization.service.ts
@@ -5,7 +5,7 @@ import { AccountRecoveryRepository, FetchAccountRecoveryRequestsSpecification } 
 import { Adapters, ValidAccountId } from '@logion/node-api';
 import { JsonExtrinsic, toString } from "./types/responses/Extrinsic.js";
 import { AccountRecoveryRequestService as AccountRecoveryService } from './accountrecoveryrequest.service.js';
-import { DirectoryService } from "./directory.service.js";
+import { LegalOfficerService } from "./legalOfficerService.js";
 
 const { logger } = Log;
 
@@ -15,7 +15,7 @@ export class AccountRecoverySynchronizer {
     constructor(
         private accountRecoveryRepository: AccountRecoveryRepository,
         private accountRecoveryService: AccountRecoveryService,
-        private directoryService: DirectoryService,
+        private directoryService: LegalOfficerService,
     ) {
     }
 

--- a/src/logion/services/accountrecoverysynchronization.service.ts
+++ b/src/logion/services/accountrecoverysynchronization.service.ts
@@ -15,7 +15,7 @@ export class AccountRecoverySynchronizer {
     constructor(
         private accountRecoveryRepository: AccountRecoveryRepository,
         private accountRecoveryService: AccountRecoveryService,
-        private directoryService: LegalOfficerService,
+        private legalOfficerService: LegalOfficerService,
     ) {
     }
 
@@ -30,7 +30,7 @@ export class AccountRecoverySynchronizer {
                 const legalOfficerAddresses = Adapters.asArray(extrinsic.call.args['legal_officers']).map(address => Adapters.asString(address));
                 for (const legalOfficerAddress of legalOfficerAddresses) {
                     const legalOfficer = ValidAccountId.polkadot(legalOfficerAddress);
-                    if (await this.directoryService.isLegalOfficerAddressOnNode(legalOfficer)) {
+                    if (await this.legalOfficerService.isLegalOfficerAddressOnNode(legalOfficer)) {
                         const signer = extrinsic.signer!;
                         const requests = await this.accountRecoveryRepository.findBy(new FetchAccountRecoveryRequestsSpecification({
                             expectedRequesterAddress: ValidAccountId.polkadot(signer),

--- a/src/logion/services/legalOfficerService.ts
+++ b/src/logion/services/legalOfficerService.ts
@@ -8,7 +8,7 @@ import { badRequest, AuthenticationSystemFactory, requireDefined, DefaultTransac
 import { AuthorityService } from "@logion/authenticator";
 import { ValidAccountId } from "@logion/node-api";
 
-export abstract class DirectoryService {
+export abstract class LegalOfficerService {
 
     private readonly authorityService: Promise<AuthorityService>;
 
@@ -51,7 +51,7 @@ export abstract class DirectoryService {
 }
 
 @injectable()
-export class TransactionalDirectoryService extends DirectoryService {
+export class TransactionalLegalOfficerService extends LegalOfficerService {
 
     constructor(
         authenticationSystemFactory: AuthenticationSystemFactory,
@@ -67,7 +67,7 @@ export class TransactionalDirectoryService extends DirectoryService {
 }
 
 @injectable()
-export class NonTransactionalDirectoryService extends DirectoryService {
+export class NonTransactionalLegalOfficerService extends LegalOfficerService {
 
     constructor(
         authenticationSystemFactory: AuthenticationSystemFactory,

--- a/src/logion/services/locsynchronization.service.ts
+++ b/src/logion/services/locsynchronization.service.ts
@@ -9,7 +9,7 @@ import { LocRequestService } from './locrequest.service.js';
 import { CollectionService } from './collection.service.js';
 import { UserIdentity } from '../model/useridentity.js';
 import { NotificationService } from './notification.service.js';
-import { DirectoryService } from './directory.service.js';
+import { LegalOfficerService } from './legalOfficerService.js';
 import { VerifiedIssuerSelectionService } from './verifiedissuerselection.service.js';
 import { TokensRecordService } from './tokensrecord.service.js';
 import { EMPTY_ITEMS, LocItems } from '../model/loc_items.js';
@@ -24,7 +24,7 @@ export class LocSynchronizer {
         private locRequestService: LocRequestService,
         private collectionService: CollectionService,
         private notificationService: NotificationService,
-        private directoryService: DirectoryService,
+        private directoryService: LegalOfficerService,
         private verifiedIssuerSelectionService: VerifiedIssuerSelectionService,
         private tokensRecordService: TokensRecordService,
     ) {}

--- a/src/logion/services/locsynchronization.service.ts
+++ b/src/logion/services/locsynchronization.service.ts
@@ -24,7 +24,7 @@ export class LocSynchronizer {
         private locRequestService: LocRequestService,
         private collectionService: CollectionService,
         private notificationService: NotificationService,
-        private directoryService: LegalOfficerService,
+        private legalOfficerService: LegalOfficerService,
         private verifiedIssuerSelectionService: VerifiedIssuerSelectionService,
         private tokensRecordService: TokensRecordService,
     ) {}
@@ -226,7 +226,7 @@ export class LocSynchronizer {
     private async notifyIssuerNominatedDismissed(extrinsic: JsonExtrinsic) {
         const nominated = extrinsic.call.method === "nominateIssuer";
         const legalOfficerAddress = ValidAccountId.polkadot(requireDefined(extrinsic.signer));
-        if(await this.directoryService.isLegalOfficerAddressOnNode(legalOfficerAddress)) {
+        if(await this.legalOfficerService.isLegalOfficerAddressOnNode(legalOfficerAddress)) {
             const issuerAccount = ValidAccountId.polkadot(Adapters.asString(extrinsic.call.args["issuer"]));
             const identityLoc = await this.getIssuerIdentityLoc(legalOfficerAddress, issuerAccount);
             logger.info("Handling nomination/dismissal of issuer %s", issuerAccount.address);
@@ -262,7 +262,7 @@ export class LocSynchronizer {
     }) {
         const { legalOfficerAddress, nominated, issuer } = args;
         try {
-            const legalOfficer = await this.directoryService.get(legalOfficerAddress);
+            const legalOfficer = await this.legalOfficerService.get(legalOfficerAddress);
             const data = {
                 legalOfficer,
                 walletUser: issuer,
@@ -279,7 +279,7 @@ export class LocSynchronizer {
 
     private async handleIssuerSelectedUnselected(extrinsic: JsonExtrinsic) {
         const legalOfficerAddress = ValidAccountId.polkadot(requireDefined(extrinsic.signer));
-        if(await this.directoryService.isLegalOfficerAddressOnNode(legalOfficerAddress)) {
+        if(await this.legalOfficerService.isLegalOfficerAddressOnNode(legalOfficerAddress)) {
             const issuerAccount = ValidAccountId.polkadot(Adapters.asString(extrinsic.call.args["issuer"]));
             const identityLoc = await this.getIssuerIdentityLoc(legalOfficerAddress, issuerAccount);
             const selected = extrinsic.call.args["selected"] as boolean;
@@ -305,7 +305,7 @@ export class LocSynchronizer {
     }) {
         const { legalOfficerAddress, selected, locRequest, issuer } = args;
         try {
-            const legalOfficer = await this.directoryService.get(legalOfficerAddress);
+            const legalOfficer = await this.legalOfficerService.get(legalOfficerAddress);
             const data = {
                 legalOfficer,
                 walletUser: issuer,

--- a/test/helpers/addresses.ts
+++ b/test/helpers/addresses.ts
@@ -1,4 +1,5 @@
 import { ValidAccountId } from "@logion/node-api";
+import { LegalOfficerDescription } from "../../src/logion/model/legalofficer.model";
 
 // Note to developers: Addresses are encoded
 // using a different custom prefix: 0 (= Polkadot)
@@ -14,3 +15,60 @@ export const CHARLY = "14Gjs1TD93gnwEBfDMHoCgsuf1s2TVKUP6Z1qKmAZnZ8cW5q";
 export const ALICE_ACCOUNT = ValidAccountId.polkadot(ALICE);
 export const BOB_ACCOUNT = ValidAccountId.polkadot(BOB);
 export const CHARLY_ACCOUNT = ValidAccountId.polkadot(CHARLY);
+
+export const LEGAL_OFFICERS: LegalOfficerDescription[] = [
+    {
+        account: ALICE_ACCOUNT,
+        userIdentity: {
+            firstName: "Alice",
+            lastName: "Alice",
+            email: "alice@logion.network",
+            phoneNumber: "+32 498 00 00 00",
+        },
+        postalAddress: {
+            company: "MODERO",
+            line1: "Huissier de Justice Etterbeek",
+            line2: "Rue Beckers 17",
+            postalCode: "1040",
+            city: "Etterbeek",
+            country: "Belgique"
+        },
+        additionalDetails: "",
+    },
+    {
+        account: BOB_ACCOUNT,
+        userIdentity: {
+            firstName: "Bob",
+            lastName: "Bob",
+            email: "bob@logion.network",
+            phoneNumber: "+33 4 00  00 00 00",
+        },
+        postalAddress: {
+            company: "SELARL ADRASTEE",
+            line1: "Gare des Brotteaux",
+            line2: "14, place Jules Ferry",
+            postalCode: "69006",
+            city: "Lyon",
+            country: "France"
+        },
+        additionalDetails: "",
+    },
+    {
+        account: CHARLY_ACCOUNT,
+        userIdentity: {
+            firstName: "Charlie",
+            lastName: "Charlie",
+            email: "charlie@logion.network",
+            phoneNumber: "+33 2 00 00 00 00",
+        },
+        postalAddress: {
+            company: "AUXILIA CONSEILS 18",
+            line1: "Huissiers de Justice associés",
+            line2: "7 rue Jean Francois Champollion Parc Comitec",
+            postalCode: "18000",
+            city: "Bourges",
+            country: "France"
+        },
+        additionalDetails: "",
+    }
+]

--- a/test/integration/migration/migration.spec.ts
+++ b/test/integration/migration/migration.spec.ts
@@ -3,7 +3,7 @@ const { connect, disconnect, queryRunner, runAllMigrations, revertAllMigrations 
 
 describe('Migration', () => {
 
-    const NUM_OF_TABLES = 24;
+    const NUM_OF_TABLES = 25;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
     beforeEach(async () => {

--- a/test/unit/controllers/account_recovery.controller.spec.ts
+++ b/test/unit/controllers/account_recovery.controller.spec.ts
@@ -15,7 +15,7 @@ import { ALICE, BOB, BOB_ACCOUNT, ALICE_ACCOUNT } from '../../helpers/addresses.
 import { AccountRecoveryController } from '../../../src/logion/controllers/account_recovery.controller.js';
 import { NotificationService, Template } from "../../../src/logion/services/notification.service.js";
 import moment from "moment";
-import { DirectoryService } from "../../../src/logion/services/directory.service.js";
+import { LegalOfficerService } from "../../../src/logion/services/legalOfficerService.js";
 import { notifiedLegalOfficer } from "../services/notification-test-data.js";
 import { UserIdentity } from '../../../src/logion/model/useridentity.js';
 import { PostalAddress } from '../../../src/logion/model/postaladdress.js';
@@ -96,7 +96,7 @@ function mockRecoveryRequestModel(container: Container, addressToRecover: ValidA
     root.setup(instance => instance.requesterIdentityLocId)
         .returns(identityLoc.id)
 
-    
+
     factory.setup(instance => instance.newAccountRecoveryRequest(
         It.Is<NewAccountRecoveryRequestParameters>(params => {
             return params.addressToRecover !== null
@@ -485,14 +485,14 @@ function mockNotificationAndDirectoryService(container: Container) {
         .returns(Promise.resolve())
     container.bind(NotificationService).toConstantValue(notificationService.object())
 
-    const directoryService = new Mock<DirectoryService>();
+    const directoryService = new Mock<LegalOfficerService>();
     directoryService
         .setup(instance => instance.get(It.IsAny<string>()))
         .returns(Promise.resolve(notifiedLegalOfficer(ALICE_ACCOUNT.address)))
     directoryService
         .setup(instance => instance.requireLegalOfficerAddressOnNode(It.IsAny<string>()))
         .returns(Promise.resolve(ALICE_ACCOUNT));
-    container.bind(DirectoryService).toConstantValue(directoryService.object())
+    container.bind(LegalOfficerService).toConstantValue(directoryService.object())
 }
 
 function mockRecoveryRequest(): Mock<AccountRecoveryRequestAggregateRoot> {

--- a/test/unit/controllers/account_recovery.controller.spec.ts
+++ b/test/unit/controllers/account_recovery.controller.spec.ts
@@ -105,7 +105,7 @@ function mockRecoveryRequestModel(container: Container, addressToRecover: ValidA
         })))
         .returns(Promise.resolve(root.object()));
     container.bind(AccountRecoveryRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container);
+    mockNotificationAndLegalOfficerService(container);
 
     container.bind(AccountRecoveryRequestService).toConstantValue(new NonTransactionalAccountRecoveryRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
@@ -253,7 +253,7 @@ function mockModelForFetch(container: Container): void {
 
     const factory = new Mock<AccountRecoveryRequestFactory>();
     container.bind(AccountRecoveryRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container)
+    mockNotificationAndLegalOfficerService(container)
 
     container.bind(AccountRecoveryRequestService).toConstantValue(new NonTransactionalAccountRecoveryRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
@@ -288,7 +288,7 @@ function mockModelForReview(container: Container): void {
 
     const factory = new Mock<AccountRecoveryRequestFactory>();
     container.bind(AccountRecoveryRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container)
+    mockNotificationAndLegalOfficerService(container)
 
     container.bind(AccountRecoveryRequestService).toConstantValue(new NonTransactionalAccountRecoveryRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
@@ -356,7 +356,7 @@ function mockModelForAccept(container: Container, verifies: boolean): void {
 
     const factory = new Mock<AccountRecoveryRequestFactory>();
     container.bind(AccountRecoveryRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container);
+    mockNotificationAndLegalOfficerService(container);
 
     container.bind(AccountRecoveryRequestService).toConstantValue(new NonTransactionalAccountRecoveryRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
@@ -471,28 +471,28 @@ function mockModelForReject(container: Container, verifies: boolean): void {
 
     const factory = new Mock<AccountRecoveryRequestFactory>();
     container.bind(AccountRecoveryRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container);
+    mockNotificationAndLegalOfficerService(container);
 
     container.bind(AccountRecoveryRequestService).toConstantValue(new NonTransactionalAccountRecoveryRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());
     container.bind(LocRequestRepository).toConstantValue(mockLocRequestRepository());
 }
 
-function mockNotificationAndDirectoryService(container: Container) {
+function mockNotificationAndLegalOfficerService(container: Container) {
     notificationService = new Mock<NotificationService>();
     notificationService
         .setup(instance => instance.notify(It.IsAny<string>(), It.IsAny<Template>(), It.IsAny<any>()))
         .returns(Promise.resolve())
     container.bind(NotificationService).toConstantValue(notificationService.object())
 
-    const directoryService = new Mock<LegalOfficerService>();
-    directoryService
+    const legalOfficerService = new Mock<LegalOfficerService>();
+    legalOfficerService
         .setup(instance => instance.get(It.IsAny<string>()))
         .returns(Promise.resolve(notifiedLegalOfficer(ALICE_ACCOUNT.address)))
-    directoryService
+    legalOfficerService
         .setup(instance => instance.requireLegalOfficerAddressOnNode(It.IsAny<string>()))
         .returns(Promise.resolve(ALICE_ACCOUNT));
-    container.bind(LegalOfficerService).toConstantValue(directoryService.object())
+    container.bind(LegalOfficerService).toConstantValue(legalOfficerService.object())
 }
 
 function mockRecoveryRequest(): Mock<AccountRecoveryRequestAggregateRoot> {
@@ -537,7 +537,7 @@ function mockModelForUser(container: Container, request: Mock<AccountRecoveryReq
 
     const factory = new Mock<AccountRecoveryRequestFactory>();
     container.bind(AccountRecoveryRequestFactory).toConstantValue(factory.object());
-    mockNotificationAndDirectoryService(container);
+    mockNotificationAndLegalOfficerService(container);
 
     container.bind(AccountRecoveryRequestService).toConstantValue(new NonTransactionalAccountRecoveryRequestService(repository.object()));
     container.bind(LocRequestAdapter).toConstantValue(mockLocRequestAdapter());

--- a/test/unit/controllers/legalofficer.controller.spec.ts
+++ b/test/unit/controllers/legalofficer.controller.spec.ts
@@ -13,7 +13,7 @@ import {
 import { ValidAccountId } from "@logion/node-api";
 import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
 import { LEGAL_OFFICERS } from "../../helpers/addresses.js";
-import { DirectoryService } from "../../../src/logion/services/directory.service.js";
+import { LegalOfficerService } from "../../../src/logion/services/legalOfficerService.js";
 
 const AUTHENTICATED_ADDRESS = LEGAL_OFFICERS[0].account;
 const { setupApp, mockAuthenticationForUserOrLegalOfficer } = TestApp;
@@ -109,8 +109,8 @@ function mockForFetch(container: Container) {
     const factory = new Mock<LegalOfficerFactory>();
     container.bind(LegalOfficerFactory).toConstantValue(factory.object());
 
-    const directoryService = new Mock<DirectoryService>();
-    container.bind(DirectoryService).toConstantValue(directoryService.object());
+    const directoryService = new Mock<LegalOfficerService>();
+    container.bind(LegalOfficerService).toConstantValue(directoryService.object());
 }
 
 function mockForCreateOrUpdate(container: Container) {
@@ -130,8 +130,8 @@ function mockForCreateOrUpdate(container: Container) {
     factory.setup(instance => instance.newLegalOfficer(It.IsAny<LegalOfficerDescription>()))
         .returns(legalOfficer0);
 
-    const directoryService = new Mock<DirectoryService>();
-    container.bind(DirectoryService).toConstantValue(directoryService.object());
+    const directoryService = new Mock<LegalOfficerService>();
+    container.bind(LegalOfficerService).toConstantValue(directoryService.object());
     directoryService.setup(instance => instance.createOrUpdateLegalOfficer(It.IsAny<LegalOfficerAggregateRoot>()))
         .returns(Promise.resolve());
 }

--- a/test/unit/controllers/legalofficer.controller.spec.ts
+++ b/test/unit/controllers/legalofficer.controller.spec.ts
@@ -109,8 +109,8 @@ function mockForFetch(container: Container) {
     const factory = new Mock<LegalOfficerFactory>();
     container.bind(LegalOfficerFactory).toConstantValue(factory.object());
 
-    const directoryService = new Mock<LegalOfficerService>();
-    container.bind(LegalOfficerService).toConstantValue(directoryService.object());
+    const legalOfficerService = new Mock<LegalOfficerService>();
+    container.bind(LegalOfficerService).toConstantValue(legalOfficerService.object());
 }
 
 function mockForCreateOrUpdate(container: Container) {
@@ -130,9 +130,9 @@ function mockForCreateOrUpdate(container: Container) {
     factory.setup(instance => instance.newLegalOfficer(It.IsAny<LegalOfficerDescription>()))
         .returns(legalOfficer0);
 
-    const directoryService = new Mock<LegalOfficerService>();
-    container.bind(LegalOfficerService).toConstantValue(directoryService.object());
-    directoryService.setup(instance => instance.createOrUpdateLegalOfficer(It.IsAny<LegalOfficerAggregateRoot>()))
+    const legalOfficerService = new Mock<LegalOfficerService>();
+    container.bind(LegalOfficerService).toConstantValue(legalOfficerService.object());
+    legalOfficerService.setup(instance => instance.createOrUpdateLegalOfficer(It.IsAny<LegalOfficerAggregateRoot>()))
         .returns(Promise.resolve());
 }
 

--- a/test/unit/controllers/legalofficer.controller.spec.ts
+++ b/test/unit/controllers/legalofficer.controller.spec.ts
@@ -1,0 +1,146 @@
+import { TestApp } from "@logion/rest-api-core";
+import request from "supertest";
+import { Container } from "inversify";
+import { Mock, It } from "moq.ts";
+
+import { LegalOfficerController } from "../../../src/logion/controllers/legalofficer.controller.js";
+import {
+    LegalOfficerRepository,
+    LegalOfficerAggregateRoot,
+    LegalOfficerFactory,
+    LegalOfficerDescription,
+} from "../../../src/logion/model/legalofficer.model.js";
+import { ValidAccountId } from "@logion/node-api";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
+import { LEGAL_OFFICERS } from "../../helpers/addresses.js";
+import { DirectoryService } from "../../../src/logion/services/directory.service.js";
+
+const AUTHENTICATED_ADDRESS = LEGAL_OFFICERS[0].account;
+const { setupApp, mockAuthenticationForUserOrLegalOfficer } = TestApp;
+
+describe("LegalOfficerController", () => {
+
+    it("should fetch all legal officers", async () => {
+
+        const app = setupApp(LegalOfficerController, mockForFetch)
+        await request(app)
+            .get("/api/legal-officer")
+            .expect(200)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.legalOfficers.length).toBe(LEGAL_OFFICERS.length)
+            });
+    });
+
+    it("should fetch one legal officer", async () => {
+        const app = setupApp(LegalOfficerController, mockForFetch)
+        await request(app)
+            .get("/api/legal-officer/vQx5kESPn8dWyX4KxMCKqUyCaWUwtui1isX6PVNcZh2Ghjitr")
+            .expect(200)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.address).toBe("vQx5kESPn8dWyX4KxMCKqUyCaWUwtui1isX6PVNcZh2Ghjitr")
+                const userIdentity = response.body.userIdentity;
+                expect(userIdentity.firstName).toBe("Alice")
+                expect(userIdentity.lastName).toBe("Alice")
+                expect(userIdentity.email).toBe("alice@logion.network")
+                expect(userIdentity.phoneNumber).toBe("+32 498 00 00 00")
+                let postalAddress = response.body.postalAddress;
+                expect(postalAddress.company).toBe("MODERO")
+                expect(postalAddress.line1).toBe("Huissier de Justice Etterbeek")
+                expect(postalAddress.line2).toBe("Rue Beckers 17")
+                expect(postalAddress.postalCode).toBe("1040")
+                expect(postalAddress.city).toBe("Etterbeek")
+                expect(postalAddress.country).toBe("Belgique")
+            });
+    })
+
+    it("creates or updates details for a legal officer", async () => {
+        const payload = { ...LEGAL_OFFICERS[0] }
+        const app = setupApp(LegalOfficerController, mockForCreateOrUpdate, mockAuthenticationForUserOrLegalOfficer(true, AUTHENTICATED_ADDRESS))
+        await request(app)
+            .put("/api/legal-officer")
+            .send(payload)
+            .expect(200)
+            .expect('Content-Type', /application\/json/)
+            .then(response => {
+                expect(response.body.address).toBe(AUTHENTICATED_ADDRESS.address)
+                const userIdentity = response.body.userIdentity;
+                expect(userIdentity.firstName).toBe("Alice")
+                expect(userIdentity.lastName).toBe("Alice")
+                expect(userIdentity.email).toBe("alice@logion.network")
+                expect(userIdentity.phoneNumber).toBe("+32 498 00 00 00")
+                let postalAddress = response.body.postalAddress;
+                expect(postalAddress.company).toBe("MODERO")
+                expect(postalAddress.line1).toBe("Huissier de Justice Etterbeek")
+                expect(postalAddress.line2).toBe("Rue Beckers 17")
+                expect(postalAddress.postalCode).toBe("1040")
+                expect(postalAddress.city).toBe("Etterbeek")
+                expect(postalAddress.country).toBe("Belgique")
+            });
+    })
+
+    it("fails to create or update details for a legal officer", async () => {
+        const payload = { ...LEGAL_OFFICERS[0] }
+        const app = setupApp(LegalOfficerController, mockForCreateOrUpdate, mockAuthenticationForUserOrLegalOfficer(false))
+        await request(app)
+            .put("/api/legal-officer")
+            .send(payload)
+            .expect(401)
+            .expect('Content-Type', /application\/json/);
+    })
+})
+
+function mockForFetch(container: Container) {
+    const repository = new Mock<LegalOfficerRepository>();
+    container.bind(LegalOfficerRepository).toConstantValue(repository.object());
+
+    const legalOfficer0 = mockLegalOfficer(repository, 0);
+    const legalOfficers = [
+        legalOfficer0,
+        mockLegalOfficer(repository, 1),
+        mockLegalOfficer(repository, 2),
+    ];
+    repository.setup(instance => instance.findAll())
+        .returns(Promise.resolve(legalOfficers));
+    repository.setup(instance => instance.findByAccount(It.IsAny<string>()))
+        .returns(Promise.resolve(legalOfficer0));
+
+    const factory = new Mock<LegalOfficerFactory>();
+    container.bind(LegalOfficerFactory).toConstantValue(factory.object());
+
+    const directoryService = new Mock<DirectoryService>();
+    container.bind(DirectoryService).toConstantValue(directoryService.object());
+}
+
+function mockForCreateOrUpdate(container: Container) {
+    const repository = new Mock<LegalOfficerRepository>();
+    container.bind(LegalOfficerRepository).toConstantValue(repository.object());
+    const legalOfficer0 = mockLegalOfficer(repository, 0);
+    const legalOfficers = [
+        legalOfficer0,
+        mockLegalOfficer(repository, 1),
+        mockLegalOfficer(repository, 2),
+    ];
+    repository.setup(instance => instance.findAll())
+        .returns(Promise.resolve(legalOfficers));
+
+    const factory = new Mock<LegalOfficerFactory>();
+    container.bind(LegalOfficerFactory).toConstantValue(factory.object());
+    factory.setup(instance => instance.newLegalOfficer(It.IsAny<LegalOfficerDescription>()))
+        .returns(legalOfficer0);
+
+    const directoryService = new Mock<DirectoryService>();
+    container.bind(DirectoryService).toConstantValue(directoryService.object());
+    directoryService.setup(instance => instance.createOrUpdateLegalOfficer(It.IsAny<LegalOfficerAggregateRoot>()))
+        .returns(Promise.resolve());
+}
+
+function mockLegalOfficer(repository: Mock<LegalOfficerRepository>, idx:number):LegalOfficerAggregateRoot {
+    const legalOfficer = new Mock<LegalOfficerAggregateRoot>();
+    legalOfficer.setup(instance => instance.getDescription()).returns(LEGAL_OFFICERS[idx]);
+    legalOfficer.setup(instance => instance.address).returns(LEGAL_OFFICERS[idx].account.getAddress(DB_SS58_PREFIX));
+    repository.setup(instance => instance.findByAccount(It.Is<ValidAccountId>(account => account.equals(LEGAL_OFFICERS[idx].account))))
+        .returns(Promise.resolve(legalOfficer.object()));
+    return legalOfficer.object();
+}

--- a/test/unit/controllers/locrequest.controller.shared.ts
+++ b/test/unit/controllers/locrequest.controller.shared.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../src/logion/model/locrequest.model.js";
 import { FileStorageService } from "../../../src/logion/services/file.storage.service.js";
 import { NotificationService, Template } from "../../../src/logion/services/notification.service.js";
-import { DirectoryService } from "../../../src/logion/services/directory.service.js";
+import { LegalOfficerService } from "../../../src/logion/services/legalOfficerService.js";
 import { notifiedLegalOfficer } from "../services/notification-test-data.js";
 import { CollectionRepository } from "../../../src/logion/model/collection.model.js";
 import { LATEST_SEAL_VERSION, PersonalInfoSealService, Seal, } from "../../../src/logion/services/seal.service.js";
@@ -230,14 +230,14 @@ function mockOtherDependencies(container: Container, existingMocks?: {
         .returns(Promise.resolve())
     container.bind(NotificationService).toConstantValue(notificationService.object())
 
-    const directoryService = new Mock<DirectoryService>();
+    const directoryService = new Mock<LegalOfficerService>();
     directoryService
         .setup(instance => instance.get(It.IsAny<string>()))
         .returns(Promise.resolve(notifiedLegalOfficer(ALICE_ACCOUNT.address)))
     directoryService
         .setup(instance => instance.requireLegalOfficerAddressOnNode(It.IsAny<string>()))
         .returns(Promise.resolve(ALICE_ACCOUNT));
-    container.bind(DirectoryService).toConstantValue(directoryService.object())
+    container.bind(LegalOfficerService).toConstantValue(directoryService.object())
 
     const collectionRepository = existingMocks?.collectionRepository ? existingMocks.collectionRepository : new Mock<CollectionRepository>();
     container.bind(CollectionRepository).toConstantValue(collectionRepository.object())

--- a/test/unit/controllers/locrequest.controller.shared.ts
+++ b/test/unit/controllers/locrequest.controller.shared.ts
@@ -230,14 +230,14 @@ function mockOtherDependencies(container: Container, existingMocks?: {
         .returns(Promise.resolve())
     container.bind(NotificationService).toConstantValue(notificationService.object())
 
-    const directoryService = new Mock<LegalOfficerService>();
-    directoryService
+    const legalOfficerService = new Mock<LegalOfficerService>();
+    legalOfficerService
         .setup(instance => instance.get(It.IsAny<string>()))
         .returns(Promise.resolve(notifiedLegalOfficer(ALICE_ACCOUNT.address)))
-    directoryService
+    legalOfficerService
         .setup(instance => instance.requireLegalOfficerAddressOnNode(It.IsAny<string>()))
         .returns(Promise.resolve(ALICE_ACCOUNT));
-    container.bind(LegalOfficerService).toConstantValue(directoryService.object())
+    container.bind(LegalOfficerService).toConstantValue(legalOfficerService.object())
 
     const collectionRepository = existingMocks?.collectionRepository ? existingMocks.collectionRepository : new Mock<CollectionRepository>();
     container.bind(CollectionRepository).toConstantValue(collectionRepository.object())

--- a/test/unit/controllers/secret_recovery.controller.spec.ts
+++ b/test/unit/controllers/secret_recovery.controller.spec.ts
@@ -15,7 +15,7 @@ import {
 import { Mock, It, Times } from "moq.ts";
 import request from "supertest";
 import { ALICE_ACCOUNT, ALICE } from "../../helpers/addresses.js";
-import { DirectoryService } from "../../../src/logion/services/directory.service.js";
+import { LegalOfficerService } from "../../../src/logion/services/legalOfficerService.js";
 import { NotificationService, Template } from "../../../src/logion/services/notification.service.js";
 import moment from "moment";
 import { notifiedLegalOfficer } from "../services/notification-test-data.js";
@@ -228,7 +228,7 @@ let identityLoc: Mock<LocRequestAggregateRoot>;
 let secretRecoveryRequestFactory: Mock<SecretRecoveryRequestFactory>;
 let secretRecoveryRequestRepository: Mock<SecretRecoveryRequestRepository>;
 let locRequestRepository: Mock<LocRequestRepository>;
-let directoryService: Mock<DirectoryService>;
+let directoryService: Mock<LegalOfficerService>;
 let notificationService: Mock<NotificationService>;
 let secretRecoveryRequest: Mock<SecretRecoveryRequestAggregateRoot>;
 
@@ -241,8 +241,8 @@ function createAndBindMocks(container: Container) {
     container.bind(SecretRecoveryRequestService).toConstantValue(new NonTransactionalSecretRecoveryRequestService(secretRecoveryRequestRepository.object()));
     locRequestRepository = new Mock<LocRequestRepository>();
     container.bind(LocRequestRepository).toConstantValue(locRequestRepository.object());
-    directoryService = new Mock<DirectoryService>();
-    container.bind(DirectoryService).toConstantValue(directoryService.object());
+    directoryService = new Mock<LegalOfficerService>();
+    container.bind(LegalOfficerService).toConstantValue(directoryService.object());
     notificationService = new Mock<NotificationService>();
     container.bind(NotificationService).toConstantValue(notificationService.object());
 }

--- a/test/unit/controllers/secret_recovery.controller.spec.ts
+++ b/test/unit/controllers/secret_recovery.controller.spec.ts
@@ -190,7 +190,7 @@ function mockForAll(container: Container) {
 }
 
 function mockNotifications() {
-    directoryService.setup(instance => instance.get(It.IsAny<ValidAccountId>()))
+    legalOfficerService.setup(instance => instance.get(It.IsAny<ValidAccountId>()))
         .returns(Promise.resolve(notifiedLegalOfficer(ALICE)));
     notificationService.setup(instance => instance.notify(
         It.IsAny<string>(),
@@ -228,7 +228,7 @@ let identityLoc: Mock<LocRequestAggregateRoot>;
 let secretRecoveryRequestFactory: Mock<SecretRecoveryRequestFactory>;
 let secretRecoveryRequestRepository: Mock<SecretRecoveryRequestRepository>;
 let locRequestRepository: Mock<LocRequestRepository>;
-let directoryService: Mock<LegalOfficerService>;
+let legalOfficerService: Mock<LegalOfficerService>;
 let notificationService: Mock<NotificationService>;
 let secretRecoveryRequest: Mock<SecretRecoveryRequestAggregateRoot>;
 
@@ -241,8 +241,8 @@ function createAndBindMocks(container: Container) {
     container.bind(SecretRecoveryRequestService).toConstantValue(new NonTransactionalSecretRecoveryRequestService(secretRecoveryRequestRepository.object()));
     locRequestRepository = new Mock<LocRequestRepository>();
     container.bind(LocRequestRepository).toConstantValue(locRequestRepository.object());
-    directoryService = new Mock<LegalOfficerService>();
-    container.bind(LegalOfficerService).toConstantValue(directoryService.object());
+    legalOfficerService = new Mock<LegalOfficerService>();
+    container.bind(LegalOfficerService).toConstantValue(legalOfficerService.object());
     notificationService = new Mock<NotificationService>();
     container.bind(NotificationService).toConstantValue(notificationService.object());
 }

--- a/test/unit/controllers/vaulttransferrequest.controller.spec.ts
+++ b/test/unit/controllers/vaulttransferrequest.controller.spec.ts
@@ -14,7 +14,7 @@ import { ALICE, BOB_ACCOUNT, ALICE_ACCOUNT } from '../../helpers/addresses.js';
 import { VaultTransferRequestController } from '../../../src/logion/controllers/vaulttransferrequest.controller.js';
 import { NotificationService, Template } from "../../../src/logion/services/notification.service.js";
 import moment from "moment";
-import { DirectoryService } from "../../../src/logion/services/directory.service.js";
+import { LegalOfficerService } from "../../../src/logion/services/legalOfficerService.js";
 import { notifiedLegalOfficer } from "../services/notification-test-data.js";
 import {
     FetchAccountRecoveryRequestsSpecification,
@@ -247,14 +247,14 @@ function mockOtherDependencies(container: Container, repository: Mock<VaultTrans
         .returns(Promise.resolve());
     container.bind(NotificationService).toConstantValue(notificationService.object());
 
-    const directoryService = new Mock<DirectoryService>();
+    const directoryService = new Mock<LegalOfficerService>();
     directoryService
         .setup(instance => instance.get(It.IsAny<ValidAccountId>()))
         .returns(Promise.resolve(ALICE_LEGAL_OFFICER));
     directoryService
         .setup(instance => instance.requireLegalOfficerAddressOnNode(It.IsAny<string>()))
         .returns(Promise.resolve(ALICE_ACCOUNT));
-    container.bind(DirectoryService).toConstantValue(directoryService.object());
+    container.bind(LegalOfficerService).toConstantValue(directoryService.object());
 
     const accountRecoveryRequest = new Mock<AccountRecoveryRequestAggregateRoot>();
     accountRecoveryRequest.setup(instance => instance.getDescription()).returns(accountRecoveryRequestDescription);

--- a/test/unit/controllers/vaulttransferrequest.controller.spec.ts
+++ b/test/unit/controllers/vaulttransferrequest.controller.spec.ts
@@ -247,14 +247,14 @@ function mockOtherDependencies(container: Container, repository: Mock<VaultTrans
         .returns(Promise.resolve());
     container.bind(NotificationService).toConstantValue(notificationService.object());
 
-    const directoryService = new Mock<LegalOfficerService>();
-    directoryService
+    const legalOfficerService = new Mock<LegalOfficerService>();
+    legalOfficerService
         .setup(instance => instance.get(It.IsAny<ValidAccountId>()))
         .returns(Promise.resolve(ALICE_LEGAL_OFFICER));
-    directoryService
+    legalOfficerService
         .setup(instance => instance.requireLegalOfficerAddressOnNode(It.IsAny<string>()))
         .returns(Promise.resolve(ALICE_ACCOUNT));
-    container.bind(LegalOfficerService).toConstantValue(directoryService.object());
+    container.bind(LegalOfficerService).toConstantValue(legalOfficerService.object());
 
     const accountRecoveryRequest = new Mock<AccountRecoveryRequestAggregateRoot>();
     accountRecoveryRequest.setup(instance => instance.getDescription()).returns(accountRecoveryRequestDescription);

--- a/test/unit/model/legalofficer.model.spec.ts
+++ b/test/unit/model/legalofficer.model.spec.ts
@@ -1,0 +1,23 @@
+import { LegalOfficerFactory, LegalOfficerDescription } from "../../../src/logion/model/legalofficer.model.js";
+import { LEGAL_OFFICERS } from "../../helpers/addresses.js";
+import { DB_SS58_PREFIX } from "../../../src/logion/model/supportedaccountid.model.js";
+
+describe("LegalOfficerFactory", () => {
+
+    let factory: LegalOfficerFactory = new LegalOfficerFactory();
+
+    it("succeeds to create a LegalOfficerAggregateRoot", async () => {
+
+        LEGAL_OFFICERS.forEach(legalOfficer => {
+            testNewLegalOfficer(legalOfficer)
+        })
+    })
+
+    function testNewLegalOfficer(legalOfficer: LegalOfficerDescription) {
+        let aggregate = factory.newLegalOfficer(legalOfficer)
+        expect(aggregate.address).toBe(legalOfficer.account.getAddress(DB_SS58_PREFIX));
+        expect(aggregate.getDescription().userIdentity).toEqual(legalOfficer.userIdentity);
+        expect(aggregate.getDescription().postalAddress).toEqual(legalOfficer.postalAddress);
+        expect(aggregate.getDescription().additionalDetails).toEqual(legalOfficer.additionalDetails);
+    }
+})

--- a/test/unit/services/accountrecoverysynchronizer.service.spec.ts
+++ b/test/unit/services/accountrecoverysynchronizer.service.spec.ts
@@ -27,7 +27,7 @@ describe("AccountRecoverySynchronizer", () => {
 });
 
 let protectionRequestRepository: Mock<AccountRecoveryRepository>;
-let directoryService: Mock<LegalOfficerService>;
+let legalOfficerService: Mock<LegalOfficerService>;
 
 function givenCreateRecoveryExtrinsic() {
     locExtrinsic = new Mock<JsonExtrinsic>();
@@ -58,8 +58,8 @@ function givenProtectionRequest() {
     protectionRequestRepository.setup(instance => instance.findById(requestId)).returns(Promise.resolve(locRequest.object()));
     protectionRequestRepository.setup(instance => instance.save(locRequest.object())).returns(Promise.resolve());
 
-    directoryService = new Mock<LegalOfficerService>();
-    directoryService.setup(instance => instance.isLegalOfficerAddressOnNode)
+    legalOfficerService = new Mock<LegalOfficerService>();
+    legalOfficerService.setup(instance => instance.isLegalOfficerAddressOnNode)
         .returns(account => Promise.resolve(account.equals(ALICE_ACCOUNT)));
 }
 
@@ -75,7 +75,7 @@ function synchronizer(): AccountRecoverySynchronizer {
     return new AccountRecoverySynchronizer(
         protectionRequestRepository.object(),
         new NonTransactionalAccountRecoveryRequestService(protectionRequestRepository.object()),
-        directoryService.object(),
+        legalOfficerService.object(),
     );
 }
 

--- a/test/unit/services/accountrecoverysynchronizer.service.spec.ts
+++ b/test/unit/services/accountrecoverysynchronizer.service.spec.ts
@@ -8,7 +8,7 @@ import { JsonExtrinsic } from '../../../src/logion/services/types/responses/Extr
 import { AccountRecoverySynchronizer } from '../../../src/logion/services/accountrecoverysynchronization.service.js';
 import { BOB_ACCOUNT, ALICE_ACCOUNT } from '../../helpers/addresses.js';
 import { NonTransactionalAccountRecoveryRequestService } from '../../../src/logion/services/accountrecoveryrequest.service.js';
-import { DirectoryService } from "../../../src/logion/services/directory.service.js";
+import { LegalOfficerService } from "../../../src/logion/services/legalOfficerService.js";
 import { ValidAccountId } from "@logion/node-api";
 
 describe("AccountRecoverySynchronizer", () => {
@@ -27,7 +27,7 @@ describe("AccountRecoverySynchronizer", () => {
 });
 
 let protectionRequestRepository: Mock<AccountRecoveryRepository>;
-let directoryService: Mock<DirectoryService>;
+let directoryService: Mock<LegalOfficerService>;
 
 function givenCreateRecoveryExtrinsic() {
     locExtrinsic = new Mock<JsonExtrinsic>();
@@ -58,7 +58,7 @@ function givenProtectionRequest() {
     protectionRequestRepository.setup(instance => instance.findById(requestId)).returns(Promise.resolve(locRequest.object()));
     protectionRequestRepository.setup(instance => instance.save(locRequest.object())).returns(Promise.resolve());
 
-    directoryService = new Mock<DirectoryService>();
+    directoryService = new Mock<LegalOfficerService>();
     directoryService.setup(instance => instance.isLegalOfficerAddressOnNode)
         .returns(account => Promise.resolve(account.equals(ALICE_ACCOUNT)));
 }

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -11,7 +11,7 @@ import {
 import { NonTransactionalLocRequestService } from "../../../src/logion/services/locrequest.service.js";
 import { NonTransactionalCollectionService } from "../../../src/logion/services/collection.service.js";
 import { NotificationService } from "../../../src/logion/services/notification.service.js";
-import { DirectoryService } from "../../../src/logion/services/directory.service.js";
+import { LegalOfficerService } from "../../../src/logion/services/legalOfficerService.js";
 import { VerifiedIssuerSelectionService } from "src/logion/services/verifiedissuerselection.service.js";
 import { NonTransactionalTokensRecordService } from "../../../src/logion/services/tokensrecord.service.js";
 import { TokensRecordRepository } from "../../../src/logion/model/tokensrecord.model.js";
@@ -264,7 +264,7 @@ function locSynchronizer(): LocSynchronizer {
 }
 
 let notificationService: Mock<NotificationService>;
-let directoryService: Mock<DirectoryService>;
+let directoryService: Mock<LegalOfficerService>;
 let verifiedIssuerSelectionService: Mock<VerifiedIssuerSelectionService>;
 let tokensRecordRepository: Mock<TokensRecordRepository>;
 

--- a/test/unit/services/locsynchronization.service.spec.ts
+++ b/test/unit/services/locsynchronization.service.spec.ts
@@ -26,7 +26,7 @@ describe("LocSynchronizer", () => {
         locRequestRepository = new Mock<LocRequestRepository>();
         collectionRepository = new Mock<CollectionRepository>();
         notificationService = new Mock();
-        directoryService = new Mock();
+        legalOfficerService = new Mock();
         verifiedIssuerSelectionService = new Mock();
         tokensRecordRepository = new Mock();
     });
@@ -257,14 +257,14 @@ function locSynchronizer(): LocSynchronizer {
         new NonTransactionalLocRequestService(locRequestRepository.object()),
         new NonTransactionalCollectionService(collectionRepository.object()),
         notificationService.object(),
-        directoryService.object(),
+        legalOfficerService.object(),
         verifiedIssuerSelectionService.object(),
         new NonTransactionalTokensRecordService(tokensRecordRepository.object()),
     );
 }
 
 let notificationService: Mock<NotificationService>;
-let directoryService: Mock<LegalOfficerService>;
+let legalOfficerService: Mock<LegalOfficerService>;
 let verifiedIssuerSelectionService: Mock<VerifiedIssuerSelectionService>;
 let tokensRecordRepository: Mock<TokensRecordRepository>;
 

--- a/test/unit/services/notification-test-data.ts
+++ b/test/unit/services/notification-test-data.ts
@@ -2,7 +2,7 @@ import {
     AccountRecoveryRequestDescription,
 } from "../../../src/logion/model/account_recovery.model.js";
 import { ALICE_ACCOUNT, BOB_ACCOUNT } from "../../helpers/addresses.js";
-import { LegalOfficer } from "../../../src/logion/model/legalofficer.model.js";
+import { LegalOfficerDescription } from "../../../src/logion/model/legalofficer.model.js";
 import { VaultTransferRequestDescription } from "src/logion/model/vaulttransferrequest.model.js";
 import { ValidAccountId } from "@logion/node-api";
 import { LocRequestDecision, LocRequestDescription } from "src/logion/model/loc_vos.js";
@@ -25,11 +25,10 @@ export const recovery: AccountRecoveryRequestDescription & { decision: LegalOffi
     }
 }
 
-export function notifiedLegalOfficer(address:string): LegalOfficer {
+export function notifiedLegalOfficer(address:string): LegalOfficerDescription {
     return {
-        address,
+        account: ValidAccountId.polkadot(address),
         additionalDetails: "some details",
-        node: "http://localhost:8080",
         userIdentity: {
             firstName: address === BOB_ACCOUNT.address ? "Bob": "Alice",
             lastName: "Network",


### PR DESCRIPTION
* Directory service is moved from [logion-directory](https://github.com/logion-network/logion-directory) to backend.
* Notifications cannot be sent to other legal officers - feature was anyway no more used.
* `DirectoryService` is renamed to `LegalOfficerService`.

NOTE: Migration does not include data - will be done manually later on.

logion-network/logion-internal#1292

