### PR TITLE
Add address type when fetching loc requests.

### DIFF
--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -1215,7 +1215,10 @@
                     },
                     "requesterAddress": {
                         "type": "string",
-                        "description": "The SS58 address of the requester in expected LOC Requests"
+                        "description": "The address of the requester in expected LOC Requests"
+                    },
+                    "requesterAddressType": {
+                        "$ref": "#/components/schemas/AddressType"
                     },
                     "statuses": {
                         "type": "array",

--- a/src/logion/controllers/components.ts
+++ b/src/logion/controllers/components.ts
@@ -653,8 +653,9 @@ export interface components {
     FetchLocRequestsSpecificationView: {
       /** @description The SS58 address of the owner in expected LOC Requests */
       ownerAddress?: string;
-      /** @description The SS58 address of the requester in expected LOC Requests */
+      /** @description The address of the requester in expected LOC Requests */
       requesterAddress?: string;
+      requesterAddressType?: components["schemas"]["AddressType"];
       /** @description The statuses of expected LOC Requests */
       statuses?: components["schemas"]["LocRequestStatus"][];
       /** @description The type of the LOC to fetch */

--- a/src/logion/controllers/locrequest.controller.ts
+++ b/src/logion/controllers/locrequest.controller.ts
@@ -389,7 +389,16 @@ export class LocRequestController extends ApiController {
     @Async()
     async fetchRequests(specificationView: FetchLocRequestsSpecificationView): Promise<FetchLocRequestsResponseView> {
         const authenticatedUser = await this.authenticationService.authenticatedUser(this.request);
-        const requester = specificationView.requesterAddress ? ValidAccountId.polkadot(specificationView.requesterAddress) : undefined;
+        let requester: ValidAccountId | undefined = undefined;
+        const address = specificationView.requesterAddress;
+        if (address) {
+            const type = specificationView.requesterAddressType;
+            if (type) {
+                requester = validAccountId({ address, type })
+            } else {
+                requester = ValidAccountId.fromUnknown(address)
+            }
+        }
         const owner = specificationView.ownerAddress ? ValidAccountId.polkadot(specificationView.ownerAddress) : undefined;
         authenticatedUser.require(authenticatedUser => authenticatedUser.isOneOf([ requester, owner ]));
         const specification: FetchLocRequestsSpecification = {


### PR DESCRIPTION
Add address type when fetching loc requests.

If the `requesterAddress` is set but not `requesterAddressType`, the controller will attempt to guess the type using `ValidAccountId.fromUnknown()`.

logion-network/logion-internal#1312